### PR TITLE
Weapon descriptions fix

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Turrets.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Turrets.xml
@@ -164,7 +164,7 @@
 	<RecipeDef ParentName="cratecraftbase">
 		<defName>BuildMinigunTurret_Crate</defName>
 		<label>Build 7.62x51mm M134 Minigun crate</label>
-		<description>Use this to build a 7.62x51mm Vulcan Cannon, a type of stationary manned turret. Requires 800 W to function and it uses 7.62x51mm ammo.</description>
+		<description>Use this to build a 7.62x51mm M134 Minigun, a type of stationary manned turret. It uses 7.62x51mm ammo.</description>
 		<jobString>Building 7.62x51mm M134 Minigun crate</jobString>
 		<workAmount>10500</workAmount>
 		<skillRequirements>
@@ -515,9 +515,9 @@
 	
 	<RecipeDef ParentName="cratecraftbase">
 		<defName>BuildAvenger_Crate</defName>
-		<label>Build 35x228mm GAU-8 Avenger crate</label>
-		<description>Use this to build a 35x228mm GAU-8 Avenger, a type of stationary manned turret. It uses 35x228mm Avenger Shells for ammo.</description>
-		<jobString>Building 35x228mm GAU-8 Avenger crate.</jobString>
+		<label>Build 30x173mm GAU-8 Avenger crate</label>
+		<description>Use this to build a 30x173mm GAU-8 Avenger, a type of stationary manned turret. It uses 30x173mm shells for ammo.</description>
+		<jobString>Building 30x173mm GAU-8 Avenger crate.</jobString>
 		<workAmount>18500</workAmount>
 		<skillRequirements>
 				<li>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_WeaponComponents.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_WeaponComponents.xml
@@ -4,7 +4,7 @@
 
   <RecipeDef>
     <defName>MakeWeapon_Parts</defName>
-    <label>Make weapon parts</label>
+    <label>Make Weapon parts</label>
     <description>It's the main part of craft all types of weapons. Produces 5.</description>
     <jobString>Making  weapon parts.</jobString>
     <workAmount>1500</workAmount>
@@ -69,7 +69,7 @@
 
   <RecipeDef>
     <defName>MakePistol_Component</defName>
-    <label>Make pistol component</label>
+    <label>Make Pistol component</label>
     <description>Pistol components used as basis for craft pistols. Produces 1.</description>
     <jobString>Making pistol component.</jobString>
     <workAmount>1200</workAmount>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Heavy.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Heavy.xml
@@ -4,7 +4,7 @@
     <RecipeDef>
 		<defName>BuildLMG</defName>
 		<label>Build L-15 LMG</label>
-		<description>Builds the L-15 LMG for personal defense. As a portable light machine gun the L-15 is heavy to carry around but is capable of providing 15-round bursts for suppressing fire. Has a large magazine to accomodate the large burst fire.</description>
+		<description>Builds the L-15 LMG for personal defense. As a portable light machine gun the L-15 is heavy to carry around but is capable of providing 15-round bursts for suppressing fire.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building L-15 LMG</jobString>
 		<workAmount>9500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -84,7 +84,7 @@
     <RecipeDef>
 		<defName>BuildM56_USCM</defName>
 		<label>Build M56 Smart Gun</label>
-		<description>The M56 Smart Gun is a portable heavy machine gun with automatic targeting capabilities chambered for 10x28mm caseless ammunition. It is notably employed by the United States Colonial Marine Corps. It hurts like hell.</description>
+		<description>The M56 Smart Gun is a portable heavy machine gun with automatic targeting capabilities.\nCaliber: .50 BMG</description>
 		<jobString>Building M56 smart gun.</jobString>
 		<workAmount>9900</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -173,7 +173,7 @@
 	<RecipeDef>
 		<defName>BuildMinigun</defName>
 		<label>Build XM214 Microgun</label>
-		<description>Builds the XM214 Microgun, which is a multi-barrel machine gun with an extremely high rate of fire. The design of this weapon originates from Mechanoids.</description>
+		<description>Builds the XM214 Microgun, which is a multi-barrel machine gun with an extremely high rate of fire.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building XM214 Microgun.</jobString>
 		<workAmount>16000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -261,7 +261,7 @@
 	<RecipeDef>
 		<defName>BuildIncendiaryLauncher</defName>
 		<label>Build RL T9 Burning Sun</label>
-		<description>Builds the RL T9 Burning Sun, an incendiary bolt launcher that is capable of starting fires from a distance.</description>
+		<description>Builds the RL T9 Burning Sun, an incendiary bolt launcher that is capable of starting fires from a distance.\nCaliber: 30x64mm Fuel cell</description>
 		<jobString>Building RL T9 Burning Sun.</jobString>
 		<workAmount>9000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -349,7 +349,7 @@
 	<RecipeDef>
 		<defName>BuildGalilBurstRifle</defName>
 		<label>Build RPK-74</label>
-		<description>Builds the RPK-47, an ancient pattern military rifle. Fires an 8-round burst. Good range, low power and high rate of fire.</description>
+		<description>Builds the RPK-47, an ancient pattern military rifle. Fires an 8-round burst. Good range, low power and high rate of fire.\nCaliber: 7.62x39mm Soviet</description>
 		<jobString>Building RPK-74.</jobString>
 		<workAmount>10500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -438,7 +438,7 @@
 	<RecipeDef>
 		<defName>BuildHeavyCombatRifle</defName>
 		<label>Build MA39X ICWS</label>
-		<description>Builds the MA39X Individual Combat Weapon System (MA39X ICWS or MA39X Assault Rifle), a close combat service rifle of the UNSC. Fires a 12-round burst with average medium range accuracy.</description>
+		<description>Builds the MA39X Individual Combat Weapon System, a close combat service rifle of the UNSC. Fires a 12-round burst with average medium range accuracy.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building MA39X ICWS.</jobString>
 		<workAmount>10500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -526,7 +526,7 @@
 	<RecipeDef>
 		<defName>BuildMilkorGrenadeLauncher</defName>
 		<label>Build Milkor MGL</label>
-		<description>Builds the Milkor MGL (multiple grenade launcher), a launcher-type weapon that fires 40mm concussive grenades at a higher rate than a human could.</description>
+		<description>Builds the Milkor MGL (multiple grenade launcher), a launcher-type weapon that fires grenades at a higher rate than a human could.\nCaliber: 40x46mm Grenade</description>
 		<jobString>Building Milkor MGL.</jobString>
 		<workAmount>11000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -613,8 +613,8 @@
 	
 	<RecipeDef>
 		<defName>BuildM249</defName>
-		<label>Build M249 SAW MG</label>
-		<description>Builds the M249 SAW MG, a heavy machinegun. It has a 200 round magazine and fires in 20 round bursts. Not very accurate but good at providing suppressing fire.</description>
+		<label>Build M249 LMG SAW MG</label>
+		<description>Builds the M249 LMG SAW MG, a heavy machinegun. It has a 120 round magazine and fires in 20 round bursts. Not very accurate but good at providing suppressing fire.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building M249 SAW MG.</jobString>
 		<workAmount>13000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Launchers.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Launchers.xml
@@ -4,7 +4,7 @@
 	<RecipeDef>
 		<defName>BuildRPG</defName>
 		<label>Build RPG-7</label>
-		<description>Builds the RPG-7 (rocket propelled grenade). It is a portable, shoulder-fired, unguided weapon that is capable of firing a deadly explosive from long range. The explosive has a wide blast radius. Slow to reload and slow to fire. It must be reloaded after every shot.</description>
+		<description>Builds the RPG-7 (rocket propelled grenade). Slow to reload and slow to fire. It must be reloaded after every shot.\nCaliber: RPG-7 Grenade</description>
 		<jobString>Building RPG-7.</jobString>
 		<workAmount>13000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -84,7 +84,7 @@
 	<RecipeDef>
 		<defName>BuildM5_USCM</defName>
 		<label>Build M5 RPG</label>
