### PR TITLE
Dev fix typos

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -100,7 +100,7 @@
 			<WorkToMake>2500</WorkToMake>
 			<MaxHitPoints>100</MaxHitPoints>
 			<Flammability>1.0</Flammability>
-      		<Cleanliness>-15</Cleanliness>
+			<Cleanliness>-15</Cleanliness>
     </statBases>
     <Size>(3,1)</Size>
     <DesignationCategory>Production</DesignationCategory>
@@ -111,17 +111,17 @@
     <surfaceType>Item</surfaceType>
 		<recipes>
 			<li>ButcherCorpseFlesh</li>
-            <li>ShellMashgon</li>
-            <li>PrepareSduiggles</li>
-            <li>PrepareSeasnake</li>
-            <li>PrepareBlueblade</li>
-            <li>ButcherTailteeth</li>
-            <li>MakeTofu</li>
-            <li>Makesoymilk</li>
-            <li>MakeSugar</li>
-            <li>MakeFlour</li>
-            <li>Makecheese</li>
-            <li>MakeFruitDrink</li>
+			<li>ShellMashgon</li>
+			<li>PrepareSduiggles</li>
+			<li>PrepareSeasnake</li>
+			<li>PrepareBlueblade</li>
+			<li>ButcherTailteeth</li>
+			<li>MakeTofu</li>
+			<li>Makesoymilk</li>
+			<li>MakeSugar</li>
+			<li>MakeFlour</li>
+			<li>Makecheese</li>
+			<li>MakeFruitDrink</li>
 			<li>MakeHerbMedicine</li>
 		</recipes>
     <inspectorTabs>
@@ -191,11 +191,11 @@
 			<li>CookMealFine</li>
 			<li>CookMealLavish</li>
 			<li>CookMealLuxury</li>
-            <li>MakeStewMushrooms</li>
-            <li>MakeSaladwMushrooms</li>    
-            <li>MakeRoastwMushrooms</li>  
-            <li>MakeChocoMilk</li>         
-            <li>MakeFruitYogurt</li>
+			<li>MakeStewMushrooms</li>
+			<li>MakeSaladwMushrooms</li>    
+			<li>MakeRoastwMushrooms</li>  
+			<li>MakeChocoMilk</li>         
+			<li>MakeFruitYogurt</li>
 		</recipes>
     <inspectorTabs>
       <li>ITab_Bills</li>
@@ -276,11 +276,11 @@
 			<li>CookMealFine</li>
 			<li>CookMealLavish</li>
 			<li>CookMealLuxury</li>
-            <li>MakeStewMushrooms</li>
-            <li>MakeSaladwMushrooms</li>    
-            <li>MakeRoastwMushrooms</li>  
-            <li>MakeChocoMilk</li>         
-            <li>MakeFruitYogurt</li>
+			<li>MakeStewMushrooms</li>
+			<li>MakeSaladwMushrooms</li>    
+			<li>MakeRoastwMushrooms</li>  
+			<li>MakeChocoMilk</li>         
+			<li>MakeFruitYogurt</li>
     </recipes>
     <inspectorTabs>
       <li>ITab_Bills</li>
@@ -310,7 +310,7 @@
     <defName>ElectricStove_Pro</defName>
     <label>Professional Cook Stove</label>
     <ThingClass>Building_WorkTable_HeatPush</ThingClass>
-    <Description>A professional quality stove and attached countertop for preparing meals in bulk. Requires power.</Description>
+    <Description>A professional-quality stove and attached countertop for preparing meals in bulk. Requires power.</Description>
         <graphicData>
       <texPath>Things/Building/Production/TableElectricStove_ProXL</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -383,7 +383,7 @@
 		<defName>TableOven</defName>
 		<label>Oven</label>
 		<ThingClass>Building_WorkTable_HeatPush</ThingClass>
-		<Description>An electric oven for baking candies and tasty treats. Requires kindking, coal or charcoal.</Description>
+		<Description>A fueled oven for baking candies and tasty treats. Requires kindking, coal or charcoal.</Description>
 		<graphicData>
 		  <texPath>Things/Building/Production/Tableoven</texPath>
 		  <graphicClass>Graphic_Multi</graphicClass>
@@ -423,10 +423,10 @@
 			<li>MakeTaffy</li>
 			<li>MakeCookies</li>
 			<li>MakeBread</li>
-            <li>MakePieBlueberry</li>
-            <li>MakePiePumpkin</li> 
-            <li>MakeSweetBun</li>
-            <li>MakePizza</li>
+			<li>MakePieBlueberry</li>
+			<li>MakePiePumpkin</li> 
+			<li>MakeSweetBun</li>
+			<li>MakePizza</li>
 		</recipes>
 		<inspectorTabs>
 			<li>ITab_Bills</li>
@@ -451,9 +451,6 @@
 			<consumeFuelOnlyWhenUsed>true</consumeFuelOnlyWhenUsed>
 		  </li>
 		</comps>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
 		<building>
 			<isMealSource>true</isMealSource>
 			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
