### PR TITLE
Glowstone fix attempt#1: no depletion

### DIFF
--- a/Mods/Core_SK/Defs/QuarryResourceDefs/QuarryResources_QRY.xml
+++ b/Mods/Core_SK/Defs/QuarryResourceDefs/QuarryResources_QRY.xml
@@ -199,7 +199,7 @@
 			<li>
 				<ThingDef>Glowstone</ThingDef>
 				<Probability>4</Probability>
-				<StackCount>3</StackCount>
+				<StackCount>2</StackCount>
 			</li>
 			<li>
 				<ThingDef>Glowstone</ThingDef>

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Furniture.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Furniture.xml
@@ -5,6 +5,20 @@
 
 
   <ResearchProjectDef>
+    <defName>SK_Glowstone</defName>
+    <label>Glowstone lamps</label>
+    <description>Discover how to build beautiful lamps with the glowstones.</description>
+    <baseCost>350</baseCost>
+    <techLevel>Medieval</techLevel>
+		<prerequisites>
+			<li>SK_Craftsmanship</li>
+		</prerequisites>
+  </ResearchProjectDef>
+	<!-- 
+	GlowstoneLamp
+	-->
+
+  <ResearchProjectDef>
     <defName>SK_DiningRoomI</defName>
     <label>Dining room furniture I</label>
     <description>It opens the possibility of building some new furniture for dining room, such as Long Table and Stool.</description>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -1284,7 +1284,7 @@
 		</stuffCategories>
 		<costStuffCount>25</costStuffCount>
 		<CostList>
-		  <Glowstone>15</Glowstone>
+		  <Glowstone>12</Glowstone>
       <SilverBar>25</SilverBar>
 		</CostList>
 		<statBases>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -1267,7 +1267,7 @@
 	<ThingDef ParentName="AccessoriesBase" >
 		<defName>GlowstoneLamp</defName>
 		<label>Glowstone Lamp</label>
-		<description>A lamp supporting two large glowstones. Consuming glowstones.</description>
+		<description>A beautiful lamp topped with polished silver, emitting reflected light from dozen of glowstones. Free source of light.</description>
 		<graphicData>
 			<texPath>Things/Building/Lamps/GlowstoneLamp</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -1276,37 +1276,28 @@
 		</graphicData>
 		<fillPercent>0</fillPercent>
 		<leaveResourcesWhenKilled>false</leaveResourcesWhenKilled>
-		<resourcesFractionWhenDeconstructed>0</resourcesFractionWhenDeconstructed>
 		<rotatable>false</rotatable>
 		<pathCost>60</pathCost>
 		<stuffCategories>
 			<li>Woody</li>
 			<li>Metallic</li>
 		</stuffCategories>
-		<costStuffCount>15</costStuffCount>
+		<costStuffCount>25</costStuffCount>
 		<CostList>
-		<Glowstone>5</Glowstone>
+		  <Glowstone>15</Glowstone>
+      <SilverBar>25</SilverBar>
 		</CostList>
 		<statBases>
-			<Beauty>7</Beauty>
-			<WorkToMake>200</WorkToMake>
+			<Beauty>9</Beauty>
+			<WorkToMake>400</WorkToMake>
 		</statBases>
     <comps>
-      <li Class="CompProperties_Refuelable">
-        <fuelConsumptionRate>0.5</fuelConsumptionRate>
-        <fuelCapacity>5.0</fuelCapacity>
-        <fuelFilter>
-          <thingDefs>
-            <li>Glowstone</li>
-          </thingDefs>
-        </fuelFilter>
-        <destroyOnNoFuel>false</destroyOnNoFuel>
-      </li>
-    <li Class="CompProperties_Glower">
+      <li Class="CompProperties_Glower">
         <glowRadius>8</glowRadius>
         <glowColor>(220,237,255,0)</glowColor>
       </li>
     </comps>
+    <researchPrerequisites><li>SK_GlowstoneLamp</li></researchPrerequisites>
 	</ThingDef>
   
   <!--======================================OutdoorLights======================================-->


### PR DESCRIPTION
An attempt to fix #364 
My take: 

1) Glowstone lamp now requires an appropriate tech researched.
2) Requires ~3x more resources
3) Doesn't deplete
And nerfed a bit glowstones from quarry