-		<description>Builds the M5 Rocket Propelled Grenade (RPG). It is a portable, shoulder-fired, reloadable, semi-automatic unguided anti-armor rocket-propelled grenade launcher used by United States Colonial Marine Corps as their standard issue RPG. Able to load up to 4 rockets, the M5 RPG is the favorite anti-infantry toy of the USCM.</description>
+		<description>Builds the M5 Rocket Propelled Grenade (RPG). It is a portable, shoulder-fired, reloadable, semi-automatic unguided anti-armor rocket-propelled grenade launcher. Able to load up to 4 rockets.\nCaliber: RPG-7 Grenade</description>
 		<jobString>Building M5 RPG.</jobString>
 		<workAmount>13000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -163,7 +163,7 @@
 	<RecipeDef>
 		<defName>BuildLAW</defName>
 		<label>Build M72 LAW</label>
-		<description>Builds the M72 LAW, an anti-tank rocket launcher with a special armor-piercing penetration rocket.</description>
+		<description>Builds the M72 LAW, an anti-tank rocket launcher with a special armor-piercing penetration rocket.\nCaliber: M72 LAW</description>
 		<jobString>Building M72 LAW.</jobString>
 		<workAmount>12000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Pistols.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Pistols.xml
@@ -4,7 +4,7 @@
 	<RecipeDef>
 		<defName>BuildHandGun</defName>
 		<label>Build Colt M1911</label>
-		<description>Builds an ancient pattern automatic pistol. Weak and short range, but quick.</description>
+		<description>Builds an ancient pattern automatic pistol. Weak and short range, but quick.\nCaliber: .45 ACP</description>
 		<jobString>Building Colt M1911.</jobString>
 		<workAmount>3500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -148,7 +148,7 @@
 	<RecipeDef>
 		<defName>BuildP226Gun</defName>
 		<label>Build SIG Sauer P226</label>
-		<description>The SIG Sauer P226 is a full-sized, service-type pistol made by SIG Sauer. The SIG Sauer P226 and its variants are in service with numerous law enforcement and military organizations worldwide. Low damage, high rate of fire and good accuracy.</description>
+		<description>The SIG Sauer P226 is a full-sized, service-type pistol made by SIG Sauer. Low damage, high rate of fire and good accuracy.\nCaliber: .40 Rimfire</description>
 		<jobString>Building SIG Sauer P226.</jobString>
 		<workAmount>3800</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -227,7 +227,7 @@
 	<RecipeDef>
 		<defName>BuildDeringerPistol</defName>
 		<label>Build Remington M95 Derringer</label>
-		<description>Builds a Remington M95 Derringer, a small decorated revolver. Accurate at short range only.  Moderately damaging with a short aim and cooldown period.</description>
+		<description>Builds a Remington M95 Derringer, a small decorated revolver. Accurate at short range only.  Moderately damaging with a short aim and cooldown period.\nCaliber: .45 ACP</description>
 		<jobString>Building Remington M95 Derringer.</jobString>
 		<workAmount>4500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -307,7 +307,7 @@
 	<RecipeDef>
 		<defName>BuildSphinxPistol</defName>
 		<label>Build Sphinx AT 2000</label>
-		<description>Builds a Sphinx AT 2000, a high quality and highly durable handgun that is used by elite forces and sport shooters. Great accuracy, moderate damage but a tad slow.</description>
+		<description>Builds a Sphinx AT 2000, a high quality and highly durable handgun that is used by elite forces and sport shooters. Great accuracy, moderate damage but a tad slow.\nCaliber: 9x19mm Para</description>
 		<jobString>Building Sphinx AT 2000.</jobString>
 		<workAmount>4800</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -396,7 +396,7 @@
 	<RecipeDef>
 		<defName>BuildVektorCP</defName>
 		<label>Build Vektor CP1</label>
-		<description>Builds a Vektor CP1, an ergonomical handgun with a drastically non-rectangular design. Good accuracy and low recoil, but weak with a slightly lower range.</description>
+		<description>Builds a Vektor CP1, an ergonomical handgun with a drastically non-rectangular design. Good accuracy and low recoil, but weak with a slightly lower range.\nCaliber: 9x19mm Para</description>
 		<jobString>Building Vektor CP1.</jobString>
 		<workAmount>4800</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -477,7 +477,7 @@
 	<RecipeDef>
 		<defName>BuildParaOrdnancePFourteenFortyfive</defName>
 		<label>Build Para Ordnance P14-45</label>
-		<description>Builds a Para Ordnance P14-45m which is a counterfeit ancient 45 ACP handgun with slightly improved internal mechanisms and a plastic frame. High accuracy and above average range, average fire rate and damage.</description>
+		<description>Builds a Para Ordnance P14-45m. High accuracy and above average range, average fire rate and damage.\nCaliber: .45 ACP</description>
 		<jobString>Building Para Ordnance P14-45</jobString>
 		<workAmount>4800</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -566,7 +566,7 @@
 	<RecipeDef>
 		<defName>BuildTecnine</defName>
 		<label>Build TEC-9</label>
-		<description>Builds a Tec-9 lightweight semi-automatic pistol with a quick draw, low damage and very high firerate. Operates at a short range.</description>
+		<description>Builds a Tec-9 lightweight semi-automatic pistol with a quick draw, low damage and very high firerate. Operates at a short range.\nCaliber: 9x19mm Para</description>
 		<jobString>Building TEC-9.</jobString>
 		<workAmount>5200</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -654,7 +654,7 @@
 	<RecipeDef>
 		<defName>Build93RBurstPistol</defName>
 		<label>Build Beretta 93R</label>
-		<description>Builds a Beretta 93R, a nice-looking machinepistol with a very fast burstfire mode. Low stopping power and hits up to pistol range.</description>
+		<description>Builds a Beretta 93R, a nice-looking machinepistol with a very fast burstfire mode. Low stopping power and hits up to pistol range.\nCaliber: 9x19mm Para</description>
 		<jobString>Building Beretta 93R.</jobString>
 		<workAmount>5300</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -742,7 +742,7 @@
 	<RecipeDef>
 		<defName>BuildMagnum</defName>
 		<label>Build .44 Remington Magnum</label>
-		<description>Builds the .44 Remington Magnum. It is based on a lengthened .44 Special Case, and it is calibrated to higher pressures for greater velocity (and thus, energy). Very lightweight and accurate at medium range.</description>
+		<description>Builds the .44 Remington Magnum. Very lightweight and accurate at medium range.\nCaliber: .44 Magnum</description>
 		<jobString>Building .44 Remington Magnum.</jobString>
 		<workAmount>7500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -829,9 +829,9 @@
 		
 	<RecipeDef>
 		<defName>BuildDesertEagle</defName>
-		<label>Build Desert Eagle .45 ACP</label>
-		<description>Builds the Desert Eagle .45 ACP, a famous and deadly pistol. Very accurate, fast fire rate and lightweight to carry.</description>
-		<jobString>Building Desert Eagle .45 ACP.</jobString>
+		<label>Build Desert Eagle .50AE</label>
+		<description>Builds the Desert Eagle .50AE, a famous and deadly pistol. Very accurate, fast fire rate and lightweight to carry.\nCaliber: .50 AE</description>
+		<jobString>Building Desert Eagle .50 AE.</jobString>
 		<workAmount>8000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Rifle.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Rifle.xml
@@ -4,7 +4,7 @@
 	<RecipeDef>
 		<defName>Build_LeeEnfield</defName>
 		<label>Build Lee-Enfield</label>