@@ -467,7 +464,7 @@
 	<DefName>Canningstove</DefName>
 	<label>Electric Pressure Cooker</label>
 	<ThingClass>Building_WorkTable_HeatPush</ThingClass>
-	<Description>A stove for canning foods. Requires power.</Description>
+	<Description>A stove for canning foods, drying fruit, and making tofu. Requires power.</Description>
 	<graphicData>
       <texPath>Things/Building/Production/Canningstove</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -554,7 +551,7 @@
     <DefName>CandyTable</DefName>
     <label>Candy Table</label>
     <ThingClass>Building_WorkTable</ThingClass>
-    <Description>The candy table is used to make chocolate, caramel and taffy. Requires power.</Description>
+    <Description>A candy-making table used to make chocolate, caramel and taffy. Requires power.</Description>
     <graphicData>
       <texPath>Things/Building/Production/Candytable</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -650,7 +647,7 @@
 			<MaxHitPoints>180</MaxHitPoints>
 			<Flammability>1.0</Flammability>
     </statBases>
-    <description>Synthesizes nutrient paste from organic ingredients. It consumes less ingredients and time than any other meal production method - but nobody likes eating nutrient paste. Requires power.</description>
+    <description>Synthesizes nutrient paste from organic ingredients. It consumes less ingredients and time than any other meal production method, but nobody likes eating nutrient paste. Requires power.</description>
     <building>
       <isMealSource>true</isMealSource>
       <wantsHopperAdjacent>true</wantsHopperAdjacent>
@@ -763,7 +760,7 @@
       <DefName>soylenttable</DefName>
       <Label>Soylent Machine</Label>
       <ThingClass>Building_WorkTable</ThingClass>
-      <Description>A machine to produce Soylent Green from human-like corpses. Requires power.</Description>
+      <Description>A machine to produce Soylent Green from humanlike corpses. Requires power.</Description>
       <graphicData>
          <texPath>Things/Building/Production/soylenttable</texPath>
          <graphicClass>Graphic_Single</graphicClass>
@@ -820,6 +817,9 @@
 			  <li Class="CompProperties_Flickable"/>
 			  <li Class="CompProperties_Breakdownable"/>
       </comps>
+		<placeWorkers>
+			<li>PlaceWorker_ShowFacilitiesConnections</li>
+		</placeWorkers>
       <recipes>
          <li>makesoylentgreen</li>
       </recipes>
@@ -912,6 +912,9 @@
 			  <li Class="CompProperties_Flickable"/>
 			  <li Class="CompProperties_Breakdownable"/>
 		</comps>
+		<placeWorkers>
+			<li>PlaceWorker_ShowFacilitiesConnections</li>
+		</placeWorkers>
 		<researchPrerequisites><li>Brewing</li></researchPrerequisites>
   </ThingDef>
 
@@ -982,7 +985,7 @@
 	<defName>TableCoffee</defName>
 	<label>Coffee Machine</label>
 	<thingClass>Building_WorkTable</thingClass>
-	<Description>A machine built for the preparation of coffee beans into coffee. It can also produce tea and spectago tea. Requires power.</Description>
+	<Description>A machine for the preparation of coffee. It can also produce tea and spectago tea. Requires power.</Description>
     <graphicData>
 	  <texPath>Things/Building/Production/TableCoffee</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -1031,6 +1034,9 @@
 		<li Class="CompProperties_Flickable"/>
 		<li Class="CompProperties_Breakdownable"/>
 	</comps>
+	<placeWorkers>
+		<li>PlaceWorker_ShowFacilitiesConnections</li>
+	</placeWorkers>
 	<building>
 		<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
         <heatPerTickWhileWorking>0.1</heatPerTickWhileWorking>
@@ -1041,7 +1047,7 @@
 		<defName>TableSawmillHand</defName>
 		<label>Hand Sawmill</label>
 		<ThingClass>Building_WorkTable</ThingClass>
-		<Description>A small muscle-powered hand saw for cutting wood logs into wood planks.</Description>
+		<Description>A small muscle-powered hand saw for cutting logs into planks and kindling.</Description>
     <graphicData>
 		<texPath>Things/Building/Production/TableSawmillHand</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
@@ -1091,9 +1097,6 @@
       </li>
 	   <li Class="CompProperties_Breakdownable"/>
     </comps>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
 	</ThingDef>
 
 
@@ -1101,7 +1104,7 @@
 		<defName>TableSawmillElectric</defName>
 		<label>Electric Sawmill</label>
 		<ThingClass>Building_WorkTable</ThingClass>
-		<Description>An electric saw for cutting logs into wood planks. Requires power.</Description>
+		<Description>An electric saw for cutting logs into planks and kindling. Requires power.</Description>
     <graphicData>
 		<texPath>Things/Building/Production/TableHandsaw3x1</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
@@ -1182,7 +1185,7 @@
 		<defName>TableFurnace</defName>
 		<label>Hand Smelting Furnace</label>
 		<ThingClass>Building_WorkTable</ThingClass>
