### PR TITLE
fixing fusebox prerequisites

### DIFF
--- a/Mods/RT Fusebox_SK/Defs/ResearchProjectDefs/ResearchProjects_RTFusebox.xml
+++ b/Mods/RT Fusebox_SK/Defs/ResearchProjectDefs/ResearchProjects_RTFusebox.xml
@@ -6,6 +6,9 @@
     <label>Basic Fuses</label>
     <description>Builds makeshift fuses. Each one is enough to dissipate up to 2,500 W discharge, but will burn out if exceeded.</description>
     <totalCost>500</totalCost>
+		<prerequisites>
+			<li>GeothermalPower</li>
+		</prerequisites>
   </ResearchProjectDef>
 
   <ResearchProjectDef>
@@ -15,6 +18,7 @@
     <totalCost>1500</totalCost>
     <prerequisites>
       <li>RTFusebox_BasicFuses</li>
+			<li>DynElect</li>
     </prerequisites>
   </ResearchProjectDef>
 
@@ -23,6 +27,9 @@
     <label>Solar Flare Shielding</label>
     <description>Construct a magnetic shield that will protect electric devices in your colony from solar flares.</description>
     <totalCost>1000</totalCost>
+		<prerequisites>
+			<li>PowerIV</li>
+		</prerequisites>
   </ResearchProjectDef>
   
 </ResearchProjectDefs>

--- a/Mods/RT Fusebox_SK/Defs/ThingDefs/Building_RTFusebox.xml
+++ b/Mods/RT Fusebox_SK/Defs/ThingDefs/Building_RTFusebox.xml
@@ -18,7 +18,7 @@
     <repairEffect>Repair</repairEffect>
     <soundImpactDefault>BulletImpactMetal</soundImpactDefault>
     <filthLeaving>BuildingRubble</filthLeaving>
-    <researchPrerequisite>GeothermalPower</researchPrerequisite>
+    <researchPrerequisite>RTFusebox_BasicFuses</researchPrerequisite>
     <size>(2,1)</size>
     <leaveResourcesWhenKilled>True</leaveResourcesWhenKilled>
     <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
@@ -76,7 +76,7 @@
     <repairEffect>Repair</repairEffect>
     <soundImpactDefault>BulletImpactMetal</soundImpactDefault>
     <filthLeaving>BuildingRubble</filthLeaving>
-    <researchPrerequisite>DynElect</researchPrerequisite>
+    <researchPrerequisite>RTFusebox_AdvancedFuses</researchPrerequisite>
     <size>(2,1)</size>
     <leaveResourcesWhenKilled>True</leaveResourcesWhenKilled>
     <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>


### PR DESCRIPTION
Если есть исследования предохранителей, надо бы их связать с самими постройками. А заодно и требования к этим исследованиям добавить, чтобы они не появлялись со старта игры.