-		<description>Builds an ancient bolt-action rifle. Good range, good power and low rate of fire.</description>
+		<description>Builds an ancient bolt-action rifle. Good range, good power and low rate of fire.\nCaliber: .303 British</description>
 		<jobString>Building Lee-Enfield.</jobString>
 		<workAmount>4200</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -83,7 +83,7 @@
 	<RecipeDef>
 		<defName>BuildMosinBoltRifle</defName>
 		<label>Build Mosin-Nagant M91</label>
-		<description>Builds a Mosin-Nagant M91, an ancient bolt-action rifle. Good range, dood power and low rate of fire.</description>
+		<description>Builds a Mosin-Nagant M91, an ancient bolt-action rifle. Good range, dood power and low rate of fire.\nCaliber: 7.62x54mm R</description>
 		<jobString>Building Mosin-Nagant M91.</jobString>
 		<workAmount>5000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -162,7 +162,7 @@
 	<RecipeDef>
 		<defName>BuildCXfour</defName>
 		<label>Build Beretta CX4</label>
-		<description>Builds the Beretta CX4, a highly reliable compact carbine. It is designed to fire pistol rounds up to rifle range. Below average damage, average fire rate, above average range and fires in two round burst.</description>
+		<description>Builds the Beretta CX4, a highly reliable compact carbine. Below average damage, average fire rate, above average range and fires in two round burst.\nCaliber: 9x19mm Para</description>
 		<jobString>Building Beretta CX4.</jobString>
 		<workAmount>7000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -251,7 +251,7 @@
 	<RecipeDef>
 		<defName>BuildPCnine</defName>
 		<label>Build Ruger PC-9</label>
-		<description>Builds the Ruger PC-9, a carbine sidearm with pistol-calibre. Its long barrel allows it to fire pistol bullets at rifle range. Average damage, above average fire rate and average range.</description>
+		<description>Builds the Ruger PC-9, a carbine sidearm with pistol-calibre. Average damage, above average fire rate and average range.\nCaliber: .40 Rimfire</description>
 		<jobString>Building Ruger PC-9.</jobString>
 		<workAmount>7000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -340,7 +340,7 @@
 	<RecipeDef>
 		<defName>BuildUSC</defName>
 		<label>Build HK USC</label>
-		<description>Builds the HK USC, a stable semi-automatic pistol-calibre carbine with low kickback and an unusual stock design. Average damage, above average fire rate and range that fires three round bursts.</description>
+		<description>Builds the HK USC, a stable semi-automatic pistol-calibre carbine with low kickback and an unusual stock design. Average damage, above average fire rate and range that fires three round bursts.\nCaliber: .45 ACP</description>
 		<jobString>Building HK USC.</jobString>
 		<workAmount>7000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -428,7 +428,7 @@
 	<RecipeDef>
 		<defName>BuildAKS74U</defName>
 		<label>Build AKS-74U</label>
-		<description>Builds the AKS-74U short assault rifle (the "U" suffix means "Ukorochennyj" in Russian = "Shortened" in English). It was developed in the late 1970s from the AKS-74 assault rifle. The AKS-74U was intended as a personal defense weapon for tank, gun, helicopter and other vehicle crews as well as for special operation forces. The AKS-74U has the size and effective range of a typical submachine gun, but has advantage of assault rifle ammunition and magazines. Average damage and rate of fire, low range but poor accurracy.</description>
+		<description>Builds the AKS-74U short assault rifle. Average damage and rate of fire, low range but poor accurracy. \nCaliber: 5.45x39mm R</description>
 		<jobString>Building AKS-74U.</jobString>
 		<workAmount>7000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -517,7 +517,7 @@
 	<RecipeDef>
 		<defName>BuildM4A1Gun</defName>
 		<label>Build M4A1 Carbine</label>
-		<description>Builds the M4 Carbine, a shorter and lighter variant of the M16A2 assault rifle. It is heavily used by the United States Armed Forces and is replacing the M16 rifle in most of the United States Army and United States Marine Corps combat units as the primary infantry weapon. Average damage and range, good rate of fire and good accurracy.</description>
+		<description>Builds the M4A1 Carbine, a shorter and lighter variant of the M16A2 assault rifle. Average damage and range, good rate of fire and good accurracy.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building M4A1 Carbine.</jobString>
 		<workAmount>7000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_RifleAdvanced.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_RifleAdvanced.xml
@@ -4,7 +4,7 @@
 	<RecipeDef>
 		<defName>BuildAssaultRifle</defName>
 		<label>Build M16 Rifle</label>
-		<description>Builds a general-purpose military assault rifle for field or urban combat. Fires a 3-round burst.</description>
+		<description>Builds a general-purpose military assault rifle for field or urban combat. Fires a 3-round burst.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building M16 Rifle.</jobString>
 		<workAmount>8000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -93,7 +93,7 @@
 	<RecipeDef>
 		<defName>BuildSG553Gun</defName>
 		<label>Build SIG SG553</label>
-		<description>The SIG SG553, a slightly improved version of the SG552, is the SBR (Short Barrel Rifle) version of the SIG SG550. It fires the 5.56x45mm NATO round. Average damage and range, good rate of fire and accurracy.</description>
+		<description>The SIG SG553, a slightly improved version of the SG552, is the SBR (Short Barrel Rifle) version of the SIG SG550. Average damage and range, good rate of fire and accurracy.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building SIG SG553.</jobString>
 		<workAmount>9500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -182,7 +182,7 @@
 	<RecipeDef>
 		<defName>BuildAUG</defName>
 		<label>Build Steyr AUG A3</label>
-		<description>The Steyr AUG  A3 is an Austrian bullpup 5.56×45mm NATO assault rifle, designed in the 1960s by Steyr Mannlicher GmbH. Average damage, good range, good accuracy and low rate of fire.</description>
+		<description>The Steyr AUG  A3 is an Austrian bullpup 5.56×45mm NATO assault rifle, designed in the 1960s by Steyr Mannlicher GmbH. Average damage, good range, good accuracy and low rate of fire.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building Steyr AUG A3.</jobString>
 		<workAmount>9500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -271,7 +271,7 @@
 	<RecipeDef>
 		<defName>BuildSCAR_H</defName>
 		<label>Build FN SCAR-H</label>
-		<description>The Special Operations Forces Combat Assault Rifle (SCAR) is a gas-operated self-loading rifle with a rotating bolt. The rifle was developed by FN Herstal (FNH) for the United States Special Operations Command (SOCOM) to satisfy the requirements of the SCAR competition. Good damage, good range, good accuracy and low rate of fire.</description>
+		<description>The Special Operations Forces Combat Assault Rifle (SCAR) is a gas-operated self-loading rifle with a rotating bolt. Good damage, good range, good accuracy and low rate of fire.\nCaliber: 7.62x51mm NATO</description>
 		<jobString>Building FN SCAR-H.</jobString>
 		<workAmount>9200</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -360,7 +360,7 @@
 	<RecipeDef>
 		<defName>BuildFAMAS</defName>
 		<label>Build FAMAS G2</label>
-		<description>The FAMAS is a bullpup-styled assault rifle designed and manufactured in France by MAS located in Saint-Étienne, which is now a member of the French government-owned Nexter group. It is the service rifle of the French military. Average damage and range, good rate of fire and accurracy.</description>
+		<description>The FAMAS is a bullpup-styled assault rifle. Average damage and range, good rate of fire and accurracy.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building FAMAS G2.</jobString>
 		<workAmount>7500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -490,7 +490,7 @@
 	<RecipeDef>
 		<defName>BuildXM8MilitaryRifle</defName>
 		<label>Build HK XM8 Military Rifle</label>
-		<description>Builds the HK XM8 Military Rifle, an ancient pattern military weapon. Three-round burst. Good range, low power an high rate of fire.</description>
+		<description>Builds the HK XM8 Military Rifle, an ancient pattern military weapon. Three-round burst. Good range, low power an high rate of fire.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building HK XM8 Military Rifle.</jobString>
 		<workAmount>10000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -579,7 +579,7 @@
 	<RecipeDef>
 		<defName>BuildAK47Gun</defName>
 		<label>Build AK-47</label>
