### PR TITLE
Fix passive cooler

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
@@ -239,7 +239,7 @@
   <ThingDef ParentName="BuildingBase">
     <defName>PassiveCooler</defName>
     <label>passive cooler</label>
-    <description>A traditional unpowered cooler that works by water evaporation. Will run out and self-destruct after several days.</description>
+    <description>A traditional unpowered cooler that works by water evaporation. While it's not strong enough to refridgerate food, it can help survive a heat wave. It will run out and self-destruct after several days.</description>
     <category>Building</category>
     <graphicData>
       <texPath>Things/Building/Misc/PassiveCooler</texPath>
@@ -282,7 +282,8 @@
         <lifeSpanTicks>300000</lifeSpanTicks>
       </li>
     </comps>
-    <designationCategory>Temperature</designationCategory>
+    <designationCategory>Temperature</designationCategory>	
+    <researchPrerequisites><li>PassiveCooler</li></researchPrerequisites>
   </ThingDef>
   
   <ThingDef ParentName="BuildingBase">


### PR DESCRIPTION
The passive cooler tech wasn't giving you anything because the building was missing the prereq attribute. I also clarified the purpose of this building better in the description.