### PR TITLE
Balance changes to prim floors

### DIFF
--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
@@ -1,19 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <TerrainDefs>
 
-	<TerrainDef Abstract="True" ParentName="FloorBase" Name="WoodfloorBase">
-		<PathCost>-2</PathCost>
-		<statBases>
-			<WorkToBuild>1000</WorkToBuild>
-			<Beauty>3</Beauty>
-		</statBases>
-		<designationCategory>Floors</designationCategory>
-		<Fertility>0</Fertility>
-		<constructEffect>ConstructWood</constructEffect>
-		<AcceptTerrainSourceFilth>True</AcceptTerrainSourceFilth>
-		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
-	</TerrainDef>
-
 	<!-- ================= Wood Tile ================= -->
 
 

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
@@ -1,135 +1,135 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <TerrainDefs>
 
+	<TerrainDef Abstract="True" ParentName="FloorBase" Name="PrimitiveFloorBase">
+		<PathCost>-2</PathCost>
+		<statBases>
+			<WorkToBuild>400</WorkToBuild>
+			<Beauty>2</Beauty>
+		</statBases>
+		<designationCategory>Floors</designationCategory>
+		<Fertility>0</Fertility>
+		<constructEffect>ConstructWood</constructEffect>
+		<AcceptTerrainSourceFilth>True</AcceptTerrainSourceFilth>
+		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+	</TerrainDef>
+
   <!-- ================= Floors ================= -->
 
-  <TerrainDef  ParentName="WoodfloorBase">
+  <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>TikiFloorBamboo</DefName>
     <label>Tiki Floor (Bamboo)</label>
     <RenderPrecedence>250</RenderPrecedence>
-    <Description>A Nice Tiki Floor</Description>
+    <Description>A nice tiki floor. 
+Beauty: 2.</Description>
     <texturePath>Terrain/Surfaces/TikiFloorBamboo</texturePath>
 	<uiIconPath>Terrain/Surfaces/TikiFloorBambooIco</uiIconPath>
-    <statBases>
-      <WorkToBuild>300</WorkToBuild>
-    </statBases>
     <CostList>
       <Bamboo>4</Bamboo>
     </CostList>
     <constructEffect>ConstructWood</constructEffect>
   </TerrainDef>
 
-  <TerrainDef  ParentName="WoodfloorBase">
+  <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>TikiFloorDark</DefName>
     <label>Tiki Floor (Dark)</label>
     <RenderPrecedence>250</RenderPrecedence>
-    <Description>A Nice Dark Tiki Floor</Description>
+    <Description>A nice dark tiki floor. 
+Beauty: 2.</Description>
     <texturePath>Terrain/Surfaces/TikiFloorDark</texturePath>
 	<uiIconPath>Terrain/Surfaces/TikiFloorDarkIco</uiIconPath>
-    <statBases>
-      <WorkToBuild>300</WorkToBuild>
-    </statBases>
     <CostList>
       <WoodLog>4</WoodLog>
     </CostList>
     <constructEffect>ConstructWood</constructEffect>
   </TerrainDef>
 
-  <TerrainDef  ParentName="WoodfloorBase">
+  <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>TikiFloorLight</DefName>
     <label>Tiki Floor (Light)</label>
     <RenderPrecedence>250</RenderPrecedence>
-    <Description>A Nice Light Tiki Floor</Description>
+    <Description>A nice light tiki floor.
+Beauty: 2.</Description>
     <texturePath>Terrain/Surfaces/TikiFloorLight</texturePath>
 	<uiIconPath>Terrain/Surfaces/TikiFloorLightIco</uiIconPath>	
-    <statBases>
-      <WorkToBuild>300</WorkToBuild>
-    </statBases>
     <CostList>
       <WoodLog>4</WoodLog>
     </CostList>
     <constructEffect>ConstructWood</constructEffect>
   </TerrainDef>
 
-  <TerrainDef  ParentName="WoodfloorBase">
+  <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>TikiFloorFancy</DefName>
     <label>Tiki Floor (Fancy)</label>
     <RenderPrecedence>250</RenderPrecedence>