-		<description>Builds the AK-47, a selective-fire, gas-operated 7.62×39mm assault rifle. It was first developed in the Soviet Union by Mikhail Kalashnikov. It is officially known as Avtomat Kalashnikova (Russian: Автомат Калашникова). Good damage, average range and rate of fire but poor accuracy.</description>
+		<description>Builds the AK-47, a selective-fire, gas-operated assault rifle. Good damage, average range and rate of fire but poor accuracy.\nCaliber: 7.62x39mm Soviet</description>
 		<jobString>Building AK-47.</jobString>
 		<workAmount>9000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -659,7 +659,7 @@
 	<RecipeDef>
 		<defName>BuildTacticalCombatrifle</defName>
 		<label>Build MA5 ICWS</label>
-		<description>Builds the MA5 Individual Combat Weapon System (MA5 ICWS or MA5 Assault rifle). It is a standard-issue service rifle of the UNSC Marines.</description>
+		<description>Builds the MA5 Individual Combat Weapon System (MA5 ICWS or MA5 Assault rifle). It is a standard-issue service rifle of the UNSC Marines.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building MA5 ICWS.</jobString>
 		<workAmount>10000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -746,8 +746,8 @@
 	
 	<RecipeDef>
 		<defName>BuildMarineSturmRifle</defName>
-		<label>Build TAR-21</label>
-		<description>Builds the TAR-21. This marine sturm rifle is the standard firearm for all combat personnel in the Colonial Marine Corps. Fires a 5 round burst.</description>
+		<label>Build Tavor TAR-21</label>
+		<description>Builds the Tavor TAR-21. Fires a 5 round burst.\nCaliber: 5.56x45mm NATO</description>
 		<jobString>Building TAR-21.</jobString>
 		<workAmount>11000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_SMGs.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_SMGs.xml
@@ -4,7 +4,7 @@
 	<RecipeDef>
 		<defName>BuildPDW</defName>
 		<label>Build Uzi</label>
-		<description>The Uzi is a micro-submachine gun. Short range, low power and high rate of fire. Very quick to aim and fire.</description>
+		<description>The Uzi is a micro-submachine gun. Short range, low power and high rate of fire. Very quick to aim and fire.\nCaliber: 9x19mm Para</description>
 		<jobString>Building Uzi.</jobString>
 		<workAmount>4600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -84,7 +84,7 @@
 	<RecipeDef>
 		<defName>BuildHeavySMG</defName>
 		<label>Build Spectre M4 Luger</label>
-		<description>Builds a compact, wide-caliber slug-thrower. Very short range, but it packs a punch and handles quite well.</description>
+		<description>Builds a compact, wide-caliber slug-thrower. Very short range, but it packs a punch and handles quite well.\nCaliber: .40 Rimfire</description>
 		<jobString>Building Spectre M4 Luger</jobString>
 		<workAmount>5000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -172,7 +172,7 @@
 	<RecipeDef>
 		<defName>BuildTMPMachinePistol</defName>
 		<label>Build Silenced TMP</label>
-		<description>Builds a Silenced TMP (tactical machine pistol). Somewhat accurate at long range, has fast burstfire but low stopping power.</description>
+		<description>Builds a Silenced TMP (tactical machine pistol). Somewhat accurate at long range, has fast burstfire but low stopping power.\nCaliber: 9x19mm Para</description>
 		<jobString>Building Silenced TMP.</jobString>
 		<workAmount>5000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -251,7 +251,7 @@
 	<RecipeDef>
 		<defName>BuildSkorpionSMG</defName>
 		<label>Build Scorpion EVO 3</label>
-		<description>Builds a Scorpion EVO 3, a machinepistol or light SMG with a notorious folding stock design. Fires weak ammunition in quick five shot-bursts at pistol range.</description>
+		<description>Builds a Scorpion EVO 3, a machinepistol or light SMG with a notorious folding stock design. Fires weak ammunition in quick five shot-bursts at pistol range.\nCaliber: 9x19mm Para</description>
 		<jobString>Building Scorpion EVO 3.</jobString>
 		<workAmount>5600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -331,7 +331,7 @@
 	<RecipeDef>
 		<defName>BuildM3SMG</defName>
 		<label>Build M3 Greasegun</label>
-		<description>Builds a M3 Greasegun, a very simplistic submachinegun design. Low damage, high fire rate and short range.</description>
+		<description>Builds a M3 Greasegun, a very simplistic submachinegun design. Low damage, high fire rate and short range.\nCaliber: .40 Rimfire</description>
 		<jobString>Building M3 Greasegun.</jobString>
 		<workAmount>5600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -411,7 +411,7 @@
 	<RecipeDef>
 		<defName>BuildVector</defName>
 		<label>Build Kriss Vector K10</label>
-		<description>Builds a Kriss Vector K10, a submachinegun that fires in medium length bursts. Its substantially reduced knockback causes it to be accurate up to medium range, but its bullet drop limits maximum range by a lot.</description>
+		<description>Builds a Kriss Vector K10, a submachinegun that fires in medium length bursts. Its substantially reduced knockback causes it to be accurate up to medium range, but its bullet drop limits maximum range by a lot.\nCaliber: .45 ACP</description>
 		<jobString>Building Vector K10.</jobString>
 		<workAmount>5600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -500,7 +500,7 @@
 	<RecipeDef>
 		<defName>BuildMP5Gun</defName>
 		<label>Build HK MP5A3</label>
-		<description>Builds a Heckler Koch Machine Pistol 5A3, a 9mm submachine gun of German design. It was originally developed in the 1960s by a team of engineers from the German small arms manufacturer Heckler Koch GmbH of Oberndorf am Neckar. Low damage and short range, very high rate of fire.</description>
+		<description>Builds a Heckler Koch Machine Pistol 5A3, a 9mm submachine gun of German design. Low damage and short range, very high rate of fire.\nCaliber: 9x19mm Para</description>
 		<jobString>Building HK MP5A3.</jobString>
 		<workAmount>5600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -589,7 +589,7 @@
 	<RecipeDef>
 		<defName>BuildUMP45Gun</defName>
 		<label>Build HK UMP45</label>
-		<description>The HK UMP45 is a submachine gun developed and manufactured by Heckler Koch. The HK UMP45 has been adopted by various agencies such as the U.S. Customs and Border Protection. Heckler Koch developed the UMP45 as a successor to the MP5. Average damage, low range and high rate of fire.</description>
+		<description>The HK UMP45 is a submachine gun developed and manufactured by Heckler Koch. Average damage, low range and high rate of fire.\nCaliber: .45 ACP</description>
 		<jobString>Building HK UMP45.</jobString>
 		<workAmount>5900</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Shotguns.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Shotguns.xml
@@ -4,7 +4,7 @@
 	<RecipeDef>
 		<defName>BuildPumpShotgun</defName>
 		<label>Build Remington 870</label>
-		<description>Builds an ancient shotgun for personal defence.</description>
+		<description>Builds an ancient shotgun for personal defence.\nCaliber: 12 Gauge</description>
 		<jobString>Building Remington 870.</jobString>
 		<workAmount>5000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -84,7 +84,7 @@
 	<RecipeDef>
 		<defName>BuildM37A2_USCM</defName>
 		<label>Build M37A2 Pump Shotgun</label>
