### PR TITLE
Make Enlighten movement bonuses/penalties a factor

### DIFF
--- a/Mods/Core_SK/Defs/HediffDefs/HediffDefs_Enlighten.xml
+++ b/Mods/Core_SK/Defs/HediffDefs/HediffDefs_Enlighten.xml
@@ -14,7 +14,7 @@
           </li>
           <li>
             <capacity>Moving</capacity>
-            <offset>0.05</offset>
+            <postFactor>1.05</postFactor>
           </li>
         </capMods>
       </li>
@@ -31,7 +31,7 @@
         <capMods>
           <li>
             <capacity>Moving</capacity>
-            <offset>-0.15</offset>
+            <postFactor>0.85</postFactor>
           </li>
           <li>
             <capacity>Hearing</capacity>


### PR DESCRIPTION
Sometimes when your Colonists have their movement too low, entering darkness will make them become incapacited. It can be hilarious the first time but it gets old fast. This patch changes the bonus to a factor, so the situation will not happen.