### PR TITLE
Fishing fix

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Building_FishingPier.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Building_FishingPier.xml
@@ -83,6 +83,9 @@
     <building>
       <spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
     </building>
+	<researchPrerequisites>
+		<li>SK_FishingI</li>
+	</researchPrerequisites>
   </ThingDef>
 
 </Buildings>


### PR DESCRIPTION
- fishing pier now require SK_FishingI research to build

___
to prevent shit happens like when you have fishing pier and fishing rod but cant into fishing due to lack of research