### PR TITLE
fixes missing PawnKindDefs

### DIFF
--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Player.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Player.xml
@@ -195,5 +195,76 @@
 	</fixedInventory>
   </PawnKindDef>
   
+  <!-- Added for WandererJoin Fix -->
+  
+     <PawnKindDef ParentName="BasePlayerPawnKind">
+    <defName>NorbalHeroPlayer</defName>
+    <label>member</label>
+    <race>Human</race>
+    <backstoryCategory>Tribal</backstoryCategory>
+    <apparelTags>
+      <li>Tribal</li>
+    </apparelTags>
+    <apparelMoney>
+      <min>200</min>
+      <max>400</max>
+    </apparelMoney>
+    <apparelAllowHeadwearChance>0</apparelAllowHeadwearChance>
+    <backstoryCryptosleepCommonality>0.01</backstoryCryptosleepCommonality>
+	<maxGenerationAge>40</maxGenerationAge>
+  </PawnKindDef>
+  
+    <PawnKindDef ParentName="BasePlayerPawnKindOrassan">
+    <defName>OrassanHunterPlayer</defName>
+	<label>colonist</label>
+    <backstoryCategory>Civil</backstoryCategory>
+    <apparelTags>
+		<li>Outlander</li>
+		<li>PredatorsLight</li>
+		<li>BanditsLight</li>
+    </apparelTags>
+    <apparelMoney>
+      <min>1600</min>
+      <max>2800</max>
+    </apparelMoney>
+    <weaponMoney>
+      <min>620</min>
+      <max>1200</max>
+    </weaponMoney>
+		<weaponTags>
+			<li>TierTwoSMG</li>
+		</weaponTags>
+    <backstoryCryptosleepCommonality>1</backstoryCryptosleepCommonality>
+    <apparelAllowHeadwearChance>0</apparelAllowHeadwearChance>
+	<fixedInventory>
+	  <LoadoutGen_AmmoTypeH>1</LoadoutGen_AmmoTypeH>
+	  <LoadoutGen_SidearmGrenadeTierTwo>1</LoadoutGen_SidearmGrenadeTierTwo>
+	  <LoadoutGen_SidearmGrenadeFlashbang>1</LoadoutGen_SidearmGrenadeFlashbang>
+	</fixedInventory>
+  </PawnKindDef>
+  
+    <PawnKindDef ParentName="BasePlayerPawnKindAsari">
+    <defName>AsariHunterPlayer</defName>
+    <label>member</label>
+    <apparelTags>
+		<li>AsariCommando</li>
+    </apparelTags>
+    <apparelMoney>
+      <min>5000</min>
+      <max>8000</max>
+    </apparelMoney>
+    <weaponMoney>
+      <min>2620</min>
+      <max>2900</max>
+    </weaponMoney>
+		<weaponTags>
+			<li>TierTwoLow</li>
+		</weaponTags>
+	<fixedInventory>
+	  <LoadoutGen_AmmoTypeF>1</LoadoutGen_AmmoTypeF>
+	  <LoadoutGen_SidearmGrenadeTierTwo>1</LoadoutGen_SidearmGrenadeTierTwo>
+	  <LoadoutGen_SidearmGrenadeFlashbang>1</LoadoutGen_SidearmGrenadeFlashbang>
+	</fixedInventory>
+  </PawnKindDef>
   
 </PawnKindDefs>


### PR DESCRIPTION
Adds PawnKindDefs called for by Core_SK.DLL::SK.Events.IncidentWorker_WandererJoin

this.pawnKindDef = PawnKindDef.Named("NorbalHeroPlayer");
this.pawnKindDef = PawnKindDef.Named("OrassanHunterPlayer");
this.pawnKindDef = PawnKindDef.Named("AsariHunterPlayer");