### PR TITLE
Fueled buildings cleanup

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Power_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Power_SK.xml
@@ -505,8 +505,8 @@
 			<WorkToMake>3800</WorkToMake>
 			<Flammability>1.0</Flammability>
 		</statBases>
-		<description>The basic Steam Generator that produces electricity. Can be fueled with Ethanol Fuel, Charcoal, Coal, Kindling and wooden stuff.
-Power output: 750 W.</description>
+		<description>The basic Steam Generator that produces electricity. Can be fueled with Ethanol Fuel, Charcoal, Kindling and wooden stuff.
+Power output: around 750 W.</description>
 		<size>(2,2)</size>
 		<building>
 			<ignoreNeedsPower>true</ignoreNeedsPower>
@@ -546,7 +546,6 @@ Power output: 750 W.</description>
 						<li>EthanolFuel</li>
 						<li>Kindling</li>
 						<li>Charcoal</li>
-						<li>Coal</li>
 					</thingDefs>
 					<categories>
 					  <li>Wooden</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Power_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Power_SK.xml
@@ -505,7 +505,7 @@
 			<WorkToMake>3800</WorkToMake>
 			<Flammability>1.0</Flammability>
 		</statBases>
-		<description>The Steam Generator produces electricity. Requires a hopper filled with Ethanol Fuel or Kindling for a fuel source.
+		<description>The basic Steam Generator that produces electricity. Can be fueled with Ethanol Fuel, Charcoal, Coal, Kindling and wooden stuff.
 Power output: 750 W.</description>
 		<size>(2,2)</size>
 		<building>
@@ -546,6 +546,7 @@ Power output: 750 W.</description>
 						<li>EthanolFuel</li>
 						<li>Kindling</li>
 						<li>Charcoal</li>
+						<li>Coal</li>
 					</thingDefs>
 					<categories>
 					  <li>Wooden</li>
@@ -719,7 +720,7 @@ Power output: 1000 W.</description>
       <Flammability>1.0</Flammability>
       <Beauty>-60</Beauty>
     </statBases>
-		<description>The Coal Power Plant produces electricity by burning coal-like fuels. Requires a hopper filled with Coal Ore, Charcoal or Peat.
+		<description>The Coal Power Plant that produces electricity by burning coal-like fuels. Can be fueled with Coal Ore or Peat.
 Power output: 2,000 W.</description>
 		<size>(2,3)</size>
 		<building>
@@ -791,7 +792,7 @@ Power output: 2,000 W.</description>
       <Beauty>-60</Beauty>
     </statBases>
 		<tickerType>Normal</tickerType>
-		<description>A Fuel Power Plant that produces electricity. Requires a hopper filled with Fuel.
+		<description>A Fuel Power Plant that produces electricity. Can be fueled with Fuel, Prometheum or FSX.
 Power output: 3,500 W.</description>
 		<size>(3,2)</size>
 		<building>
@@ -1428,7 +1429,7 @@ Power output: 2,500 W.</description>
       <Flammability>1.0</Flammability>
       <Beauty>-10</Beauty>
     </statBases>
-    <Description>Produces tax-free electricity from a steam geyser. Must be placed on a steam geyser. A Plasma Generator can be linked to absorb plasma discharges. Use for work Tin or Aluminium.</Description>
+    <Description>Produces tax-free electricity from a steam geyser. Must be placed on a steam geyser. A Plasma Generator can be linked to absorb plasma discharges. Requires to be fueled by Tin or Aluminium.</Description>
     <Size>(4,4)</Size>
 		<stuffCategories>
 		<li>Metallic</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -1736,7 +1736,7 @@
 	<ThingDef ParentName="WorkTableFueled">
     <DefName>FueledSmithy</DefName>
     <label>Fueled Smithy</label>
-    <Description>A wood-fueled station equipped for smithing non-mechanical weapons and tools. (Can be fueled by Coal or Peat)</Description>
+    <Description>A fueled station equipped for smithing non-mechanical weapons and tools. (Can be fueled by Coal or Peat)</Description>
     <graphicData>
 		<texPath>Things/Building/Production/BYF</texPath>
 		<graphicClass>Graphic_Multi</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -54,7 +54,7 @@
 	<ThingDef ParentName="WorkTableFueled">
 		<DefName>TableGrill</DefName>
 		<label>Simple Grill</label>