-		<Description>A furnace used for smelting metal ores into metal alloys. Can make metal cans and produce charcoal from wood logs.</Description>
+		<Description>A furnace used for smelting basic metal ores into metal alloys. Can make metal cans and produce charcoal from logs.</Description>
     <graphicData>
 		<texPath>Things/Building/Production/TableFurnace3x1</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
@@ -1240,17 +1243,14 @@
 			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
 			<heatPerTickWhileWorking>2</heatPerTickWhileWorking>
 		</building>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
 	</ThingDef>
 
 
   <ThingDef ParentName="BenchBase">
     <DefName>ElectricSmelter</DefName>
-    <label>Electric Smelter</label>
+    <label>Electric Smelting Furnace</label>
     <ThingClass>Building_WorkTable_HeatPush</ThingClass>
-    <Description>A furnace used for smelting metal ores, slag, and sand into metal alloys and silicon-based alloys. Can make metal cans and produce charcoal from wood logs. Requires power.</Description>
+    <Description>A furnace used for smelting more advanced metal ores, slag, and sand into metal alloys and silicon-based alloys. Can make metal cans and produce charcoal from wood logs. Requires power.</Description>
     <graphicData>
       <texPath>Things/Building/Production/ElectricSmelter</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -1345,7 +1345,7 @@
     <DefName>TableMachining</DefName>
     <label>Electric Machining Table</label>
     <ThingClass>Building_WorkTable</ThingClass>
-    <Description>An electric table and tools that can process stone chunks into blocks, rubble or sand. Drill Heads can be made here. Mechanoid bodies can be disassembled here.</Description>
+    <Description>An electric table that can process stone chunks into blocks, rubble or sand. Can also make drill heads, create reinforced concrete and disassemble mechanoids. Requires power.</Description>
     <graphicData>
       <texPath>Things/Building/Production/TableMachining</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -1524,7 +1524,7 @@
 		<DefName>TableElectronics</DefName>
 		<label>Electronics Table</label>
 		<ThingClass>Building_WorkTable</ThingClass>
-		<Description>A table with tools for crafting electronic chips. Requires power.</Description>
+		<Description>A table with tools for crafting electronic chips, robot parts, and the mobile mineral sonar. Requires power.</Description>
     <graphicData>
 		<texPath>Things/Building/Production/TableElectronics3x1</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
@@ -1600,7 +1600,7 @@
     <DefName>HandTailoringBench</DefName>
     <label>Tailor's Loom</label>
     <ThingClass>Building_WorkTable</ThingClass>
-    <Description>A workbench equipped for tailoring basic clothing from textiles. Requires power.</Description>
+    <Description>A workbench equipped for tailoring basic clothing from textiles.</Description>
     <graphicData>
       <texPath>Things/Building/Production/TableTailor</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -1644,9 +1644,6 @@
       <spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
     </building>
 		<researchPrerequisites><li>CraftingI</li></researchPrerequisites>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
   </ThingDef>
   
   
@@ -1949,8 +1946,11 @@
 		<li Class="CompProperties_Breakdownable"/>
     </comps>
     <building>
-		<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
+	<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
     </building>
+	<placeWorkers>
+		<li>PlaceWorker_ShowFacilitiesConnections</li>
+	</placeWorkers>
     <researchPrerequisites><li>RecycleApparel</li></researchPrerequisites>
 </ThingDef>
 
@@ -1959,7 +1959,7 @@
 	<DefName>ElectricTableRepair</DefName>
     <label>Mending Workbench</label>
 	<ThingClass>Repair.Building_RepairTable</ThingClass>
-    <Description>A workbench equipped with all the tools required to mend and repair damaged items. Requires power.</Description>
+    <Description>A workbench equipped with all the tools required to mend and repair damaged items. Works at 40% speed when not powered.</Description>
     <graphicData>
       <texPath>Things/Building/TableMending</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -2189,9 +2189,6 @@
     <building>
       <spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
     </building>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
   </ThingDef>
 
 
@@ -2276,7 +2273,7 @@
 
   <ThingDef ParentName="BenchBase">
     <DefName>ElectricSmithy</DefName>
-    <label>Electric smithy</label>
+    <label>Electric Smithy</label>
     <ThingClass>Building_WorkTable</ThingClass>
     <Description>A smithing table equipped for basic weapon and protective apparel production. Requires power.</Description>
     <graphicData>
@@ -2359,7 +2356,7 @@
   
     <ThingDef ParentName="BenchBase">
     <DefName>FueledSmithy</DefName>
-    <label>fueled smithy</label>
+    <label>Fueled Smithy</label>
     <ThingClass>Building_WorkTable</ThingClass>
     <Description>A wood-fueled station equipped for smithing non-mechanical weapons and tools.</Description>
     <graphicData>
@@ -2423,9 +2420,6 @@
         </linkableFacilities>
       </li>
     </comps>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
     <researchPrerequisites><li>Machining</li></researchPrerequisites>
   </ThingDef>
   