-		<description>The M37A2 Pump Shotgun which also known as the M37A2 Combat Shotgun, is a pump-action combat shotgun manufactured by Armat Battlefield Systems. The M37A2 is a simple and effective pump-action shotgun; its "classic" pump-action allows extremely powerful shells to be fired reliably. The M37A2 is employed by the United States Colonial Marine Corps and Weyland-Yutani PMCs.</description>
+		<description>The M37A2 Pump Shotgun which also known as the M37A2 Combat Shotgun, is a pump-action combat shotgun.\nCaliber: 12 Gauge</description>
 		<jobString>Building M37A2 Pumpshotgun.</jobString>
 		<workAmount>5800</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -165,7 +165,7 @@
 	<RecipeDef>
 		<defName>BuildPumpShotgun</defName>
 		<label>Build Remington 870</label>
-		<description>Builds an ancient shotgun for personal defence.</description>
+		<description>Builds an ancient shotgun for personal defence.\nCaliber: 12 Gauge</description>
 		<jobString>Building Remington 870.</jobString>
 		<workAmount>5000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -245,7 +245,7 @@
 	<RecipeDef>
 		<defName>BuildM37A2_USCM</defName>
 		<label>Build M37A2 Pump Shotgun</label>
-		<description>The M37A2 Pump Shotgun which also known as the M37A2 Combat Shotgun, is a pump-action combat shotgun manufactured by Armat Battlefield Systems. The M37A2 is a simple and effective pump-action shotgun; its "classic" pump-action allows extremely powerful shells to be fired reliably. The M37A2 is employed by the United States Colonial Marine Corps and Weyland-Yutani PMCs.</description>
+		<description>The M37A2 Pump Shotgun which also known as the M37A2 Combat Shotgun, is a pump-action combat shotgun.\nCaliber: 12 Gauge</description>
 		<jobString>Building M37A2 Pumpshotgun.</jobString>
 		<workAmount>5800</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -324,7 +324,7 @@
 	<RecipeDef>
 		<defName>BuildStrikerShotgun</defName>
 		<label>Build Striker Shotgun</label>
-		<description>Builds a Striker Shotgun, a cheap-looking semi-automatic shotgun. Has a high fire rate and high damage output, but low range.</description>
+		<description>Builds a Striker Shotgun, a cheap-looking semi-automatic shotgun. Has a high fire rate and high damage output, but low range.\nCaliber: 12 Gauge</description>
 		<jobString>Building Striker Shotgun.</jobString>
 		<workAmount>6200</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -413,7 +413,7 @@
 	<RecipeDef>
 		<defName>BuildTacticalShotgun</defName>
 		<label>Build M45 Tactical Shotgun</label>
-		<description>Builds the M45 Tactical Shotgun, a shotgun used by the United Nations Space Command Army. Holds 8 shells with a quick fire rate but low range.</description>
+		<description>Builds the M45 Tactical Shotgun, a shotgun used by the United Nations Space Command Army. Holds 8 shells with a quick fire rate but low range.\nCaliber: 12 Gauge</description>
 		<jobString>Building M45 Tactical Shotgun.</jobString>
 		<workAmount>7500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -502,7 +502,7 @@
 	<RecipeDef>
 		<defName>BuildAA12AutoShotgun</defName>
 		<label>Build Atchisson Assault AA-12</label>
-		<description>Builds an Atchisson Assault AA-12, an automatic shotgun with almost no recoil. Has burst fire, is moderately accurate at just under rifle range and has high damage output.</description>
+		<description>Builds an Atchisson Assault AA-12, an automatic shotgun with almost no recoil. Has burst fire, is moderately accurate at just under rifle range and has high damage output.\nCaliber: 12 Gauge</description>
 		<jobString>Building Atchisson Assault AA-12.</jobString>
 		<workAmount>9000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -591,7 +591,7 @@
 	<RecipeDef>
 		<defName>BuildTacticalAutoshotgun</defName>
 		<label>Build M90 CAWS</label>
-		<description>Builds the M90 Close Assault Weapon System (M90 CAWS). It is the UNSC's primary shotgun and is one of the most effective close range infantry weapons used by front line forces.</description>
+		<description>Builds the M90 Close Assault Weapon System (M90 CAWS). It is the UNSC's primary shotgun and is one of the most effective close range infantry weapons used by front line forces.\nCaliber: 12 Gauge</description>
 		<jobString>Building M90 CAWS automatic shotgun.</jobString>
 		<workAmount>9000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Snipers.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Snipers.xml
@@ -4,7 +4,7 @@
 	<RecipeDef>
 		<defName>BuildSniperRifle</defName>
 		<label>Build M24 Sniper Rifle</label>
-		<description>Builds an ancient pattern military sniper rifle. Bolt action, long range, great accuracy and power.</description>
+		<description>Builds an ancient pattern military sniper rifle. Bolt action, long range, great accuracy and power.\nCaliber: 7.62x51mm NATO</description>
 		<jobString>Building M24 Sniper Rifle.</jobString>
 		<workAmount>6600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -93,7 +93,7 @@
 	<RecipeDef>
 		<defName>BuildM42A_USCM</defName>
 		<label>Build M42A Scope Rifle</label>
-		<description>The M42A Scope Rifle is an American-made semi-automatic sniper rifle chambered for 10mm M252 HEAP ammunition. It is employed as the primary sniper weapon of the United States Colonial Marine Corps.</description>
+		<description>The M42A Scope Rifle is an American-made semi-automatic sniper rifle.\nCaliber: 7.62x51mm NATO</description>
 		<jobString>Building M42A Scope Rifle.</jobString>
 		<workAmount>6900</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -182,7 +182,7 @@
 	<RecipeDef>
 		<defName>BuildDragunovSVU</defName>
 		<label>Build SVU OTs-03 Dragunov</label>
-		<description>The SVU OTs-03 Dragunov is a bullpup configuration of the SVD sniper rifle. The SVU was developed to meet the needs of the security forces of the Russian Ministry of Internal Affairs, such as OMON. High damage, long range and very good accuracy.</description>
+		<description>The SVU OTs-03 Dragunov is a bullpup configuration of the SVD sniper rifle. High damage, long range and very good accuracy.\nCaliber: 7.62x54mm R</description>
 		<jobString>Building SVU OTs-03 Dragunov.</jobString>
 		<workAmount>6900</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -270,7 +270,7 @@
 	<RecipeDef>
 		<defName>BuildWA2000SpecialistRifle</defName>
 		<label>Build Walther WA 2000 Rifle</label>
-		<description>Builds the Walther WA 2000 Rifle, a limited edition ancient sniper rifle. Great range, exceptional accuracy, very high damage and very low fire rate.</description>
+		<description>Builds the Walther WA 2000 Rifle, a limited edition ancient sniper rifle. Great range, exceptional accuracy, very high damage and very low fire rate.\nCaliber: 7.62x51mm NATO</description>
 		<jobString>Building Walther WA 2000 Rifle.</jobString>
 		<workAmount>11000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -358,7 +358,7 @@
 	<RecipeDef>
 		<defName>BuildM82Gun</defName>
 		<label>Build Barrett M82A1 SASR</label>
-		<description>Builds the AM Barrett M82, a recoil-operated semi-automatic anti-materiel rifle developed by the American Barrett Firearms Manufacturing company. It is used by many units and armies around the world. Despite its designation as an anti-materiel rifle, it is used by some armed forces as an anti-personnel sniper rifle. Very high damage, long range and very good accuracy.</description>
+		<description>Builds the AM Barrett M82, a recoil-operated semi-automatic anti-materiel rifle. Very high damage, long range and very good accuracy.\nCaliber: 14.5x114mm</description>
 		<jobString>Building Barrett M82A1 SASR.</jobString>
 		<workAmount>12500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -447,7 +447,7 @@
 	<RecipeDef>
 		<defName>BuildTAMSR</defName>
 		<label>Build SRS99 AM Sniper Rifle</label>
