### PR TITLE
Fix kibble

### DIFF
--- a/Mods/Core/Defs/RecipeDefs/Recipes_Food.xml
+++ b/Mods/Core/Defs/RecipeDefs/Recipes_Food.xml
@@ -3,10 +3,10 @@
 
   <RecipeDef>
     <defName>MakeKibble</defName>
-    <label>make kibble</label>
+    <label>Make Kibble</label>
     <description>Make animal kibble by combining raw meat and plants.</description>
     <jobString>Making kibble.</jobString>
-    <workAmount>300</workAmount>
+    <workAmount>500</workAmount>
     <workSpeedStat>CookSpeed</workSpeedStat>
     <effectWorking>Cook</effectWorking>
     <soundWorking>Recipe_CookMeal</soundWorking>
@@ -20,7 +20,7 @@
             <li>AnimalProductRaw</li>
           </categories>
         </filter>
-        <count>1</count>
+        <count>10</count>
       </li>
       <li>
         <filter>
@@ -31,7 +31,7 @@
             <li>Hay</li>
           </thingDefs>
         </filter>
-        <count>1</count>
+        <count>15</count>
       </li>
     </ingredients>
     <products>


### PR DESCRIPTION
Kibble was massively unbalanced, increasing the nutrition by a whopping 25x (0.05 x 2 in, 0.05 x 50 out).
The proposed formula would be a simple 2x yield instead.

It should probably also take a bit longer. This is a lot of food being prepared.