### PR TITLE
Proposed balance change to fences

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Walls.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Walls.xml
@@ -298,7 +298,7 @@
 		</blueprintGraphicData>
 		<statBases>
 			<MaxHitPoints>180</MaxHitPoints>
-			<WorkToBuild>170</WorkToBuild>
+			<WorkToBuild>300</WorkToBuild>
 			<Flammability>1.0</Flammability>
 		</statBases>
 		<stuffCategories>
@@ -306,9 +306,6 @@
 			<li>Woody</li>
 		</stuffCategories>
 		<costStuffCount>4</costStuffCount>
-		<costList>
-			<Component>1</Component>
-		</costList>
 		<pathCost>98</pathCost>
 		<passability>PassThroughOnly</passability>
 		<fillPercent>0.2</fillPercent>


### PR DESCRIPTION
I can't see any logical reason on why simple fences cost components and other type of walls do not. They're mostly just aesthetic buildings anyway. They're also unlocked at a cost-100, first tier research, suggesting they're intended for very early game use, but components are a premium in the early game so that doesn't align very well.

Increased the workload though, because digging post holes is rather labor intensive.