-    <Description>A Nice Fancy Tiki Floor</Description>
+    <Description>A nice fancy tiki floor with gold inlays.
+Beauty: 3.</Description>
     <texturePath>Terrain/Surfaces/TikiFloorFancy</texturePath>
 	<uiIconPath>Terrain/Surfaces/TikiFloorFancyIco</uiIconPath>	
     <statBases>
-      <WorkToBuild>300</WorkToBuild>
-      <Beauty>3</Beauty>
-    </statBases>
-    <CostList>
+		<WorkToBuild>700</WorkToBuild>
+		<Beauty>3</Beauty>
+	</statBases>
+	<CostList>
       <WoodLog>4</WoodLog>
       <Gold>1</Gold>
       </CostList>
     <constructEffect>ConstructWood</constructEffect>
   </TerrainDef>
 
-  <TerrainDef  ParentName="WoodfloorBase">
+  <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>LogFloor</DefName>
     <label>Log Floor</label>
     <RenderPrecedence>250</RenderPrecedence>
-    <Description>A Nice Log Floor</Description>
+    <Description>A simple log floor.
+Beauty: 2.</Description>
     <texturePath>Terrain/Surfaces/LogFloor</texturePath>
 	<uiIconPath>Terrain/Surfaces/LogFloorIco</uiIconPath>	
-    <statBases>
-      <WorkToBuild>300</WorkToBuild>
-    </statBases>
     <CostList>
-      <WoodLog>5</WoodLog>
+      <WoodLog>4</WoodLog>
       </CostList>
     <constructEffect>ConstructWood</constructEffect>
   </TerrainDef>
 
-  <TerrainDef  ParentName="WoodfloorBase">
+  <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>ThatchFloor</DefName>
     <label>Thatch Floor</label>
     <RenderPrecedence>250</RenderPrecedence>
-    <Description>A Nice Thatch Floor</Description>
+    <Description>A primitive thatch floor.
+Beauty: 2.</Description>
     <texturePath>Terrain/Surfaces/ThatchFloor</texturePath>
 	<uiIconPath>Terrain/Surfaces/ThatchFloorIco</uiIconPath>	
-    <statBases>
-      <WorkToBuild>300</WorkToBuild>
-    </statBases>
     <CostList>
-      <Hay>4</Hay>
+      <Hay>5</Hay>
       </CostList>
     <constructEffect>ConstructWood</constructEffect>
   </TerrainDef>
 
- <TerrainDef  ParentName="WoodfloorBase">
+ <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>WeaveFloor</DefName>
     <label>Weave Floor</label>
     <RenderPrecedence>250</RenderPrecedence>
-    <Description>A Nice Woven Floor</Description>
+    <Description>A nice woven floor.
+Beauty: 2.</Description>
     <texturePath>Terrain/Surfaces/WeaveFloor</texturePath>
 	<uiIconPath>Terrain/Surfaces/WeaveFloorIco</uiIconPath>	
-    <statBases>
-      <WorkToBuild>300</WorkToBuild>
-    </statBases>
     <CostList>
-      <Hay>4</Hay>
+      <Hay>5</Hay>
       </CostList>
     <constructEffect>ConstructWood</constructEffect>
   </TerrainDef>
 
 
- <TerrainDef  ParentName="WoodfloorBase">
+ <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>WovenLeafFloor</DefName>
     <label>Woven Leaf Floor</label>
     <RenderPrecedence>250</RenderPrecedence>
-    <Description>A Nice Woven Leaf Floor</Description>
+    <Description>A nice woven leaf floor.
+Beauty: 2.</Description>
     <texturePath>Terrain/Surfaces/WovenLeafFloor</texturePath>
 	<uiIconPath>Terrain/Surfaces/WovenLeafFloorIco</uiIconPath>	
-    <statBases>
-      <WorkToBuild>300</WorkToBuild>
-    </statBases>
     <CostList>
-      <Hay>4</Hay>
+      <Hay>5</Hay>
       </CostList>
     <constructEffect>ConstructWood</constructEffect>
   </TerrainDef>


### PR DESCRIPTION
Changed beauty from 3 to 2 and increased work by 25% (except for the fancy tiki floor which uses gold), and amount of hay needed by +1. Also cleaned up the code inheritance (it was located in the wood floor xml for some reason but isn't actually used there, so it was moved over to the prim floor xml instead) and in-game descriptions.