### PR TITLE
Fix for Melee cooldown/Freeze

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Arid.xml
@@ -2,7 +2,7 @@
 <Defs>
   
   <!-- ========================== Arid ============================ -->
-  
+
   <ThingDef ParentName="AnimalThingBase">
     <defName>Muffalo</defName>
     <label>Muffalo</label>
@@ -18,7 +18,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.35</defaultCooldownTime>
         <meleeDamageBaseAmount>9</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
@@ -187,14 +187,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>6</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>6</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
@@ -311,21 +311,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>110</defaultCooldownTime>
+        <defaultCooldownTime>2.0</defaultCooldownTime>
         <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -481,7 +481,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>140</defaultCooldownTime>
+        <defaultCooldownTime>2.6</defaultCooldownTime>
         <meleeDamageBaseAmount>16</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
@@ -496,7 +496,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>140</defaultCooldownTime>
+        <defaultCooldownTime>2.6</defaultCooldownTime>
         <meleeDamageBaseAmount>18</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
@@ -649,14 +649,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.35</defaultCooldownTime>
         <meleeDamageBaseAmount>6</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.35</defaultCooldownTime>
         <meleeDamageBaseAmount>6</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
@@ -792,7 +792,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.35</defaultCooldownTime>
         <meleeDamageBaseAmount>9</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
@@ -967,7 +967,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.35</defaultCooldownTime>
         <meleeDamageBaseAmount>6</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
@@ -1119,14 +1119,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.35</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.35</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Bears.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Bears.xml
@@ -11,7 +11,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>17</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -26,7 +26,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>17</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -41,7 +41,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -260,21 +260,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>6</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>6</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_BigCats.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_BigCats.xml
@@ -3,7 +3,6 @@
   
     <!-- ========================== BigCats ============================ -->
   
-  
   <ThingDef ParentName="AnimalThingBase" Name="BigCatThingBase" Abstract="True">
     <statBases>
 	  <Mass>110</Mass>
@@ -15,7 +14,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -30,7 +29,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -45,7 +44,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>110</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>19</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -269,7 +268,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -284,7 +283,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -299,7 +298,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>110</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -425,21 +424,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -609,21 +608,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -774,21 +773,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -1004,21 +1003,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Bugs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Bugs.xml
@@ -21,7 +21,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -134,7 +134,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -258,7 +258,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -370,7 +370,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>1</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Cats.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Cats.xml
@@ -13,7 +13,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -28,7 +28,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -43,7 +43,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>4</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Cold.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Cold.xml
@@ -16,7 +16,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.25</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
@@ -149,7 +149,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>16</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -273,7 +273,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>16</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Dogs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Dogs.xml
@@ -13,21 +13,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.5</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.5</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -103,21 +103,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -309,21 +309,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.5</defaultCooldownTime>
         <meleeDamageBaseAmount>8</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.5</defaultCooldownTime>
         <meleeDamageBaseAmount>8</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -421,21 +421,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -541,21 +541,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>7</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>7</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
@@ -18,7 +18,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Beak</linkedBodyPartsGroup>
@@ -154,7 +154,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>6</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -328,7 +328,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>2.4</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -502,14 +502,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>2.4</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>2.4</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Fluffy.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Fluffy.xml
@@ -32,7 +32,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.5</defaultCooldownTime>
         <meleeDamageBaseAmount>17</meleeDamageBaseAmount>
         <meleeDamageDef>Flame</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -47,7 +47,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.5</defaultCooldownTime>
         <meleeDamageBaseAmount>17</meleeDamageBaseAmount>
         <meleeDamageDef>Flame</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -62,7 +62,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>28</meleeDamageBaseAmount>
         <meleeDamageDef>Flame</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -203,7 +203,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Frostbite</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -218,7 +218,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Frostbite</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -233,7 +233,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>22</meleeDamageBaseAmount>
         <meleeDamageDef>Frostbite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Foxes.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Foxes.xml
@@ -13,7 +13,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>7</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -28,7 +28,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>7</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -43,7 +43,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>130</defaultCooldownTime>
+        <defaultCooldownTime>2.4</defaultCooldownTime>
         <meleeDamageBaseAmount>8</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Giants.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Giants.xml
@@ -18,7 +18,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>240</defaultCooldownTime>
+        <defaultCooldownTime>4.15</defaultCooldownTime>
         <meleeDamageBaseAmount>24</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
@@ -177,14 +177,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>140</defaultCooldownTime>
+        <defaultCooldownTime>2.55</defaultCooldownTime>
         <meleeDamageBaseAmount>22</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>140</defaultCooldownTime>
+        <defaultCooldownTime>2.55</defaultCooldownTime>
         <meleeDamageBaseAmount>22</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -328,7 +328,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>110</defaultCooldownTime>