@@ -2433,7 +2427,7 @@
     <DefName>EAF</DefName>
     <label>Electric Arc Furnace</label>
     <ThingClass>Building_WorkTable_HeatPush</ThingClass>
-    <Description>A electric arc furnace for advanced metal alloy smelting. It is efficient but requires a lot of power.</Description>
+    <Description>An electric arc furnace for advanced metal alloy smelting. Efficient, but requires a lot of power.</Description>
 	<graphicData>
 		<texPath>Things/Building/EAF</texPath>
 		<graphicClass>Graphic_Multi</graphicClass>
@@ -2479,10 +2473,10 @@
       <li>MakeCobaltIronAlloy</li>
       <li>MakeNichromeAlloy</li>
       <li>MakeAlnicoAlloy</li>
-	  <li>MakeFerrotitaniumAlloy</li>
-	  <li>MakeNitinolAlloy</li>
+      <li>MakeFerrotitaniumAlloy</li>
+      <li>MakeNitinolAlloy</li>
       <li>MakePobediteAlloy</li>
-	  <li>ExtractMetalFromSlag</li>
+      <li>ExtractMetalFromSlag</li>
     </recipes>
     <inspectorTabs>
       <li>ITab_Bills</li>
@@ -2594,9 +2588,6 @@
       </li>
     </comps>
     <designationHotKey>U</designationHotKey>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
   </ThingDef>
 
 
@@ -2656,9 +2647,6 @@
 	  <li Class="CompProperties_Breakdownable"/>
     </comps>
 		<researchPrerequisites><li>Stonecutting</li></researchPrerequisites>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
   </ThingDef>
 
 
@@ -2679,8 +2667,8 @@
 	</stuffCategories>
 	<costStuffCount>70</costStuffCount>
     <CostList>
-			<Components>3</Components>
-			<Mechanism>2</Mechanism>
+	<Components>3</Components>
+	<Mechanism>2</Mechanism>
     </CostList>
     <AltitudeLayer>Waist</AltitudeLayer>
     <UseHitPoints>True</UseHitPoints>
@@ -2718,9 +2706,6 @@
         </linkableFacilities>
       </li>
     </comps>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
   </ThingDef>
 
 
@@ -2792,9 +2777,9 @@
 			  <li Class="CompProperties_Flickable"/>
 			  <li Class="CompProperties_Breakdownable"/>
     </comps>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
+	<placeWorkers>
+		<li>PlaceWorker_ShowFacilitiesConnections</li>
+	</placeWorkers>
     <building>
       <spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
     </building>
@@ -2805,7 +2790,7 @@
   <ThingDef ParentName="BenchBase">
     <defName>Extractor</defName>
     <label>Mine Extractor</label>
-    <description>The mine extractor digs deep into the ground to extract metal ores and rocks. Must be placed on deposits of minerals. Requires power.</description>
+    <description>The mine extractor digs deep into the ground to extract metal ores and rocks. Must be placed on a Deposit of Minerals. Requires power.</description>
     <thingClass>SK_Miner.Building_Extractor</thingClass>
     <graphicData>
       <texPath>Buildings/Extractor/Extractor</texPath>
@@ -2879,7 +2864,7 @@
   <ThingDef ParentName="BenchBase">
     <defName>ExtractorDebris</defName>
     <label>Exhausted Mine Extractor</label>
-    <description>This mine extractor is exhausted of resources.</description>
+    <description>This mine extractor will no longer produce resources and should be deconstructed.</description>
     <thingClass>Building</thingClass>
     <graphicData>
       <texPath>Buildings/Extractor/ExtractorDebris</texPath>
@@ -2921,7 +2906,7 @@
   <ThingDef ParentName="BuildingBase">
     <defName>RareExtractor</defName>
     <label>Advanced Mine Extractor</label>
-    <description>The advanced mine extractor digs deep into the ground to extract rare metal ores. Must be placed on deposits of rare minerals. Requires power.</description>
+    <description>The advanced mine extractor digs deep into the ground to extract rare metal ores. Must be placed on a Deposit of Rare Minerals. Requires power.</description>
     <thingClass>SK_RareMiner.Building_RareExtractor</thingClass>
     <graphicData>
       <texPath>Buildings/Extractor/AdvExtrator</texPath>
@@ -2999,7 +2984,7 @@
   <ThingDef ParentName="BuildingBase">
     <defName>ExtractorDebrisRare</defName>
     <label>Exhausted Advanced Mine Extractor</label>
-    <description>This advanced mine extractor is exhausted of resources.</description>
+    <description>This mine extractor will no longer produce resources and should be deconstructed<./description>
     <thingClass>Building</thingClass>
     <graphicData>
       <texPath>Buildings/Extractor/AdvExtratorDebris</texPath>
@@ -3200,7 +3185,7 @@
     <DefName>ChemicalLab</DefName>
     <label>Petrochemical Plant</label>
     <ThingClass>Building_WorkTable</ThingClass>