-		<description>Builds the Sniper Rifle System 99 Anti-Materiel, which is more formally known as the Special Applications Rifle. It is the favored sniper rifle of the United Nations Space Command. Has a very long range with high accuracy and stopping power.</description>
+		<description>Builds the SRS99 AM Sniper Rifle, which is more formally known as the Special Applications Rifle. Has a very long range with high accuracy and stopping power.\nCaliber: 14.5x114mm</description>
 		<jobString>Building SRS99 AM Sniper Rifle.</jobString>
 		<workAmount>13000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -536,7 +536,7 @@
 	<RecipeDef>
 		<defName>BuildARFifty</defName>
 		<label>Build Armalite AR-50</label>
-		<description>Builds the Armalite AR-50, which is a heavy, accurate, military-grade bolt-action rifle chambered for .50 calibre bullets. Its weight and muzzle brake significantly lowers recoil. Average fire rate, very high damage, high accuracy and long range.</description>
+		<description>Builds the Armalite AR-50, which is a heavy, accurate, military-grade bolt-action rifle. Average fire rate, very high damage, high accuracy and long range.\nCaliber: .50 BMG</description>
 		<jobString>Building Armalite AR-50.</jobString>
 		<workAmount>15000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -625,7 +625,7 @@
 	<RecipeDef>
 		<defName>BuildMDFifty</defName>
 		<label>Build Micor Defense MD50</label>
-		<description>Builds the Micor Defense MD50, an autoloading anti-materiel rifle with a compact bullpup design. This allows it to be operated and carried by a single person. It can be used to destroy structures. Low fire rate, high range, extremely high damage and high accuracy.</description>
+		<description>Builds the Micor Defense MD50, an autoloading anti-materiel rifle with a compact bullpup design. Low fire rate, high range, extremely high damage and high accuracy.\nCaliber: .50 BMG</description>
 		<jobString>Building Micor Defense MD50.</jobString>
 		<workAmount>15000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -714,7 +714,7 @@
 	<RecipeDef>
 		<defName>BuildHecateII</defName>
 		<label>Build Ultima Ratio Hecate II</label>
-		<description>Builds the Ultima Ratio Hecate II, a special application scoped rifle with a long muzzle brake and wooden stock. It is very heavy and will greatly slow any wielder's pace. It can be used to destroy walls. Low fire rate, high range, very high damage and high accuracy.</description>
+		<description>Builds the Ultima Ratio Hecate II, a special application scoped rifle with a long muzzle brake and wooden stock. Low fire rate, high range, very high damage and high accuracy.\nCaliber: .50 BMG</description>
 		<jobString>Building Ultima Ratio Hecate II.</jobString>
 		<workAmount>15000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -802,7 +802,7 @@
 	<RecipeDef>
 		<defName>BuildATR</defName>
 		<label>Build PTRD-41 Rifle</label>
-		<description>Builds the PTRD-41 Rifle (Shortened from Russian, ProtivoTankovoye Ruzhyo Degtyaryova; "Degtyaryov Anti-Tank Rifle"), which is an anti-tank rifle with special armor piercing penetration rounds.</description>
+		<description>Builds the PTRD-41 Rifle, which is an anti-tank rifle with special armor piercing penetration rounds.\nCaliber: 14.5x114mm</description>
 		<jobString>Building PTRD-41 Rifle.</jobString>
 		<workAmount>11000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
@@ -881,7 +881,7 @@
 	<RecipeDef>
 		<defName>BuildVintorez</defName>
 		<label>Build VSS Thread Cutter</label>
-		<description>Builds the VSS Thread Cutter, a special forces sniper rifle. Very accurate at long range, has a fast fire rate and a large magazine capacity.</description>
+		<description>Builds the VSS Thread Cutter, a special forces sniper rifle. Very accurate at long range, has a fast fire rate and a large magazine capacity.\nCaliber: 9x39mm Soviet</description>
 		<jobString>Building VSS Thread Cutter.</jobString>
 		<workAmount>12000</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Security.xml
@@ -329,7 +329,7 @@
 			<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 		</comps>
-		<description>An AI-controlled 30mm autocannon turret automatically fires at enemies. It requires 2,200 W to function. It deals extra armor-piercing damage if the round has a direct hit. The turret explodes when heavily damaged.\nCaliber: 30x173mm</description>
+		<description>An AI-controlled 35mm autocannon turret automatically fires at enemies. It requires 2,200 W to function. It deals extra armor-piercing damage if the round has a direct hit. The turret explodes when heavily damaged.\nCaliber: 35x228mm</description>
 		<size>(3,3)</size>
 		<stuffCategories>
 			<li>Metallic</li>
@@ -677,7 +677,7 @@
       <Weight>58</Weight>
       <Bulk>60</Bulk>
     </statBases>
-    <description>A manned turret mounted with a 30mm Autocannon. It deals extra armor-piercing damage if the round has a direct hit. It uses 35mmx3 Autocannon Shells for ammo. The turret explodes when heavily damaged.</description>
+    <description>A manned turret mounted with a 30mm Autocannon. It deals extra armor-piercing damage if the round has a direct hit. Converted for 30x173mm ammo. The turret explodes when heavily damaged.</description>
     <size>(2,2)</size>
     <stuffCategories>
       <li>Metallic</li>
@@ -701,7 +701,7 @@
 
   <ThingDef ParentName="TurretMannedBase">
 	<defName>AvengerTurretGun</defName>
-	<label>35mm GAU-8 Avenger</label>
+	<label>30mm GAU-8 Avenger</label>
     <graphicData>
 	<texPath>Things/Building/Security/TurretGun_two</texPath>
     <graphicClass>Graphic_Single</graphicClass>
@@ -717,7 +717,7 @@
 		<Weight>59</Weight>
 		<Bulk>61</Bulk>
 	</statBases>
-	<description>A manned turret mounted with a GAU-8 Avenger Fire Cannon that shoots at enemies. It deals extra armor-piercing damage if the round has a direct hit. It uses 35x228mm Avenger Shells for ammo. The turret explodes when heavily damaged.</description>
+	<description>A manned turret mounted with a GAU-8 Avenger Fire Cannon that shoots at enemies. It deals extra armor-piercing damage if the round has a direct hit. It uses 30x173mm cartridge for ammo. The turret explodes when heavily damaged.</description>
 	<size>(2,2)</size>
     <stuffCategories>
       <li>Metallic</li>

--- a/Mods/Core_SK/Defs/ThingDefs_CR/Ammo_Cannons.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_CR/Ammo_Cannons.xml
@@ -36,7 +36,7 @@
   <ThingDef Class="Combat_Realism.AmmoDef" ParentName="Ammo20x102mmBase">
     <defName>Ammo_20x102mm</defName>
     <label>20x102mm cartridge</label>
-	<description>Old-school anti-tank cartridge originally designed for AT rifles, it is also used by a number of heavy machine guns.</description>
+	<description>The 20 mm caliber is a specific size of cannon and autocannon ammunition.</description>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/FMJ</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -83,7 +83,7 @@
   <ThingDef Class="Combat_Realism.AmmoDef" ParentName="Ammo30x173mmBase">
     <defName>Ammo_30x173mm</defName>
     <label>30x173mm cartridge</label>
-	<description>Old-school anti-tank cartridge originally designed for AT rifles, it is also used by a number of heavy machine guns.</description>
+	<description>The 30 mm caliber is a specific size of cannon and autocannon ammunition.</description>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/HE</texPath>
       <graphicClass>Graphic_StackCount</graphicClass>
@@ -129,7 +129,7 @@
 
   <ThingDef Class="Combat_Realism.AmmoDef" ParentName="Ammo35x228Base">
     <defName>Ammo_35x228mm</defName>
-	<description>Old-school anti-tank cartridge originally designed for AT rifles, it is also used by a number of heavy machine guns.</description>
+	<description>The 35 mm caliber is a specific size of cannon and autocannon ammunition.</description>
     <label>35x228 cartridge</label>
     <graphicData>
       <texPath>Things/Ammo/HighCaliber/Incendiary</texPath>

