### PR TITLE
Fixed 9x39 ammo firing wrong projectiles

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_CR/Ammo.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_CR/Ammo.xml
@@ -181,7 +181,7 @@
     <statBases>
       <MarketValue>1.5</MarketValue>
     </statBases>
-	<linkedProjectile>Bullet_9x39Soviet</linkedProjectile>
+	<linkedProjectile>Bullet_9x39Soviet_FMJ</linkedProjectile>
 	<ammoClass>FullMetalJacket</ammoClass>
   </ThingDef>
 
@@ -196,7 +196,7 @@
     <statBases>
       <MarketValue>2.5</MarketValue>
     </statBases>
-	<linkedProjectile>Bullet_545x39mmR_HP</linkedProjectile>
+	<linkedProjectile>Bullet_9x39Soviet_SH</linkedProjectile>
 	<ammoClass>Shock</ammoClass>
   </ThingDef>
   


### PR DESCRIPTION
Fixed 9x39 ammo firing wrong projectiles, 4 files simultaneous change: Ammo.xml, Projectiles.xml, Weapons_SniperRifles.xml, Projectiles_SK.xml.
Ammo.xml changes:
"Ammo_9x39Soviet_FMJ" linked projectile changed to "Bullet_9x39Soviet_FMJ" (was: "Bullet_9x39Soviet")
"Ammo_9x39Soviet_SH" linked projectile changed to "Bullet_9x39Soviet_SH" (was: "Bullet_545x39mmR_HP")