### PR TITLE
"Spare Parts" to "Components"

### DIFF
--- a/Mods/Core_SK/Defs/HelpDefs/HelpDefs_Gizmos.xml
+++ b/Mods/Core_SK/Defs/HelpDefs/HelpDefs_Gizmos.xml
@@ -57,7 +57,7 @@ A. The beauty of the plasma generator in an infinite clock work and the developm
 Q.  Nutrient paste dispenser eating resources, but does not produce a paste.
 A. The dispenser gives out food only when colonist comes to get it , and it appears in the hands of the colonist.
 
-Q.  Where can I find hoppers for soylent machines and dispensers? I can’t put food direct in them, and there is no hoppers for food at all, just generator hopper only.
+Q.  Where can I find hoppers for soylent machines and dispensers? I canâ€™t put food direct in them, and there is no hoppers for food at all, just generator hopper only.
 A. You can find it in Architect menu "Misc" named Hopper/Refrigerated Hopper (Hot key H).
 
 Q.  Where can I find Comms Console? I have only Orbital Trade Beacon.
@@ -92,7 +92,7 @@ Q.  Where can I find synthread cloth?
 A. On Tailor's Loom, you will need some cotton and syntetic fibres (v1.11).
 
 Q. And what about synthetic materials?
-A. On Assembling Workbench, where you also can produce some spare parts etc.
+A. On Assembling Workbench, where you also can produce some components, etc.
 
 Q.  How can I recycle Aloe?
 A. On Canningstove you can make some Herb Med Kit from it.

--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Parts_SK.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Parts_SK.xml
@@ -6,9 +6,9 @@
 
 	<RecipeDef>
 		<defName>MakeComponents_Hand</defName>
-		<label>Make Spare Parts</label>
-		<description>Makes spare parts from metal alloy. Quite slow. Produces 12.</description>
-		<jobString>Making spare parts.</jobString>
+		<label>Make Components</label>
+		<description>Makes components from metal alloy. Quite slow. Produces 12.</description>
+		<jobString>Making components.</jobString>
 		<workAmount>1600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>
@@ -55,9 +55,9 @@
 	
 	<RecipeDef>
 		<defName>MakeComponents_Electric</defName>
-		<label>Make Spare Parts</label>
-		<description>Makes spare parts from metal alloy. Quite fast. Produces 24.</description>
-		<jobString>Making spare parts.</jobString>
+		<label>Make Components</label>
+		<description>Makes components from metal alloy. Quite fast. Produces 24.</description>
+		<jobString>Making components.</jobString>
 		<workAmount>1600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -2140,7 +2140,7 @@
     <DefName>ComponentAssemblyBench</DefName>
     <label>Hand Assembling Workbench</label>
     <thingClass>Building_WorkTable</thingClass>
-    <Description>A table for the assembling of spare parts, wires, mechanisms and basic hand tools.</Description>
+    <Description>A table for the assembling of components, wires, mechanisms, advanced mechanisms, and hand tools.</Description>
     <graphicData>
     <texPath>Things/Building/Production/AssemblyWorkbench</texPath>
 	<graphicClass>Graphic_Single</graphicClass>
@@ -2199,7 +2199,7 @@
     <DefName>AdvToolBench</DefName>
     <label>Electric Assembling Bench</label>
     <thingClass>Building_WorkTable</thingClass>
-    <Description>An electric table for the assembling of spare parts, wires, mechanisms, advanced mechanisms and basic hand tools. Requires power.</Description>
+    <Description>An electric table for the assembling of components, wires, mechanisms, and advanced mechanisms and basic hand tools. Requires power.</Description>
     <graphicData>
     <texPath>Things/Building/Production/Lathe</texPath>
 	<graphicClass>Graphic_Single</graphicClass>


### PR DESCRIPTION
Got to at least mid-game before I realized I'd never created "spare parts" on the assembling workbench. Created one set because I had the materials, only to find that recipe was the key to the component shortage I'd had the entire playthrough.

Was tempted to remove "hand tools" from the building description because I still haven't seen them yet, but didn't for now. :>