### PR TITLE
Holstered chaps description fix

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
@@ -663,7 +663,7 @@
 	<ThingDef ParentName="ApparelMedievalBase">
 		<defName>Apparello_Holser</defName>
 		<label>Holstered Chaps</label>
-		<description>A pair of chaps with holsters. All of the fastest shooters wore these. They usually got shot in the back. (Can be worn over other pants).</description>
+		<description>A pair of chaps with holsters. All of the fastest shooters wore these. They usually got shot in the back.</description>
 		<graphicData>
 		  <texPath>Things/Apparel/Apparello/Accessorello/Chaps</texPath>
 		  <graphicClass>Graphic_Single</graphicClass>


### PR DESCRIPTION
It can't be worn over other pants, as the description claims. Was obviously causing some player confusion.