### PR TITLE
Fix electric sawmill, and proposed balance change

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Production.xml
@@ -44,7 +44,7 @@
 		<label>Saw Wood Planks</label>
 		<description>Saws wood logs into planks. Quite fast. Produces 30.</description>
 		<jobString>Sawing wood planks.</jobString>
-		<workAmount>1200</workAmount>
+		<workAmount>600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>MakeWoodPlanks_Electric</effectWorking>
 		<soundWorking>Recipe_MakeWoodPlanks_Electric</soundWorking>
@@ -120,7 +120,7 @@
 		<label>Saw Bamboo Planks</label>
 		<description>Saws bamboo logs into bamboo planks. Quite fast. Produces 30.</description>
 		<jobString>Sawing bamboo planks.</jobString>
-		<workAmount>1200</workAmount>
+		<workAmount>600</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>MakeWoodPlanks_Electric</effectWorking>
 		<soundWorking>Recipe_MakeWoodPlanks_Electric</soundWorking>
@@ -158,7 +158,7 @@
 		<label>Chop Wood Kindling</label>
 		<description>Chop wood logs or bamboo logs into kindling. Quite slow. Produces 15.</description>
 		<jobString>Chopping logs into kindling.</jobString>
-		<workAmount>800</workAmount>
+		<workAmount>500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>MakeWoodPlanks_Hand</effectWorking>
 		<soundWorking>Recipe_MakeWoodPlanks_Hand</soundWorking>
@@ -181,7 +181,7 @@
 			<Kindling>20</Kindling>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+    	<workSkillLearnFactor>0.25</workSkillLearnFactor>
 	</RecipeDef>
 
 
@@ -190,7 +190,7 @@
 		<label>Chop Wood Kindling</label>
 		<description>Chop wood logs or bamboo logs into kindling. Quite fast. Produces 30.</description>
 		<jobString>Chopping logs into kindling.</jobString>
-		<workAmount>800</workAmount>
+		<workAmount>250</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>MakeWoodPlanks_Electric</effectWorking>
 		<soundWorking>Recipe_MakeWoodPlanks_Electric</soundWorking>
@@ -219,7 +219,7 @@
          </li>
       </skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+    	<workSkillLearnFactor>0.25</workSkillLearnFactor>
 	</RecipeDef>
 
 


### PR DESCRIPTION
It didn't provide the 2x speed benefit like other electric workbenches provided.

I also recommend speeding up kindling production. Kindling is a crude product that doesn't take precision and skill to make and shouldn't take so long, especially since you need a lot of it every day.