### PR TITLE
Furniture fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings.xml
@@ -77,7 +77,6 @@
 	<PathCost>50</PathCost>
 	<fillPercent>0.6</fillPercent>
 	<Passability>PassThroughOnly</Passability>
-	<DrawGUIOverlay>True</DrawGUIOverlay>
     <statBases>
 	  <Flammability>1.0</Flammability>
     </statBases>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings.xml
@@ -111,6 +111,7 @@
   </ThingDef>
   
   <ThingDef Name="HighQualityFurnitureBase" ParentName="BuildingBase" Abstract="True">
+    <Passability>PassThroughOnly</Passability>	
     <comps>
       <li>
         <compClass>CompQuality</compClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
@@ -8,6 +8,7 @@
     <soundImpactDefault>BulletImpactGround</soundImpactDefault>
 	<StaticSunShadowHeight>0</StaticSunShadowHeight>
 	<CastEdgeShadows>False</CastEdgeShadows>
+	<DrawGUIOverlay>True</DrawGUIOverlay>
     <statBases>
       <MaxHitPoints>80</MaxHitPoints>
 	  <Flammability>1.0</Flammability>
@@ -1364,6 +1365,7 @@
       </damageData>
     </graphicData>
     <altitudeLayer>Building</altitudeLayer>
+    <Passability>Standable</Passability>
     <statBases>
 		<MaxHitPoints>50</MaxHitPoints>
 		<WorkToBuild>400</WorkToBuild>
@@ -1402,6 +1404,7 @@
 			</damageData>
     </graphicData>
     <altitudeLayer>Building</altitudeLayer>
+    <Passability>Standable</Passability>
     <statBases>
 		<MaxHitPoints>50</MaxHitPoints>
 		<WorkToBuild>300</WorkToBuild>
@@ -1444,6 +1447,7 @@
       </damageData>
     </graphicData>
     <altitudeLayer>Building</altitudeLayer>
+    <Passability>Standable</Passability>
     <statBases>
 			<MaxHitPoints>50</MaxHitPoints>
 			<WorkToBuild>500</WorkToBuild>
@@ -1577,6 +1581,7 @@
 			</damageData>
     </graphicData>
     <altitudeLayer>Building</altitudeLayer>
+    <Passability>Standable</Passability>
     <statBases>
 			<MaxHitPoints>70</MaxHitPoints>
 			<WorkToBuild>950</WorkToBuild>


### PR DESCRIPTION
This removes the quality display on some of the furniture that was displaying it (the same attribute is used to show bed ownership, so I had to move that to the bedbase instead).

It also allows only stools to be placed in front of work benches.