-    <Description>The petrochemical plant uses raw products from the oil refinery to produce plastic, rubber, synthetic fiber, carbon. Requires power.</Description>
+    <Description>The petrochemical plant refines crude oil into fuel and produces plastic, rubber, synthetic fiber, and carbon. Requires power.</Description>
     <graphicData>
     <texPath>Things/Building/PB</texPath>
     <graphicClass>Graphic_Single</graphicClass>
@@ -3233,12 +3218,12 @@
     <interactionCellOffset>(0,0,-2)</interactionCellOffset>
     <surfaceType>Item</surfaceType>
     <recipes>
-	  <li>OilRefining</li>
-      <li>MakePlastic</li>
-      <li>MakeRubber</li>
-      <li>VulcanizeRubber</li>
-      <li>MakeSyntheticFibers</li>
-      <li>MakeCarbon</li>
+    	<li>OilRefining</li>
+	<li>MakePlastic</li>
+	<li>MakeRubber</li>
+	<li>VulcanizeRubber</li>
+	<li>MakeSyntheticFibers</li>
+	<li>MakeCarbon</li>
     </recipes>
     <inspectorTabs>
       <li>ITab_Bills</li>
@@ -3273,9 +3258,9 @@
 			  <li Class="CompProperties_Flickable"/>
 			  <li Class="CompProperties_Breakdownable"/>
     </comps>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
+	<placeWorkers>
+		<li>PlaceWorker_ShowFacilitiesConnections</li>
+	</placeWorkers>
     <building>
 		<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
         <heatPerTickWhileWorking>0.7</heatPerTickWhileWorking>
@@ -3488,7 +3473,7 @@
   <ThingDef ParentName="BenchBase">
     <defName>GC</defName>
     <label>Gas Centrifuge</label>
-    <description>A thermal diffusion gas centrifuge is a device that performs isotope separation of gases. A centrifuge relies on the principles of centrifugal force accelerating molecules so that particles of different masses are physically separated in a gradient along the radius of a rotating container. A prominent use of gas centrifuges is for the separation uranium-235 from natural uranium-237.</description>
+    <description>A gas centrifuge performs isotope separation of gases, particularly useful for refining uranium ore.</description>
     <ThingClass>SK_GC.Building_GC</ThingClass>
     <graphicData>
       <texPath>Things/Building/GasCentrifuge</texPath>
@@ -3527,6 +3512,9 @@
 			</li>
 			  <li Class="CompProperties_Breakdownable"/>
     </comps>
+	<placeWorkers>
+		<li>PlaceWorker_ShowFacilitiesConnections</li>
+	</placeWorkers>
     <size>(3,3)</size>
 	<stuffCategories>
 	<li>Metallic</li>
@@ -3549,21 +3537,20 @@
 		<researchPrerequisites><li>PowerIV</li></researchPrerequisites>
   </ThingDef>
 
-
-	<ThingDef ParentName="BuildingBase">
-		<defName>CentrifugeFeeder</defName>
-	     <label>Gas Centrifuge Hopper</label>
-		<thingClass>Building_Storage</thingClass>
-		<graphicData>
+<ThingDef ParentName="BuildingBase">
+	<defName>CentrifugeFeeder</defName>
+	<label>Gas Centrifuge Hopper</label>
+	<thingClass>Building_Storage</thingClass>
+	<graphicData>
 		<texPath>Things/Building/GenHopper</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<altitudeLayer>Waist</altitudeLayer>
-		<passability>PassThroughOnly</passability>
-		<fillPercent>0.5</fillPercent>
-		<pathCost>70</pathCost>
-		<building>
-      <fixedStorageSettings>
+	</graphicData>
+	<altitudeLayer>Waist</altitudeLayer>
+	<passability>PassThroughOnly</passability>
+	<fillPercent>0.5</fillPercent>
+	<pathCost>70</pathCost>
+	<building>
+		<fixedStorageSettings>
         <priority>Important</priority>
         <filter>
           <thingDefs>
@@ -3589,7 +3576,7 @@
 			<MaxHitPoints>100</MaxHitPoints>
 			<Flammability>1.0</Flammability>
 		</statBases>
-	    <description>Holds Uranium Ore for the Gas Centrifuge.</description>
+	    <description>Holds uranium ore for a gas centrifuge.</description>
 	<stuffCategories>
 	<li>Metallic</li>
 	</stuffCategories>
@@ -3607,14 +3594,14 @@
 			<li>PlaceWorker_NextToHopperAccepter</li>
 		</placeWorkers>
 		<researchPrerequisites><li>PowerIV</li></researchPrerequisites>
-	</ThingDef>
+</ThingDef>
 
 
 	<ThingDef ParentName="BuildingBase">
     <DefName>ManualCrematorium</DefName>
-    <label>Fueled crematorium</label>
+    <label>Fueled Crematorium</label>
     <ThingClass>Building_WorkTable</ThingClass>