-		<Description>A small grill used to cook meat into simple jerky or roasts. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</Description>
+		<Description>A small grill used to cook meat into simple jerky or roasts. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.</Description>
 		<graphicData>
 			<texPath>Things/Building/Production/TableGrill1x1</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -264,7 +264,7 @@
 	<ThingDef ParentName="WorkTableFueled">
     <defName>FueledStove</defName>
     <label>Fueled Stove</label>
-    <Description>A simple wood-fueled stove with an attached countertop for preparing meals. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</Description>
+    <Description>A simple wood-fueled stove with an attached countertop for preparing meals. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.</Description>
     <graphicData>
       <texPath>Things/Building/Production/TableStoveFueled</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -351,7 +351,7 @@
   <ThingDef ParentName="WorkTableFueled">
 		<defName>TableOven</defName>
 		<label>Oven</label>
-		<Description>A fueled oven for baking candies and tasty treats. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</Description>
+		<Description>A fueled oven for baking candies and tasty treats. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.</Description>
 		<graphicData>
 		  <texPath>Things/Building/Production/Tableoven</texPath>
 		  <graphicClass>Graphic_Multi</graphicClass>
@@ -644,7 +644,7 @@
 	<ThingDef ParentName="WorkTableFueled">
     <DefName>Brewery</DefName>
     <label>Brewery</label>
-    <Description>A work station with all the equipment needed to brew beer. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</Description>
+    <Description>A work station with all the equipment needed to brew beer. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.</Description>
     <graphicData>
       <texPath>Things/Building/Production/TableBrewer/TableBrewerNeolithic</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -977,7 +977,7 @@
 	<ThingDef ParentName="WorkTableFueled">
 		<defName>TableFurnace</defName>
 		<label>Furnace</label>
