### PR TITLE
Fix stone cutting recipes

### DIFF
--- a/Mods/Core/Defs/ThingDefs_Misc/Various_Stone.xml
+++ b/Mods/Core/Defs/ThingDefs_Misc/Various_Stone.xml
@@ -164,8 +164,8 @@
 
 	<RecipeDef ParentName="MakeStoneBlocksBase">
 		<defName>MakeStoneBlocksSandstone</defName>
-		<label>make sandstone blocks</label>
-		<description>Cuts sandstone chunks into usable blocks.</description>
+		<label>Make Sandstone Blocks</label>
+		<description>Cuts sandstone chunks into usable blocks. Produces 20 sand and 5 rubble as a by-product.</description>
 		<ingredients>
 			<li>
 				<filter>
@@ -183,6 +183,8 @@
 		</fixedIngredientFilter>
 		<products>
 			<BlocksSandstone>20</BlocksSandstone>
+			<CrushedStone>5</CrushedStone>
+			<Sand>20</Sand>
 		</products>
 	</RecipeDef>
 
@@ -251,8 +253,8 @@
 
 	<RecipeDef ParentName="MakeStoneBlocksBase">
 		<defName>MakeStoneBlocksGranite</defName>
-		<label>make granite blocks</label>
-		<description>Cuts granite chunks into usable blocks.</description>
+		<label>Make Granite Blocks</label>
+		<description>Cuts granite chunks into usable blocks. Produces 20 sand and 5 rubble as a by-product.</description>
 		<ingredients>
 			<li>
 				<filter>
@@ -270,6 +272,8 @@
 		</fixedIngredientFilter>
 		<products>
 			<BlocksGranite>20</BlocksGranite>
+			<CrushedStone>5</CrushedStone>
+			<Sand>20</Sand>
 		</products>
 	</RecipeDef>
 
@@ -337,8 +341,8 @@
 
 	<RecipeDef ParentName="MakeStoneBlocksBase">
 		<defName>MakeStoneBlocksLimestone</defName>
-		<label>make limestone blocks</label>
-		<description>Cuts limestone chunks into usable blocks.</description>
+		<label>Make Limestone Blocks</label>
+		<description>Cuts limestone chunks into usable blocks. Produces 20 sand and 5 rubble as a by-product.</description>
 		<ingredients>
 			<li>
 				<filter>
@@ -356,6 +360,8 @@
 		</fixedIngredientFilter>
 		<products>
 			<BlocksLimestone>20</BlocksLimestone>
+			<CrushedStone>5</CrushedStone>
+			<Sand>20</Sand>
 		</products>
 	</RecipeDef>
 
@@ -424,8 +430,8 @@
 
 	<RecipeDef ParentName="MakeStoneBlocksBase">
 		<defName>MakeStoneBlocksSlate</defName>
-		<label>make slate blocks</label>
-		<description>Cuts slate chunks into usable blocks.</description>
+		<label>Make Slate Blocks</label>
+		<description>Cuts slate chunks into usable blocks. Produces 20 sand and 5 rubble as a by-product.</description>
 		<ingredients>
 			<li>
 				<filter>
@@ -443,6 +449,8 @@
 		</fixedIngredientFilter>
 		<products>
 			<BlocksSlate>20</BlocksSlate>
+			<CrushedStone>5</CrushedStone>
+			<Sand>20</Sand>
 		</products>
 	</RecipeDef>
 
@@ -514,8 +522,8 @@
 
 	<RecipeDef ParentName="MakeStoneBlocksBase">
 		<defName>MakeStoneBlocksMarble</defName>
-		<label>make marble blocks</label>
-		<description>Cuts marble chunks into usable blocks.</description>
+		<label>Make Marble Blocks</label>
+		<description>Cuts marble chunks into usable blocks. Produces 20 sand and 5 rubble as a by-product.</description>
 		<ingredients>
 			<li>
 				<filter>
@@ -533,6 +541,8 @@
 		</fixedIngredientFilter>
 		<products>
 			<BlocksMarble>20</BlocksMarble>
+			<CrushedStone>5</CrushedStone>
+			<Sand>20</Sand>
 		</products>
 	</RecipeDef>
 

--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Extracts.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Extracts.xml
@@ -231,7 +231,7 @@
          </li>
       </skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+    	<workSkillLearnFactor>0.25</workSkillLearnFactor>
 	</RecipeDef>
 	
 	

--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Extracts.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Extracts.xml
@@ -162,7 +162,7 @@
 		<label>Make Stone Blocks</label>
 		<description>Cuts a stone chunk into usable stone blocks. Produces 20 sand and 5 rubble as a by-product.</description>
 		<jobString>Cutting stone chunk into blocks.</jobString>
-		<workAmount>1200</workAmount>
+		<workAmount>1600</workAmount>
 		<workSpeedStat>StonecuttingSpeed</workSpeedStat>
 		<effectWorking>CutStone</effectWorking>
 		<soundWorking>Recipe_MakeStoneBlocks</soundWorking>
@@ -188,11 +188,10 @@
       <skillRequirements>
          <li>
             <skill>Crafting</skill>
-            <minLevel>2</minLevel>
          </li>
       </skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+    	<workSkillLearnFactor>0.25</workSkillLearnFactor>
 	</RecipeDef>
 
 


### PR DESCRIPTION
The "cut stone blocks" and cut specific stone blocks (eg "cut marble blocks") were different. They now both yield the sand and rubble byproducts.

They also had mismatched speed and skill gain. The generic one was faster and gave more skill, whereas the specific ones used vanilla stats. I reset the generic to use vanilla stats as well. Cleaned up the labels too.