-    <Description>Cremates corpses using fuel.</Description>
+    <Description>A device which turns unwanted corpses and apparel into ash. Runs on kindling, coal, or charcoal.</Description>
     <graphicData>
       <texPath>Things/Building/Production/Crematorium</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -3673,7 +3660,7 @@
     <DefName>ElectricCrematorium</DefName>
     <label>Crematorium</label>
     <ThingClass>Building_WorkTable_HeatPush</ThingClass>
-    <Description>Cremates corpses, apparel or various resources into ashes. Requires power.</Description>
+    <Description>A device which turns unwanted corpses and apparel into ash. Requires power.</Description>
     <graphicData>
       <texPath>Things/Building/Production/Crematorium</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -3739,6 +3726,9 @@
                 <idlePowerFactor>0.1</idlePowerFactor>
             </li>
     </comps>
+	<placeWorkers>
+		<li>PlaceWorker_ShowFacilitiesConnections</li>
+	</placeWorkers>
     <building>
       <spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
       <heatPerTickWhileWorking>0.6</heatPerTickWhileWorking>
@@ -3752,7 +3742,7 @@
 		<DefName>CharcoalPit</DefName>
 		<label>Charcoal Pit</label>
 		<ThingClass>Building_WorkTable</ThingClass>
-		<Description>A pit for charring a large amount of charcoal.</Description>
+		<Description>A simple, inexpensive pit for charring charcoal. Cannot be placed under a roof.</Description>
 		<graphicData>
 			<texPath>Things/Building/CharcoalPit_Empty/CharcoalPit_Empty</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>
@@ -3923,7 +3913,7 @@
       <DefName>meditable</DefName>
       <Label>Medical Table</Label>
       <ThingClass>Building_WorkTable</ThingClass>
-      <Description>A table that is used to craft medicine. Requires power.</Description>
+      <Description>A table that is used to craft medicine and life support devices. Requires power.</Description>
       <stuffCategories>
          <li>Metallic</li>
          <li>Woody</li>
@@ -4036,19 +4026,19 @@
 		<recipes>
 			<li>MakeCarbonAlloy</li>
 			<li>MakeArtificialBone</li>
-            <li>CreateGTStomach</li>
-            <li>CreateGTLung</li>
-            <li>CreateGTLiver</li>
-            <li>CreateGTKidney</li>
-            <li>CreateGTHeart</li>
-            <li>CreateGTBionicEye</li>
-            <li>CreateGTBionicArm</li>
-            <li>CreateGTBionicHand</li>
-            <li>CreateGTBionicFoot</li>
-            <li>CreateGTBionicLeg</li>
-            <li>CreateGTBionicJaw</li>
-            <li>CreateGTBionicEar</li>
-            <li>CreateGTBionicSpine</li>
+			<li>CreateGTStomach</li>
+			<li>CreateGTLung</li>
+			<li>CreateGTLiver</li>
+			<li>CreateGTKidney</li>
+			<li>CreateGTHeart</li>
+			<li>CreateGTBionicEye</li>
+			<li>CreateGTBionicArm</li>
+			<li>CreateGTBionicHand</li>
+			<li>CreateGTBionicFoot</li>
+			<li>CreateGTBionicLeg</li>
+			<li>CreateGTBionicJaw</li>
+			<li>CreateGTBionicEar</li>
+			<li>CreateGTBionicSpine</li>
 		</recipes>
 		<inspectorTabs>
 			<li>ITab_Bills</li>
@@ -4093,7 +4083,7 @@
 		<defName>TableOrganvat</defName>
 		<label>Organ Vat</label>
 		<ThingClass>Building_WorkTable</ThingClass>
-		<Description>A large vat that is used to turn human corpses into biomatter and to grow natural replacement organs. Requires power.</Description>
+		<Description>A large vat used to turn human corpses into biomatter and grow natural replacement organs. Requires power.</Description>
     <graphicData>
 		<texPath>Things/Building/Production/TableOrganvat2x2</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
@@ -4463,7 +4453,7 @@
     <DefName>AmmoBench</DefName>
     <label>Ammo Crafting Table</label>
     <ThingClass>Building_WorkTable</ThingClass>
-    <Description>A crafting table that produces ammunition for use with turrets. Can also produce sulfur from iron ore. Requires power.</Description>
+    <Description>A crafting table that produces ammunition for use in guns and turrets. Can also produce sulfur from iron ore.</Description>
     <graphicData>
       <texPath>Things/Building/AmmoBench/ammobench</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -4521,9 +4511,6 @@
       <spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
     </building>
 		<researchPrerequisites><li>CraftingI</li></researchPrerequisites>
-		<placeWorkers>
-			<li>PlaceWorker_ShowFacilitiesConnections</li>
-		</placeWorkers>
   </ThingDef>
   
 
@@ -4578,8 +4565,8 @@
 	<li>CreateArtificialPelvis</li>
 	<li>CreateHydraulicJaw</li>
 	<li>CreateArtificialNose</li>
-	<li>CreateCrystalEye</li>
 	<li>CreateGlassEye</li>