--- a/Mods/Core_SK/Defs/ThingDefs_CR/Projectiles_Cannons.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_CR/Projectiles_Cannons.xml
@@ -35,7 +35,7 @@
 
   <ThingDef ParentName="BaseBullet">
     <defName>Bullet_30x173mm</defName>
-    <label>30x173mm avenger shell</label>
+    <label>30x173mm bullet</label>
     <graphicData>
 		<texPath>Things/Projectile/50CalRound</texPath>
 		<graphicClass>Graphic_Single</graphicClass>
@@ -71,7 +71,7 @@
   
   <ThingDef ParentName="BaseBullet">
     <defName>Bullet_35x228mm</defName>
-    <label>35x228mm avenger shell</label>
+    <label>35x228mm bullet</label>
     <graphicData>
 		<texPath>Things/Projectile/50CalRound</texPath>
 		<graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Items/Items_Crate.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Items/Items_Crate.xml
@@ -104,7 +104,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>MinigunTurret_Crate</defName>
 <label>7.62x51mm M134 Minigun crate</label>
-<description>Use this to build a 7.62x51mm Vulcan Cannon, a type of stationary manned turret. Requires 7.62x51mm ammo.</description>
+<description>Use this to build a M134 Minigun, a type of stationary manned turret. Requires 7.62x51mm ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -262,8 +262,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>Avenger_Crate</defName>
-<label>35x228mm GAU-8 Avenger crate</label>
-<description>Use this to build a 35x228mm GAU-8 Avenger, a type of stationary manned turret. It uses 35x228mm Avenger Shells for ammo.</description>
+<label>30x173mm GAU-8 Avenger crate</label>
+<description>Use this to build a 30x173mm GAU-8 Avenger, a type of stationary manned turret. It uses 30x173mm Avenger Shells for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -289,7 +289,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>AGSturret_Crate</defName>
 <label>30mm AGS-17 crate</label>
-<description>Use this to build a AGS-17, a type of stationary manned turret. It uses 30mmx6 GL Turret Grenades for ammo.</description>
+<description>Use this to build a AGS-17, a type of stationary manned turret. It uses 30mmx6 GL turret grenades for ammo.</description>
     <graphicData> 
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -315,7 +315,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>AGCturret_Crate</defName>
 <label>30mm AGS-30 crate</label>
-<description>Use this to build AGS-30, a type of stationary manned turret. It uses 30mmx6 GL Turret Grenades for ammo.</description>
+<description>Use this to build AGS-30, a type of stationary manned turret. It uses 30mmx6 GL turret grenades for ammo.</description>
     <graphicData> 
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -341,7 +341,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>Mortar_Crate</defName>
 <label>81mm Mortar Launcher Crate</label>
-<description>Use this to build an Mortar Launcher, a type of stationary manned turret. It uses 81mm Explosive Mortar Shells for ammo.</description>
+<description>Use this to build an mortar launcher, a type of stationary manned turret. It uses 81mm explosive mortar shells for ammo.</description>
     <graphicData>  
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -367,7 +367,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>FlakTurret_Crate</defName>
 <label>90mm Flak turret crate</label>
-<description>Use this to build a 90mm Flak turret a type of stationary manned turret. It uses 90mm Cannon Shells for ammo.</description>
+<description>Use this to build a 90mm flak turret a type of stationary manned turret. It uses 90mm cannon shells for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -393,7 +393,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>CannonTurret_Crate</defName>
 <label>120mm Tank cannon crate</label>
-<description>Use this to build a 120mm Tank Cannon, a type of stationary manned turret. It uses 120mm Cannon Shells for ammo.</description>
+<description>Use this to build a 120mm tank cannon, a type of stationary manned turret. It uses 120mm cannon shells for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -419,7 +419,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>HowitzerTurret_Crate</defName>
 <label>155mm Howitzer Cannon Crate</label>
-<description>Use this to build a 155m Howitzer Cannon, a type of stationary manned turret. It uses 155mm Howitzer Shells for ammo.</description>
+<description>Use this to build a 155m howitzer cannon, a type of stationary manned turret. It uses 155mm howitzer shells for ammo.</description>
     <graphicData>  
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -447,7 +447,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>TOW_Crate</defName>
 <label>AT missile BGM-71 TOW crate</label>
-<description>Use this to build a Light Missile System BGM-71 TOW, a type of stationary manned turret. It uses AT missiles for ammo.</description>
+<description>Use this to build a light missile system BGM-71 TOW, a type of stationary manned turret. It uses AT missiles for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -473,7 +473,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>LightMissileSystem_Crate</defName>
 <label>AT missile FGM-148 Javelin Crate</label>
-<description>Use this to build a Light Missile System FGM-148 Javelin, a type of stationary manned turret. It uses AT missile for ammo.</description>
+<description>Use this to build a light missile system FGM-148 Javelin, a type of stationary manned turret. It uses AT missile for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -499,7 +499,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>MediumMissileSystem_Crate</defName>
 <label>130mm Medium Missile System crate</label>
-<description>Use this to build a Medium Missile System, a type of stationary manned turret. It uses 130mmx2 Missiles for ammo.</description>
+<description>Use this to build a medium missile system, a type of stationary manned turret. It uses 130mmx2 Missiles for ammo.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -525,7 +525,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>RocketLauncher_Crate</defName>
 <label>130mm Heavy Missile System crate</label>
-<description>Use this to build a Heavy Missile System, a type of stationary manned turret. It uses 130mmx3 missiles for ammo.</description>
+<description>Use this to build a heavy missile system, a type of stationary manned turret. It uses 130mmx3 missiles for ammo.</description>
     <graphicData>   
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -553,8 +553,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>SentryTurret_Crate</defName>
-<label>.40Rimfire Sentry light crate</label>
-<description>Use this to build an Automated Sentry light turret, a type of stationary automatic turret. It requires power to function.</description>
+<label>.40 Rimfire Sentry light crate</label>
+<description>Use this to build a sentry light turret, a type of stationary automatic turret. It requires power to function.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -580,8 +580,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>HeavyTurret_Crate</defName>
-<label>145x114mm Sentry heavy crate</label>
-<description>Use this to build a Laser Turret, a type of unmanned automatic turret.</description>
+<label>14.5x114mm Sentry heavy crate</label>
+<description>Use this to build a sentry heavy turret, a type of unmanned automatic turret. Requires power to function.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>
@@ -607,8 +607,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>NavalGunTurret_Crate</defName>
-<label>30x173mm Sentry naval crate</label>
-<description>Use this to build Sentry naval turret, a type of stationary unmanned turret.</description>
+<label>35mm Sentry naval crate</label>
+<description>Use this to build 35mm sentry naval turret, a type of stationary unmanned turret. Requires power to function.</description>
 <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>  
@@ -634,7 +634,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>SentryRocketLauncher_Crate</defName>
 <label>AT missile Sentry rocket launcher crate</label>
-<description>Use this to build an Sentry rocket launcher, a type of stationary unmanned turret.</description>
+<description>Use this to build a sentry rocket launcher, a type of stationary unmanned turret. Requires power to function.</description>
     <graphicData> 
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>  
@@ -659,8 +659,8 @@
 
 <ThingDef ParentName="CrateBase">
 <defName>SentryBlasterTurret_Crate</defName>
-<label>6x24mm Sentry blaster crate</label>
-<description>Use this to build a sentry blaster turret crate, a type of automatic turrets. Requires power to function but does not need ammo.</description>
+<label>Sentry blaster crate</label>
+<description>Use this to build a sentry blaster turret, a type of automatic turrets. Requires power to function.</description>
     <graphicData> 
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>  
@@ -686,7 +686,7 @@
 <ThingDef ParentName="CrateBase">
 <defName>LaserTurret_Crate</defName>
 <label>Laser Turret Crate</label>
