### PR TITLE
Pemmican fix

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -91,6 +91,7 @@
 			<li>CookRoastedMeat</li>
 			<li>MakeVegetables</li>
 			<li>MakeRoastwMushrooms</li>
+			<li>MakePemmican</li>
             <li>MakeBurgerCheese</li>
             <li>MakeCheeseGrilled</li>
 		</recipes>


### PR DESCRIPTION
Pemmican is a starting tech for tribal start, but you're unable to make it until you get post-tribal tech (fueled stoves). The grill should be able to make this, I think.