+	<li>CreateCrystalEye</li>
     </recipes>
     <inspectorTabs>
       <li>ITab_Bills</li>
@@ -4620,7 +4607,7 @@
     <DefName>TableSurrogates</DefName>
     <label>Surrogate Organ Workbench</label>
     <ThingClass>Building_WorkTable</ThingClass>
-    <Description>A simple workstation that is equipped to craft simple surrogate organs. Requires power.</Description>
+    <Description>A workstation equipped to craft simple surrogate organs. Requires power.</Description>
       <graphicData>
          <texPath>Things/Building/Production/EPOE/TableSurrogates</texPath>
          <graphicClass>Graphic_Multi</graphicClass>
@@ -4699,7 +4686,7 @@
     <DefName>TableSynthetics</DefName>
     <label>Synthetic Organ Assembler</label>
     <ThingClass>Building_WorkTable</ThingClass>
-    <Description>A workstation fully equipped with an extremely powerful nano-printer capable of producing synthetic organs an AI chips. Requires power.</Description>
+    <Description>A workstation fully equipped with an extremely powerful nano-printer capable of producing synthetic organs and AI chips. Requires power.</Description>
       <graphicData>
          <texPath>Things/Building/Production/EPOE/TableSynthetics</texPath>
          <graphicClass>Graphic_Multi</graphicClass>
@@ -4778,7 +4765,7 @@
     <DefName>TableBionics</DefName>
     <label>Bionics Workbench</label>
     <ThingClass>Building_WorkTable</ThingClass>
-    <Description>A workbench equipped for production of high tech bionic prosthetics. Requires power.</Description>
+    <Description>A workbench equipped for production of high-tech bionic prosthetics. Requires power.</Description>
       <graphicData>
          <texPath>Things/Building/Production/EPOE/TableBionics</texPath>
          <graphicClass>Graphic_Multi</graphicClass>
@@ -5002,6 +4989,9 @@
 			  <li Class="CompProperties_Flickable"/>
 			  <li Class="CompProperties_Breakdownable"/>
 		</comps>
+		<placeWorkers>
+			<li>PlaceWorker_ShowFacilitiesConnections</li>
+		</placeWorkers>
 		<building>
 			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
 			<heatPerTickWhileWorking>0.5</heatPerTickWhileWorking>
@@ -5079,6 +5069,9 @@
 			  <li Class="CompProperties_Flickable"/>
 			  <li Class="CompProperties_Breakdownable"/>
 		</comps>
+		<placeWorkers>
+			<li>PlaceWorker_ShowFacilitiesConnections</li>
+		</placeWorkers>
 		<building>
 			<spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
 			<heatPerTickWhileWorking>1.5</heatPerTickWhileWorking>
@@ -5284,7 +5277,7 @@
       <MaxHitPoints>100</MaxHitPoints>
       <Flammability>1.0</Flammability>
     </statBases>
-    <description>A hydroponic basin can grow several plants quickly. The basin requires power to work and the plants will die if the power is cut.</description>
+    <description>A hydroponic basin can grow several plants quickly. The basin requires power to work and plants will die if the power is lost.</description>
     <size>(1,4)</size>
 	<stuffCategories>
 	<li>Metallic</li>
@@ -5314,6 +5307,9 @@
       </li>
 			  <li Class="CompProperties_Flickable"/>
     </comps>
+	<placeWorkers>
+		<li>PlaceWorker_ShowFacilitiesConnections</li>
+	</placeWorkers>
     <researchPrerequisites><li>Hydroponics</li></researchPrerequisites>
     <terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 		<DesignationCategory>Misc</DesignationCategory>
@@ -5349,7 +5345,7 @@
 			<MaxHitPoints>50</MaxHitPoints>
 			<Flammability>1.0</Flammability>
 		</statBases>
-		<description>The advanced hydroponic basin grows several plants quickly. The basin requires power to work, provides its own light source but the plants will die if power is cut.</description>
+		<description>Advanced hydroponic basins grow plants quicker and provide their own light source. The basin requires power to work and plants will die if the power is lost.</description>
 	<stuffCategories>
 		<li>Metallic</li>
 		<li>Woody</li>
@@ -5395,12 +5391,14 @@
 			</li>
 			  <li Class="CompProperties_Flickable"/>
 		</comps>
+		<placeWorkers>
+			<li>PlaceWorker_ShowFacilitiesConnections</li>
+		</placeWorkers>
 		<researchPrerequisites><li>AdvHydroponic</li></researchPrerequisites>
 		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 		<designationCategory>Misc</designationCategory>
 		<staticSunShadowHeight>0.03</staticSunShadowHeight>
 	</ThingDef>
-
 
 
   <ThingDef ParentName="BuildingBase">
@@ -5452,6 +5450,9 @@
       </li>
 			  <li Class="CompProperties_Flickable"/>
     </comps>
+	<placeWorkers>
+		<li>PlaceWorker_ShowFacilitiesConnections</li>
+	</placeWorkers>
     <rotatable>false</rotatable>
     <leaveResourcesWhenKilled>true</leaveResourcesWhenKilled>
     <researchPrerequisites><li>AdvHydroponic</li></researchPrerequisites>
