### PR TITLE
Compact machinery, meals

### DIFF
--- a/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Natural.xml
+++ b/Mods/Core/Defs/ThingDefs_Buildings/Buildings_Natural.xml
@@ -250,7 +250,7 @@
     <building>
       <isResourceRock>true</isResourceRock>
       <mineableThing>Component</mineableThing>
-      <mineableYield>2</mineableYield>
+      <mineableYield>8</mineableYield>
       <mineableScatterCommonality>1.00</mineableScatterCommonality> <!-- as often as steel, with smaller blotches -->
       <mineableScatterLumpSizeRange>
         <min>3</min>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Fruits.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Fruits.xml
@@ -3,7 +3,7 @@
 
   <ThingDef Abstract="True" Name="FruitFoodRawBase" ParentName="OrganicProductBase" >
     <ingestible>
-      <preferability>MealAwful</preferability>
+      <preferability>MealSimple</preferability>
 	  <tastesRaw>false</tastesRaw>
       <eatEffect>EatVegetarian</eatEffect>
       <soundEat>RawVegetable_Eat</soundEat>


### PR DESCRIPTION
Compact machinery increased since 2 to 8. With the number of components that go to build, spend a lot of time to get 2 things - ridiculously.

Banana, apple, orange, peach, and other now not an AWFUL meals. Here it is better to make the character's trait "does not like fruit," or something like that.