+        <defaultCooldownTime>2.0</defaultCooldownTime>
         <meleeDamageBaseAmount>22</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Hares.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Hares.xml
@@ -14,7 +14,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Insects.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Insects.xml
@@ -37,7 +37,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>110</defaultCooldownTime>
+        <defaultCooldownTime>2.0</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -159,7 +159,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>115</defaultCooldownTime>
+        <defaultCooldownTime>2.15</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
@@ -276,7 +276,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>110</defaultCooldownTime>
+        <defaultCooldownTime>2.0</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>HeadClaw</linkedBodyPartsGroup>
@@ -405,7 +405,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -525,7 +525,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -646,7 +646,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>16</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Rodentlike.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Rodentlike.xml
@@ -18,21 +18,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>1</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>1</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -166,21 +166,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>4</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -315,21 +315,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>4</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -469,21 +469,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>4</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -614,21 +614,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>4</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -715,21 +715,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -859,21 +859,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>1</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>1</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -18,14 +18,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>2.25</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>2.25</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
@@ -175,14 +175,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>7</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>7</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
@@ -337,14 +337,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>2.25</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>2.25</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
@@ -500,14 +500,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>110</defaultCooldownTime>
+        <defaultCooldownTime>2.0</defaultCooldownTime>
         <meleeDamageBaseAmount>8</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftLeg</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>110</defaultCooldownTime>
+        <defaultCooldownTime>2.0</defaultCooldownTime>
         <meleeDamageBaseAmount>8</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightLeg</linkedBodyPartsGroup>
@@ -638,7 +638,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>140</defaultCooldownTime>
+        <defaultCooldownTime>2.55</defaultCooldownTime>
         <meleeDamageBaseAmount>8</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
@@ -779,7 +779,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.25</defaultCooldownTime>
         <meleeDamageBaseAmount>4</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>TurtleBeakAttackTool</linkedBodyPartsGroup>
@@ -922,21 +922,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>3</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>2</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_TradePacks.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_TradePacks.xml
@@ -19,7 +19,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>180</defaultCooldownTime>
+        <defaultCooldownTime>3.15</defaultCooldownTime>
         <meleeDamageBaseAmount>18</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -18,7 +18,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -170,14 +170,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>4</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.45</defaultCooldownTime>
         <meleeDamageBaseAmount>4</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -309,7 +309,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>9</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
@@ -451,21 +451,21 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftClaws</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>11</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightClaws</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>18</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_WildCanines.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_WildCanines.xml
@@ -20,7 +20,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -35,7 +35,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -50,7 +50,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>16</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -213,7 +213,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>16</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -227,7 +227,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
        </surpriseAttack></li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -242,7 +242,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -424,7 +424,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>LeftLegClaws</linkedBodyPartsGroup>
@@ -439,7 +439,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>RightLegClaws</linkedBodyPartsGroup>
@@ -454,7 +454,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -469,7 +469,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -484,7 +484,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>20</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -658,7 +658,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>20</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -673,7 +673,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>20</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -688,7 +688,7 @@ The rim is a violent place and the dead are a common sight. But over the years, 
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>25</meleeDamageBaseAmount>
         <meleeDamageDef>Frostbite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Wolfs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Wolfs.xml
@@ -16,7 +16,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>9</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
@@ -31,7 +31,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>9</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
@@ -46,7 +46,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>130</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
         <meleeDamageDef>Bite</meleeDamageDef>
         <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Event.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Event.xml
@@ -24,7 +24,7 @@
 		<verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
@@ -82,7 +82,7 @@
 		<verbs>
 		  <li>
 			<verbClass>Verb_MeleeAttack</verbClass>
-			<defaultCooldownTime>100</defaultCooldownTime>
+			<defaultCooldownTime>1.85</defaultCooldownTime>
 			<meleeDamageBaseAmount>25</meleeDamageBaseAmount>
 			<meleeDamageDef>Frostbite</meleeDamageDef>
 			<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
@@ -240,14 +240,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>5</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -297,14 +297,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -345,14 +345,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -433,7 +433,7 @@
         <verbs>
             <li>
                 <verbClass>Verb_MeleeAttack</verbClass>
-                <defaultCooldownTime>80</defaultCooldownTime>
+                <defaultCooldownTime>1.48</defaultCooldownTime>
                 <meleeDamageBaseAmount>15</meleeDamageBaseAmount>
                 <meleeDamageDef>Bite</meleeDamageDef>
                 <linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -448,21 +448,21 @@
             </li>
             <li>
                 <verbClass>Verb_MeleeAttack</verbClass>