-<description>Use this to build a Laser Turret, a type of unmanned automatic turret. It requires power to function.</description>
+<description>Use this to build a laser turret, a type of unmanned automatic turret. It requires power to function.</description>
     <graphicData>
 <texPath>Things/Item/Resource/WeaponCrate</texPath>
 <graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
@@ -225,7 +225,7 @@
 	<ThingDef ParentName="BaseGunCR">
 		<defName>Gun_HHMG</defName>
 		<label>M249 LMG SAW MG</label>
-		<description>M249 hand machinegun.</description>
+		<description>M249 LMG SAW MG, a heavy machinegun. It has a 120 round magazine and fires in 20 round bursts. Not very accurate but good at providing suppressing fire.</description>
     <graphicData>
 		<texPath>Things/Weapons/MHMG</texPath>
 		<graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Pistols.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Pistols.xml
@@ -440,8 +440,8 @@
 
 	<ThingDef ParentName="BaseGunCR">
 		<defName>Gun_DesertEagle</defName>
-		<label>Desert Eagle .45 ACP</label>
-		<description>The legendary desert eagle .50 ACP. Marines favorite toy.</description>
+		<label>Desert Eagle .50 AE</label>
+		<description>The legendary desert eagle .50 AE. Marines favorite toy.</description>
     <graphicData>
 		<texPath>Things/Weapons/DesertEagle</texPath>
 		<graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
@@ -304,7 +304,7 @@
 			<recoilAmount>0.65</recoilAmount>
 			<verbClass>Combat_Realism.Verb_ShootCR</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<projectileDef>Bullet_545x39mmR_FMJ</projectileDef>
+			<projectileDef>Bullet_556x45mmNATO_FMJ</projectileDef>
 			<warmupTicks>66</warmupTicks>
 			<range>45</range>
 			<burstShotCount>10</burstShotCount>
@@ -324,7 +324,7 @@
 		  <li Class="Combat_Realism.CompProperties_AmmoUser">
 			<magazineSize>30</magazineSize>
 			<reloadTicks>220</reloadTicks>
-			<ammoSet>AmmoSet_545x39mmR</ammoSet>
+			<ammoSet>AmmoSet_556x45mmNATO</ammoSet>
 		  </li>
 		</comps>
     <smeltProducts>
@@ -572,7 +572,7 @@
 			<recoilAmount>0.85</recoilAmount>
 			<verbClass>Combat_Realism.Verb_ShootCR</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<projectileDef>Bullet_762x39mmSoviet_FMJ</projectileDef>
+			<projectileDef>Bullet_762x51mmNATO_FMJ</projectileDef>
 			<warmupTicks>70</warmupTicks>
 			<range>54</range>
 			<burstShotCount>5</burstShotCount>
@@ -592,7 +592,7 @@
 		  <li Class="Combat_Realism.CompProperties_AmmoUser">
 			<magazineSize>20</magazineSize>
 			<reloadTicks>230</reloadTicks>
-			<ammoSet>AmmoSet_762x39mmSoviet</ammoSet>
+			<ammoSet>AmmoSet_762x51mmNATO</ammoSet>
 		  </li>
 		</comps>
     <smeltProducts>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SniperRifles.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SniperRifles.xml
@@ -195,7 +195,7 @@
 	<ThingDef ParentName="BaseGunCR">
 		<defName>Gun_M42A_USCM</defName>
 		<label>M42A Scope Rifle</label>
-		<description>The M42A Scope Rifle is an American-made semi-automatic sniper rifle chambered for 10mm M252 HEAP ammunition. It is employed as the primary sniper weapon of the United States Colonial Marine Corps.</description>
+		<description>The M42A Scope Rifle is an American-made semi-automatic sniper rifle chambered for 7.62x51mm NATO ammunition. It is employed as the primary sniper weapon of the United States Colonial Marine Corps.</description>
 		<graphicData>
 			<texPath>Things/Weapons/M42A</texPath>
 			<graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SniperRiflesAdvanced.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SniperRiflesAdvanced.xml
@@ -386,7 +386,7 @@
       <li Class="Combat_Realism.VerbPropertiesCR">
         <verbClass>Combat_Realism.Verb_ShootCR</verbClass>
         <hasStandardCommand>true</hasStandardCommand>
-        <projectileDef>Bullet_145x114mm_FMJ</projectileDef>
+        <projectileDef>Bullet_50BMG_FMJ</projectileDef>
         <warmupTicks>120</warmupTicks>
         <range>70</range>
         <soundCast>ShotM82</soundCast>
@@ -403,7 +403,7 @@
 		  <li Class="Combat_Realism.CompProperties_AmmoUser">
 			<magazineSize>5</magazineSize>
 			<reloadTicks>310</reloadTicks>
-			<ammoSet>AmmoSet_145x114mm</ammoSet>
+			<ammoSet>AmmoSet_50BMG</ammoSet>
 		  </li>
     </comps>
     <smeltProducts>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Machineguns.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Machineguns.xml
@@ -245,8 +245,8 @@
 
   <ThingDef ParentName="BaseTurretGun">
 		<defName>Gun_Avenger</defName>
-		<label>35x228mm Avenger Fire Cannon</label>
-		<description>35mm Avenger fire cannon attached to a turret base.</description>
+		<label>30x173mm Avenger Fire Cannon</label>
+		<description>30mm Avenger fire cannon attached to a turret base.</description>
 		<graphicData>
 			<texPath>Things/Building/Security/AvengerTurretGun_Top</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -264,7 +264,7 @@
 			<recoilAmount>0.82</recoilAmount>
 			<verbClass>Combat_Realism.Verb_ShootCR</verbClass>
 			<hasStandardCommand>true</hasStandardCommand>
-			<projectileDef>Bullet_35x228mm</projectileDef>
+			<projectileDef>Bullet_30x173mm</projectileDef>
 			<range>85</range>
             <minRange>8</minRange>
 			<warmupTicks>180</warmupTicks>
@@ -279,7 +279,7 @@
 				<magazineSize>56</magazineSize>
 				<reloadTicks>600</reloadTicks>
 				<spawnUnloaded>true</spawnUnloaded>
-				<ammoSet>AmmoSet_35x228mm</ammoSet>
+				<ammoSet>AmmoSet_30x173mm</ammoSet>
 			</li>
 			<li Class="Combat_Realism.CompProperties_FireModes">
 			</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Sentry.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Sentry.xml
@@ -231,7 +231,7 @@
 				<recoilAmount>0.91</recoilAmount>
 				<verbClass>Combat_Realism.Verb_ShootCR</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
-				<projectileDef>Bullet_30x173mm</projectileDef>
+				<projectileDef>Bullet_35x228mm</projectileDef>
 				<range>75</range>
                 <minRange>8</minRange>
 				<forcedMissRadius>2</forcedMissRadius>
@@ -248,7 +248,7 @@
 				<magazineSize>60</magazineSize>
 				<reloadTicks>800</reloadTicks>
 				<spawnUnloaded>true</spawnUnloaded>
-				<ammoSet>AmmoSet_30x173mm</ammoSet>
+				<ammoSet>AmmoSet_35x228mm</ammoSet>
 			</li>
 			<li Class="Combat_Realism.CompProperties_FireModes">
 				<aiUseAimMode>TRUE</aiUseAimMode>


### PR DESCRIPTION
- various description fixes
- "Sentry naval cannon" now uses 35mm instead 30mm
- "GAU-8" now uses 30mm instead 35mm
- "Barret M82A1" now uses .50BMG instead 14.5mm
- "FN SCAR-H" now uses 7.62x51mm NATO instead 7.62x39mm Soviet
- "Tavor TAR-21" now uses 5.56x45mm NATO instead 5.45x39mm Russian
- added caliber info for most guns
- #306 & #305 

___
X_x
