### PR TITLE
Pallet & skip fix

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture_SK.xml
@@ -2933,7 +2933,7 @@
     <designationCategory>Accessories</designationCategory>
     <staticSunShadowHeight>0.025</staticSunShadowHeight>
     <surfaceType>Item</surfaceType>
-    <researchPrerequisites><li>SK_Craftsmanship</li></researchPrerequisites>
+    <researchPrerequisites><li>SK_StorageI</li></researchPrerequisites>
   </ThingDef>
 
 
@@ -3004,7 +3004,7 @@
     <designationCategory>Accessories</designationCategory>
     <staticSunShadowHeight>0.025</staticSunShadowHeight>
     <surfaceType>Item</surfaceType>
-    <researchPrerequisites><li>SK_Petrochemistry</li></researchPrerequisites>
+    <researchPrerequisites><li>SK_StorageII</li></researchPrerequisites>
        <comps>
       <li>
         <compClass>CompQuality</compClass>


### PR DESCRIPTION
Pallet research prerequisites - Storage I (fix)
Skip research prerequisites - Storage II (fix)
__
у палета емкость 500 у скипа 800. по [дереву технологий](https://github.com/skyarkhangel/Hardcore-SK/blob/master/%D0%B4%D0%B5%D1%80%D0%B5%D0%B2%D0%BE/ResearchTreeSK.png) они оба открываются через Storage I. смысл в палете когда?
имхо я бы skip в Storage III запихнул, что бы продлить жизнь палетам по дольше. 