-                <defaultCooldownTime>80</defaultCooldownTime>
+                <defaultCooldownTime>1.48</defaultCooldownTime>
                 <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
                 <meleeDamageDef>Scratch</meleeDamageDef>
                 <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
             </li>
             <li>
                 <verbClass>Verb_MeleeAttack</verbClass>
-                <defaultCooldownTime>80</defaultCooldownTime>
+                <defaultCooldownTime>1.48</defaultCooldownTime>
                 <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
                 <meleeDamageDef>Scratch</meleeDamageDef>
                 <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
             </li>
             <li>
                 <verbClass>Verb_MeleeAttack</verbClass>
-                <defaultCooldownTime>90</defaultCooldownTime>
+                <defaultCooldownTime>1.65</defaultCooldownTime>
                 <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
                 <meleeDamageDef>Blunt</meleeDamageDef>
                 <linkedBodyPartsGroup>Tailblunt</linkedBodyPartsGroup>
@@ -557,14 +557,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.48</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>80</defaultCooldownTime>
+        <defaultCooldownTime>1.48</defaultCooldownTime>
         <meleeDamageBaseAmount>12</meleeDamageBaseAmount>
         <meleeDamageDef>Scratch</meleeDamageDef>
         <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Insectoid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Insectoid.xml
@@ -55,7 +55,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>10</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -70,7 +70,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>7</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>LeftAntisForeleg</linkedBodyPartsGroup>
@@ -85,7 +85,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>70</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>8</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>RightAntisForeleg</linkedBodyPartsGroup>
@@ -237,7 +237,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>16</meleeDamageBaseAmount>
         <meleeDamageDef>ToxicBite</meleeDamageDef>
         <linkedBodyPartsGroup>Mouth</linkedBodyPartsGroup>
@@ -252,7 +252,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>LeftAntisForeleg</linkedBodyPartsGroup>
@@ -267,7 +267,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>90</defaultCooldownTime>
+        <defaultCooldownTime>1.65</defaultCooldownTime>
         <meleeDamageBaseAmount>13</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>RightAntisForeleg</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
@@ -39,7 +39,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>140</defaultCooldownTime>
+        <defaultCooldownTime>2.55</defaultCooldownTime>
         <meleeDamageBaseAmount>25</meleeDamageBaseAmount>
         <meleeDamageDef>MechCrush</meleeDamageDef>
         <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
@@ -108,7 +108,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>24</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
@@ -123,7 +123,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>24</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
@@ -193,7 +193,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>16</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
@@ -208,7 +208,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>100</defaultCooldownTime>
+        <defaultCooldownTime>1.85</defaultCooldownTime>
         <meleeDamageBaseAmount>16</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
@@ -275,7 +275,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>60</defaultCooldownTime>
+        <defaultCooldownTime>1.1</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
@@ -290,7 +290,7 @@
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>60</defaultCooldownTime>
+        <defaultCooldownTime>1.1</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
@@ -357,7 +357,7 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>160</defaultCooldownTime>
+        <defaultCooldownTime>2.95</defaultCooldownTime>
         <meleeDamageBaseAmount>50</meleeDamageBaseAmount>
         <meleeDamageDef>MechCrush</meleeDamageDef>
         <linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_MechanoidZeon.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_MechanoidZeon.xml
@@ -84,7 +84,7 @@
 		<verbs>
 			<li>
 				<verbClass>Verb_MeleeAttack</verbClass>
-				<defaultCooldownTime>75</defaultCooldownTime>
+				<defaultCooldownTime>1.4</defaultCooldownTime>
 				<meleeDamageBaseAmount>75</meleeDamageBaseAmount>
 				<meleeDamageDef>Cut</meleeDamageDef>
 				<linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
@@ -99,8 +99,8 @@
 			</li>
 			<li>
 				<verbClass>Verb_MeleeAttack</verbClass>
-				<defaultCooldownTime>75</defaultCooldownTime>
-				<meleeDamageBaseAmount>72</meleeDamageBaseAmount>
+				<defaultCooldownTime>1.4</defaultCooldownTime>
+				<meleeDamageBaseAmount>75</meleeDamageBaseAmount>
 				<meleeDamageDef>Cut</meleeDamageDef>
 				<linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
 				<surpriseAttack>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mutant.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mutant.xml
@@ -38,14 +38,14 @@
     <verbs>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>25</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
       </li>
       <li>
         <verbClass>Verb_MeleeAttack</verbClass>
-        <defaultCooldownTime>120</defaultCooldownTime>
+        <defaultCooldownTime>2.2</defaultCooldownTime>
         <meleeDamageBaseAmount>25</meleeDamageBaseAmount>
         <meleeDamageDef>Blunt</meleeDamageDef>
         <linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>


### PR DESCRIPTION
Changes Melee cooldowns to seconds, weighted toward 1.85

Also fixes MechanoidZion damage to be 75 for both attacks.