@@ -5462,8 +5463,8 @@
   
    <ThingDef Name="Agrarian" ParentName="BuildingBase">
       <defName>Agrarian</defName>
-      <label>Hydroponic box</label>
-      <description>A small wood box with some earth in it to grow plants. Pipes supply the ground with the required water.</description>
+      <label>Hydroponic Box</label>
+      <description>A small self-watering wooden box with earth in it for growing plants. Requires power.</description>
       <thingClass>Building_PlantGrower</thingClass>
       <designationCategory>Misc</designationCategory>
       <statBases>
@@ -5500,6 +5501,9 @@
             <basePowerConsumption>150</basePowerConsumption>
          </li>
       </comps>
+	<placeWorkers>
+		<li>PlaceWorker_ShowFacilitiesConnections</li>
+	</placeWorkers>
      <uiIconPath>Things/Building/AgrarianIcon</uiIconPath>
      <graphicData>
        <texPath>Things/Building/AgrarianAtlas</texPath>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -2140,7 +2140,7 @@
     <DefName>ComponentAssemblyBench</DefName>
     <label>Hand Assembling Workbench</label>
     <thingClass>Building_WorkTable</thingClass>
-    <Description>A table for the assembling of components, wires, mechanisms, advanced mechanisms, and hand tools.</Description>
+    <Description>A table for the assembling of components, wires, mechanisms, and advanced mechanisms.</Description>
     <graphicData>
     <texPath>Things/Building/Production/AssemblyWorkbench</texPath>
 	<graphicClass>Graphic_Single</graphicClass>
@@ -2199,7 +2199,7 @@
     <DefName>AdvToolBench</DefName>
     <label>Electric Assembling Bench</label>
     <thingClass>Building_WorkTable</thingClass>
-    <Description>An electric table for the assembling of components, wires, mechanisms, and advanced mechanisms and basic hand tools. Requires power.</Description>
+    <Description>An electric table for the assembling of components, wires, mechanisms, and advanced mechanisms. Requires power.</Description>
     <graphicData>
     <texPath>Things/Building/Production/Lathe</texPath>
 	<graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -40,10 +40,10 @@
 			<li>CookRoastedMeat</li>
 			<li>MakeVegetables</li>
 			<li>MakeRoastwMushrooms</li>
-            <li>MakeBurger</li>
-            <li>MakeBurgerCheese</li>
-            <li>MakeBurgerDeluxe</li>
-            <li>MakeCheeseGrilled</li>
+			<li>MakeBurger</li>
+			<li>MakeBurgerCheese</li>
+			<li>MakeBurgerDeluxe</li>
+			<li>MakeCheeseGrilled</li>
 		</recipes>
 		<inspectorTabs>
 			<li>ITab_Bills</li>


### PR DESCRIPTION
* Fixed descriptions of the following tables to clarify that they **don't** need power:
  * Oven
  * Tailor's Loom
  * Ammo Crafting Table

* Fixed descriptions of the following items to clarify that they **do** need power:
  * Hydroponic Box

* Added PlaceWorker_ShowFacilitiesConnections (show electrical connections) to the following electric benches:
  * Soylent Machine
  * Coffee Machine
  * Brewery
  * Recycle Textile Bench
  * Electric Crematorium
  * Robotic Assembler
  * Quantum Fabricator
  * Hydroponic Basin
  * Advanced Hydroponic Basin
  * Hydroponic Pot
  * Hydroponic Box

* Removed PlaceWorker_ShowFacilitiesConnections (show electrical connections) from the following non-electric benches:
  * Oven
  * Hand Sawmill
  * Hand Smelting Furnace
  * Tailor's Loom
  * Hand Assembling Bench
  * Fueled Smithy
  * Hand Machining Table
  * Sculptor's Table
  * Hand Concrete Mixer
  * Ammo Bench

* Clarified/condensed descriptions of:
  * Canning Stove
  * Hand Sawmill
  * Electric Sawmill
  * Hand Smelting Furnace
  * Electric Smelter
  * Electric Machining Table
  * Electronics Table
  * Exhausted Mine Extractor
  * Exhausted Advanced Mine Extractor
  * Petrochemical Plant
  * Gas Centrifuge
  * Fueled Crematorium
  * Medical Table
  * Organ Vat
  * Ammo Bench
  * Surrogate Organ Workbench

* Miscellany:
  * Reversed recipe listing order of `Glass Eye` and `Crystal Eye` in the `Prosthetics Workbench` to make it more obvious that the `Crystal Eye` is the superior of the two.
  * Noted in the `Mending Workbench` description that it can work at 40% speed when not powered.
  * Renamed `Electric Smelter` to `Electric Smelting Furnace` to bring it in line with the hand version.
  * Changed `human-like` to `humanlike` to be consistent with vanilla ThoughtDefs for butchering humanlikes.
  * Misc typographical and whitespace fixes.