-		<Description>A furnace used for smelting basic metal ores into metal alloys. Can make metal cans and produce charcoal from logs. (Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</Description>
+		<Description>A furnace used for smelting basic metal ores into metal alloys. Can make metal cans and produce charcoal from logs. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.</Description>
     <graphicData>
 		<texPath>Things/Building/Production/Furnace</texPath>
 		<graphicClass>Graphic_Multi</graphicClass>
@@ -1063,7 +1063,7 @@
 	<ThingDef ParentName="WorkTableFueled">
 		<defName>Kiln</defName>
 		<label>Kiln</label>
-		<description>An impovised kiln used to produce clay briks, burning apparel and used as crematorium. (Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</description>
+		<description>An impovised kiln used to produce clay bricks, burning apparel and used as crematorium. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.</description>
 	<graphicData>
 		<texPath>Things/Building/Production/Kiln</texPath>
 		<graphicClass>Graphic_Multi</graphicClass>
@@ -1736,7 +1736,7 @@
 	<ThingDef ParentName="WorkTableFueled">
     <DefName>FueledSmithy</DefName>
     <label>Fueled Smithy</label>
-    <Description>A fueled station equipped for smithing non-mechanical weapons and tools. (Can be fueled by Coal or Peat)</Description>
+    <Description>A fueled station equipped for smithing non-mechanical weapons and tools. Can be fueled by Coal or Peat.</Description>
     <graphicData>
 		<texPath>Things/Building/Production/BYF</texPath>
 		<graphicClass>Graphic_Multi</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -54,7 +54,7 @@
 	<ThingDef ParentName="WorkTableFueled">
 		<DefName>TableGrill</DefName>
 		<label>Simple Grill</label>
-		<Description>A small grill used to cook meat into simple jerky or roasts. (Can be fueled by Kindling)</Description>
+		<Description>A small grill used to cook meat into simple jerky or roasts. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</Description>
 		<graphicData>
 			<texPath>Things/Building/Production/TableGrill1x1</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -106,6 +106,7 @@
 				<fuelFilter>
 				  <thingDefs>
 					<li>Charcoal</li>
+					<li>Coal</li>
 					<li>Kindling</li>
 				  </thingDefs>
 					<categories>
@@ -263,7 +264,7 @@
 	<ThingDef ParentName="WorkTableFueled">
     <defName>FueledStove</defName>
     <label>Fueled Stove</label>
-    <Description>A simple wood-fueled stove with an attached countertop for preparing meals. (Can be fueled by Kindling, Coal or Charcoal)</Description>
+    <Description>A simple wood-fueled stove with an attached countertop for preparing meals. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</Description>
     <graphicData>
       <texPath>Things/Building/Production/TableStoveFueled</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -331,6 +332,7 @@
 				<fuelFilter>
 				  <thingDefs>
 					<li>Charcoal</li>
+					<li>Coal</li>
 					<li>Kindling</li>
 				  </thingDefs>
 					<categories>
@@ -349,7 +351,7 @@
   <ThingDef ParentName="WorkTableFueled">
 		<defName>TableOven</defName>
 		<label>Oven</label>
-		<Description>A fueled oven for baking candies and tasty treats. Requires kindking, coal or charcoal.</Description>
+		<Description>A fueled oven for baking candies and tasty treats. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</Description>
 		<graphicData>
 		  <texPath>Things/Building/Production/Tableoven</texPath>
 		  <graphicClass>Graphic_Multi</graphicClass>
@@ -642,7 +644,7 @@
 	<ThingDef ParentName="WorkTableFueled">
     <DefName>Brewery</DefName>
     <label>Brewery</label>
-    <Description>A work station with all the equipment needed to brew beer.  (Can be fueled by Kindling, Coal or Charcoal)</Description>
+    <Description>A work station with all the equipment needed to brew beer. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.)</Description>
     <graphicData>
       <texPath>Things/Building/Production/TableBrewer/TableBrewerNeolithic</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
@@ -693,6 +695,7 @@
 				<fuelFilter>
 				  <thingDefs>
 					<li>Charcoal</li>
+					<li>Coal</li>
 					<li>Kindling</li>
 				  </thingDefs>
 					<categories>
@@ -1733,7 +1736,7 @@
 	<ThingDef ParentName="WorkTableFueled">
     <DefName>FueledSmithy</DefName>
     <label>Fueled Smithy</label>
-    <Description>A wood-fueled station equipped for smithing non-mechanical weapons and tools. (Can be fueled by Coal, Charcoal or Peat)</Description>
+    <Description>A wood-fueled station equipped for smithing non-mechanical weapons and tools. (Can be fueled by Coal or Peat)</Description>
     <graphicData>
 		<texPath>Things/Building/Production/BYF</texPath>
 		<graphicClass>Graphic_Multi</graphicClass>
@@ -1787,12 +1790,8 @@
 				<fuelFilter>
 				  <thingDefs>
 					<li>Coal</li>
-					<li>Charcoal</li>
 					<li>Peat</li>
 				  </thingDefs>
-					<categories>
-					  <li>Wooden</li>
-					</categories>  
 				</fuelFilter>
 			</li>
     </comps>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
@@ -22,7 +22,7 @@
 	<ThingDef ParentName="WorkTableFueled">
     <defName>Campfire</defName>
     <label>Campfire</label>
-    <description>A camfire can cook meals and produce heat but it will burn out after a few days. As with all heat sources, it must be placed indoors so it has a closed space to heat.</description>    
+    <description>A campfire that can cook meals and produce heat, but it will burn out after a few days. As with all heat sources, it must be placed indoors so it has a closed space to heat.</description>    
     <graphicData>
       <texPath>Things/Building/Misc/Campfire</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -76,8 +76,9 @@
 				<effectOnWeather>true</effectOnWeather>				
 				<fuelFilter>
 				  <thingDefs>
-					<li>Charcoal</li>
-					<li>Kindling</li>
+						<li>Charcoal</li>
+						<li>Coal</li>
+						<li>Kindling</li>
 				  </thingDefs>
 					<categories>
 					  <li>Wooden</li>
@@ -122,7 +123,7 @@
 			<Flammability>0</Flammability>
 		</statBases>
 		<tickerType>Normal</tickerType>
-		<description>A burner produces only heat by burning basic coal-like fuel sources.h coal, charcoal, kindling or peat in order to function.</description>
+		<description>A fueled burner that produces heat by burning basic fuel sources. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.</description>
 		<size>(2,2)</size>
 		<building>
 			<ignoreNeedsPower>true</ignoreNeedsPower>
@@ -150,10 +151,10 @@
 				<effectOnWeather>true</effectOnWeather>
 				<fuelFilter>
 				  <thingDefs>
-					<li>Coal</li>
-					<li>Charcoal</li>
-					<li>Peat</li>
-					<li>Kindling</li>
+						<li>Coal</li>
+						<li>Charcoal</li>
+						<li>Peat</li>
+						<li>Kindling</li>
 				  </thingDefs>
 					<categories>
 					  <li>Wooden</li>


### PR DESCRIPTION
1) Fueled smithy now only can be fueled by coal or peat -- other fuels
could not give enough heat anyway
2) Whenever charcoal was accepted, coal is now accepted too
3) More uniform fueling requirements in description.