### PR TITLE
Moat & WallWire fix

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
@@ -286,6 +286,7 @@
     <uiIconPath>Things/Building/BarbedWire/BarbedWire_Icon</uiIconPath>
     <altitudeLayer>Building</altitudeLayer>
     <pathCost>75</pathCost>
+	<pathCostIgnoreRepeat>False</pathCostIgnoreRepeat>
     <passability>PassThroughOnly</passability>
     <castEdgeShadows>false</castEdgeShadows>
     <fillPercent>0.05</fillPercent>
@@ -339,6 +340,7 @@
     <altitudeLayer>LowPlant</altitudeLayer>
     <uiIconPath>Things/Building/Walls/MenuMoatIcon</uiIconPath>
     <pathCost>80</pathCost>
+	<pathCostIgnoreRepeat>False</pathCostIgnoreRepeat>
     <statBases>
       <Beauty>-20</Beauty>
       <WorkToMake>700</WorkToMake>


### PR DESCRIPTION
- should stop considering pathcost of multiple tiles as single

![screenshot42](https://cloud.githubusercontent.com/assets/20729235/18028265/61cd5df4-6c7a-11e6-93ff-4c9e96e6f48a.png)

___
не думаю что это применимо к мешкам - на них можно физически залезть.