### PR TITLE
Security progression refinements

### DIFF
--- a/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Security.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Security.xml
@@ -22,11 +22,12 @@
 			<!-- <defName>SK_SecurityII</defName>-->
 			<defName>IEDBomb</defName>
 			<label>Security II</label>
-			<description>Allows colonists to build improvised explosive device-based traps from artillery shells. Also unlocks Wall Embrasures and Wall Wire.</description>
+			<description>Allows colonists to build improvised explosive device-based traps from artillery shells. Also unlocks Wall Parapet and Wall Wire.</description>
 			<baseCost>450</baseCost>
 			<techLevel>Industrial</techLevel>
 				<prerequisites>
 					<li>SK_Security</li>
+					<li>SK_ConstructionI</li>
 				</prerequisites>
 		  </ResearchProjectDef>
 			<!-- 
@@ -38,7 +39,7 @@
 					<!-- <defName>IEDBombI</defName>-->
 					<defName>IEDIncendiary</defName>
 					<label>Security III</label>
-					<description>Allows colonists to build incendiary explosive traps from artillery shells.</description>
+					<description>Allows colonists to build incendiary explosive traps from artillery shells, and highly defensive Wall Embrasures.</description>
 					<baseCost>550</baseCost>
 					<techLevel>Industrial</techLevel>
 						<prerequisites>

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Start.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Start.xml
@@ -6,7 +6,7 @@
   <ResearchProjectDef>
     <defName>SK_Craftsmanship</defName>
     <label>Primary Craftsmanship</label>
-    <description>You're not in stone age! Sit down and try to remember basics of your life beforee this catastrophe. Unlocks basic kitchen and production workbenches, some primal lightning and storages.</description>
+    <description>You're not in stone age! Sit down and try to remember basics of your life before this catastrophe. Unlocks basic kitchen and production workbenches, some primal lightning and storages.</description>
     <baseCost>500</baseCost>
     <techLevel>Medieval</techLevel>
 	<tags>
@@ -22,7 +22,6 @@
 			Storage_WoodenPalletSmall
 			OutdoorGroundLamp
 			Lighting_PathLamp
-			Parapet
 			chevalDeFrise
 			-->
   </ResearchProjectDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
@@ -193,6 +193,7 @@
     <blockLight>false</blockLight>
     <leaveResourcesWhenKilled>false</leaveResourcesWhenKilled>
     <constructEffect>ConstructWood</constructEffect>
+    <designationCategory>Security</designationCategory>
     <repairEffect>ConstructWood</repairEffect>
     <rotatable>true</rotatable>
     <neverMultiSelect>true</neverMultiSelect>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
@@ -150,7 +150,7 @@
 		<designationCategory>Security</designationCategory>
 		<staticSunShadowHeight>0.20</staticSunShadowHeight>
 		<repairEffect>ConstructDirt</repairEffect>
-		<researchPrerequisites><li>SK_Craftsmanship</li></researchPrerequisites>
+		<researchPrerequisites><li>IEDBomb</li></researchPrerequisites>
 	</ThingDef>
 
 
@@ -265,7 +265,7 @@
     <designationCategory>Security</designationCategory>
     <staticSunShadowHeight>0.20</staticSunShadowHeight>
     <repairEffect>ConstructDirt</repairEffect>
-	<researchPrerequisites><li>IEDBomb</li></researchPrerequisites>
+	<researchPrerequisites><li>IEDIncendiary</li></researchPrerequisites>
   </ThingDef>
 
   <!--========================= Barbed Wire =============================-->

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
@@ -185,7 +185,7 @@
 		<ai_chillDestination>false</ai_chillDestination>
 		<isInert>true</isInert>
     </building>
-    <description>A defensive barier made of sharpened sticks. It is weak but slow to climb over.</description>
+    <description>A defensive barrier made of sharpened sticks. It is weak but slow to climb over.</description>
     <costList>
       <WoodLog>10</WoodLog>
     </costList>


### PR DESCRIPTION
Two issues fixed:
A.) the Cheval de frise could not be built because it lacked a category
B.) you could build parapets before sandbags.

I changed it so it's now Cheval de frise (craftsmanship) -> sandbags (security 1) -> parapets (security 2) -> embrasures (security 3), and I felt it also made sense to gate security 2 behind construction 1.

Some typo fixes too.