### PR TITLE
Proposed adjustment to kindling production

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Production.xml
@@ -156,9 +156,9 @@
 	<RecipeDef>
 		<defName>MakeKindling_Hand</defName>
 		<label>Chop Wood Kindling</label>
-		<description>Chop wood logs or bamboo logs into kindling. Quite slow. Produces 15.</description>
+		<description>Chop wood logs or bamboo logs into kindling. Quite slow. Produces 20.</description>
 		<jobString>Chopping logs into kindling.</jobString>
-		<workAmount>800</workAmount>
+		<workAmount>500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>MakeWoodPlanks_Hand</effectWorking>
 		<soundWorking>Recipe_MakeWoodPlanks_Hand</soundWorking>
@@ -181,16 +181,16 @@
 			<Kindling>20</Kindling>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+    	<workSkillLearnFactor>0.25</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeKindling_Electric</defName>
 		<label>Chop Wood Kindling</label>
-		<description>Chop wood logs or bamboo logs into kindling. Quite fast. Produces 30.</description>
+		<description>Chop wood logs or bamboo logs into kindling. Quite fast. Produces 40.</description>
 		<jobString>Chopping logs into kindling.</jobString>
-		<workAmount>800</workAmount>
+		<workAmount>500</workAmount>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>MakeWoodPlanks_Electric</effectWorking>
 		<soundWorking>Recipe_MakeWoodPlanks_Electric</soundWorking>
@@ -219,7 +219,7 @@
          </li>
       </skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+    	<workSkillLearnFactor>0.25</workSkillLearnFactor>
 	</RecipeDef>
 
 


### PR DESCRIPTION
Producing kindling is a crude, non-precision task that shouldn't take so long to do, especially considering how much of the stuff a base burns through now. I propose reducing the work, but also reducing the skill gain as well.

Also the description was displaying the wrong number for yield.