### PR TITLE
Bill label consistency sweep (meals)

### DIFF
--- a/Mods/Core/Defs/RecipeDefs/Recipes_Food.xml
+++ b/Mods/Core/Defs/RecipeDefs/Recipes_Food.xml
@@ -3,7 +3,7 @@
 
   <RecipeDef>
     <defName>MakeKibble</defName>
-    <label>Make Kibble</label>
+    <label>make kibble</label>
     <description>Make animal kibble by combining raw meat and plants.</description>
     <jobString>Making kibble.</jobString>
     <workAmount>500</workAmount>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
@@ -3,7 +3,7 @@
 
 		<RecipeDef>
 		<defName>CookMealSalad</defName>
-		<label>Make Simple Salad</label>
+		<label>make simple salad</label>
 		<description>Prepares a Simple Salad made from raw vegetables. Produces 1.</description>
 		<jobString>Making Simple Salad.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -62,7 +62,7 @@
 	
 		<RecipeDef>
 		<defName>CookMealSalad_Bulk</defName>
-		<label>Make Simple Salads (x4)</label>
+		<label>make simple salads (x4)</label>
 		<description>Prepares Simple Salads made from raw vegetables. Produces 4.</description>
 		<jobString>Making Simple Salads.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -123,7 +123,7 @@
 
 <RecipeDef Name="CookRoastedMeatx4">
 		<defName>CookRoadMeatx4</defName>
-		<label>Cook Roasted Meats (x4)</label>
+		<label>cook roasted meats (x4)</label>
 		<description>Prepares fresh Roasted Meats. Produces 4.</description>
 		<jobString>Cooking Roasted Meat.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -184,7 +184,7 @@
 
 	<RecipeDef Name="CookJerkyMeatx4">
 		<defName>CookJerkyMeatx4</defName>
-		<label>Cook Jerky Meats (x4)</label>
+		<label>cook jerky meats (x4)</label>
 		<description>Prepares smoked Jerky from raw meat. Produces 4.</description>
 		<jobString>Cooking Jerky.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -244,7 +244,7 @@
 
 	<RecipeDef Name="CookMealSimple">
 		<defName>CookMealSimple</defName>
-		<label>Cook Simple Meal</label>
+		<label>cook simple meal</label>
 		<description>Cooks a Simple Meal from one ingredient. Produces 1.</description>
 		<jobString>Cooking Simple Meal.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -308,7 +308,7 @@
 
 		<RecipeDef>
 		<defName>CookMealSimple_Bulk</defName>
-		<label>Cook Simple Meals (x4)</label>
+		<label>cook simple meals (x4)</label>
 		<description>Cooks Simple Meals from one ingredient. Produces 4.</description>
 		<jobString>Cooking Simple Meals.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -368,7 +368,7 @@
 
 	<RecipeDef>
 		<defName>CookMealFine</defName>
-		<label>Cook Fine Meal</label>
+		<label>cook fine meal</label>
 		<description>Cooks a somewhat complex meal from a combination of raw meat and raw plant ingredients. Produces 1.</description>
 		<jobString>Cooking Fine Meal.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -441,7 +441,7 @@
 	
 	<RecipeDef>
 		<defName>CookMealFine_Bulk</defName>
-		<label>Cook Fine Meals (x4)</label>
+		<label>cook fine meals (x4)</label>
 		<description>Cooks somewhat complex meals from a combination of raw meat and raw plant ingredients. Produces 4.</description>
 		<jobString>Cooking Fine Meals.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -517,7 +517,7 @@
 
 	<RecipeDef>
 		<defName>CookMealLavish</defName>
-		<label>Cook Lavish Meal</label>
+		<label>cook lavish meal</label>
 		<description>Cooks a very complex meal from a combination of raw meat and raw plant ingredients. Produces 1.</description>
 		<jobString>Cooking Lavish Meal.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -598,7 +598,7 @@
 
 	<RecipeDef>
 		<defName>CookMealLavish_Bulk</defName>
-		<label>Cook Lavish Meals (x4)</label>
+		<label>cook lavish meals (x4)</label>
 		<description>Cooks very complex meals from a combination of raw meat and raw plant ingredients. Produces 4.</description>
 		<jobString>Cooking Lavish Meals.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -680,7 +680,7 @@
 	
 	<RecipeDef>
 		<defName>CookMealLuxury</defName>
-		<label>Cook Luxury Meal</label>
+		<label>cook luxury meal</label>
 		<description>Cooks a Luxurious Meal from a combination of raw meat and raw plant ingredients. Some ingredients are wasted as only the finest will do. Produces 1.</description>
 		<jobString>Cooking Luxury Meal.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -779,7 +779,7 @@
 	
 	<RecipeDef>
 		<defName>CookMealLuxury_Bulk</defName>
-		<label>Cook Luxury Meals (x4)</label>
+		<label>cook luxury meals (x4)</label>
 		<description>Cooks Luxurious Meals from a combination of raw meat and raw plant ingredients. Some ingredients are wasted as only the finest will do. Produces 4.</description>
 		<jobString>Cooking four Luxury Meals.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -881,7 +881,7 @@
 	
 	<RecipeDef Name="CookRoastedMeat">
 		<defName>CookRoastedMeat</defName>
-		<label>Cook Roasted Meat</label>
+		<label>cook roasted meat</label>
 		<description>Prepares fresh Roasted Meat. Produces 1.</description>
 		<jobString>Cooking Roasted Meat.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -946,7 +946,7 @@
 	
     <RecipeDef Name="CookMealJerky">
 		<defName>CookMealJerky</defName>
-		<label>Cook Jerky Meat</label>
+		<label>cook jerky meat</label>
 		<description>Prepares smoked Jerky from raw meat. Produces 1.</description>
 		<jobString>Cooking Jerky.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -1011,7 +1011,7 @@
 
 	<RecipeDef>
 		<defName>MakeDriedfruit</defName>
-		<label>Dry Fresh Fruit</label>
+		<label>dry fresh fruit</label>
 		<description>Dehydrates fruit to increase its lifespan. Produces 1.</description>
 		<jobString>Drying Fruit.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -1051,7 +1051,7 @@
 	
 	<RecipeDef>
 		<defName>MakeTofu</defName>
-		<label>Make Tofu</label>
+		<label>make tofu</label>
 		<description>Turns Beans into Tofu. Tofu is used in place of meat in meals or can be eaten raw. Produces 5.</description>
 		<jobString>Pressing Tofu.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -1092,7 +1092,7 @@
 
 	<RecipeDef>
 		<defName>MakeVegetables</defName>
-		<label>Cook Fried Assorts</label>
+		<label>cook fried assorts</label>
 		<description>Prepares a simple dried assortment of vegetables. Produces 1.</description>
 		<jobString>Cooking Fried Assorts.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -1136,7 +1136,7 @@
 
     <RecipeDef Name="BakePotato">
 		<defName>BakePotato</defName>
-		<label>Bake Potato</label>
+		<label>bake potato</label>
 		<description>Prepares baked potatos from raw potatos. Produces 1.</description>
 		<jobString>Baking Potato.</jobString>
 		<workAmount>350</workAmount>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Alcohol.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Alcohol.xml
@@ -4,7 +4,7 @@
 	
   <RecipeDef>
     <defName>MakeWort</defName>
-    <label>Brew Wort</label>
+    <label>brew wort</label>
     <description>Brew a batch of bottled Wort from Hops. Produces 5.</description>
     <jobString>Brewing batch of Wort.</jobString>
     <workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -43,7 +43,7 @@
 
 <RecipeDef>
 	<defName>Distillcider</defName>
-	<label>Brew Apple Cider</label>
+	<label>brew apple cider</label>
 	<description>Brew bottles of Apple Cider. Produces 5.</description>
 	<jobString>Brewing Apple Cider.</jobString>
 	<workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -86,7 +86,7 @@
 
 <RecipeDef>
 	<defName>Distillrum</defName>
-	<label>Distill Rum</label>
+	<label>distill rum</label>
 	<description>Distills bottles of Rum from Sugarcane. Produces 5.</description>
 	<jobString>Distilling bottles of Rum.</jobString>
 	<workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -129,7 +129,7 @@
 
 <RecipeDef>
 	<defName>DistillStrawberryWine</defName>
-	<label>Distill Strawberry Wine</label>
+	<label>distill strawberry wine</label>
 	<description>Distills bottles of Strawberry Wine. Produces 8.</description>
 	<jobString>Distilling Strawberry Wine.</jobString>
 	<workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -172,7 +172,7 @@
 
 <RecipeDef>
 	<defName>DistillSaki</defName>
-	<label>Distill Sake</label>
+	<label>distill sake</label>
 	<description>Distills bottles of Saki from Rice. Produces 8.</description>
 	<jobString>Distilling bottles of Saki.</jobString>
 	<workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -215,7 +215,7 @@
 
 <RecipeDef>
 	<defName>DistillVodka</defName>
-	<label>Distill Vodka</label>
+	<label>distill vodka</label>
 	<description>Distills bottles of Vodka from Potatoes. Produces 8.</description>
 	<jobString>Distilling bottles of Vodka.</jobString>
 	<workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -258,7 +258,7 @@
 	
 <RecipeDef>
 	<defName>DistillTequila</defName>
-	<label>Distill Tequila</label>
+	<label>distill tequila</label>
 	<description>Distills bottles of Tequila from Agave. Produces 8.</description>
 	<jobString>Distilling bottles of Tequila.</jobString>
 	<workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -301,7 +301,7 @@
 
 <RecipeDef>
 	<defName>DistillWhisky</defName>
-	<label>Distill Whisky</label>
+	<label>distill whisky</label>
 	<description>Distills bottles of Whisky from Corn. Produces 8.</description>
 	<jobString>Distilling bottles of Whisky.</jobString>
 	<workSpeedStat>BrewingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Bakery.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Bakery.xml
@@ -5,7 +5,7 @@
 	
 	<RecipeDef>
 		<defName>MakePizza</defName>
-		<label>Bake Pizza</label>
+		<label>bake pizza</label>
 		<description>Bakes a pizza from Flour, Cheese and Tomatoes. Scrumptious! Produces 1.</description>
 		<jobString>Baking Pizza.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -60,7 +60,7 @@
 	
 	<RecipeDef>
 		<defName>MakeCheeseGrilled</defName>
-		<label>Cook Grilled Cheese</label>
+		<label>cook grilled cheese</label>
 		<description>Cooks a sandwich from bread and cheese. Produces 1.</description>
 		<jobString>Cooking Grilled Cheese.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -105,7 +105,7 @@
 	
 	<RecipeDef>
 		<defName>MakeBurgerCheese</defName>
-		<label>Cook Cheese Burger</label>
+		<label>cook cheese burger</label>
 		<description>Cooks a burger made from bread, meat and Cheese. Delicious. Produces 1.</description>
 		<jobString>Cooking Cheese Burger.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -184,7 +184,7 @@
 
 	<RecipeDef>
 		<defName>MakePieBlueberry</defName>
-		<label>Bake Blueberry Pies</label>
+		<label>bake blueberry pies</label>
 		<description>Bake tasty blueberry pies. Produces 5.</description>
 		<jobString>Baking Blueberry Pies.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -243,7 +243,7 @@
 	
 	<RecipeDef>
 		<defName>MakePiePumpkin</defName>
-		<label>Bake Pumpkin Pies</label>
+		<label>bake pumpkin pies</label>
 		<description>Stuff the intestines of Pumpkins into dough to make sweet aromatic pies. Produces 5.</description>
 		<jobString>Baking Pumpkin Pies.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -305,7 +305,7 @@
 
 	<RecipeDef>
 		<defName>MakeTaffy</defName>
-		<label>Make Taffy Candies</label>
+		<label>make taffy candies</label>
 		<description>Turns sugar into taffy. Taffy is a type of sweet, chewable candy. Produces 4.</description>
 		<jobString>Making taffy candies.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -349,7 +349,7 @@
 	
 	<RecipeDef>
 		<defName>MakeCookies</defName>
-		<label>Bake Chocolate Cookies</label>
+		<label>bake chocolate cookies</label>
 		<description>Bakes cookies from Flour, Sugar and Chocolate. Produces 5.</description>
 		<jobString>Baking Chocolate Cookies.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -408,7 +408,7 @@
 	
 	<RecipeDef>
 		<defName>MakeSweetBun</defName>
-		<label>Bake Sweet Rolls</label>
+		<label>bake sweet rolls</label>
 		<description>Bakes Sweet Rolls covered in sugary icying. Produces 5.</description>
 		<jobString>Baking Sweet Rolls.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Canned.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Canned.xml
@@ -3,7 +3,7 @@
 
 <RecipeDef>
 	<defName>MakeBasicCannedFood</defName>
-	<label>Make Basic Canned Food</label>
+	<label>make basic canned food</label>
 	<description>Preserve plant ingredients in cans to prevent spoiling. Produces 75.</description>
 	<jobString>Canning plant ingredients.</jobString>
 	<workSpeedStat>CookSpeed</workSpeedStat>
@@ -51,7 +51,7 @@
 
 <RecipeDef>
 	<defName>MakeExtraCannedFood</defName>
-	<label>Make Extra Canned Food</label>
+	<label>make extra canned food</label>
 	<description>Preserve plant ingredients in cans to prevent spoiling. Produces 75.</description>
 	<jobString>Canning extra plant ingriedents.</jobString>
 	<workSpeedStat>CookSpeed</workSpeedStat>
@@ -99,7 +99,7 @@
 
 <RecipeDef>
 	<defName>MakeMetalCannedMeat</defName>
-	<label>Make Canned Meat</label>
+	<label>make canned meat</label>
 	<description>Preserve meat in cans to prevent spoiling. Produces 75.</description>
 	<jobString>Canning meat.</jobString>
 	<workSpeedStat>CookSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Drinks.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Drinks.xml
@@ -3,7 +3,7 @@
 
 	<RecipeDef>
 		<defName>MakeFruitYogurt</defName>
-		<label>Make Fruit Yogurts</label>
+		<label>make fruit yogurts</label>
 		<description>Make Yogurts from Milk or Soy Milk and some fruits. Produces 3.</description>
 		<jobString>Making Yogurts.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -52,7 +52,7 @@
 	
 	<RecipeDef>
 		<defName>MakeFruitYogurt_Bulk</defName>
-		<label>Make Fruit Yogurts</label>
+		<label>make fruit yogurts</label>
 		<description>Make Yogurts from Milk or Soy Milk and some fruits. Produces 10.</description>
 		<jobString>Making Yogurts.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -104,7 +104,7 @@
 	
 	<RecipeDef>
 		<defName>MakeChocoMilk</defName>
-		<label>Make Chocolate Milks</label>
+		<label>make chocolate milks</label>
 		<description>Mix Milk or Soy Milk with Chocolate for tastier beverages. Produces 3.</description>
 		<jobString>Making Chocolate milks.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -152,7 +152,7 @@
 	
 	<RecipeDef>
 		<defName>MakeChocoMilk_Bulk</defName>
-		<label>Make Chocolate Milks</label>
+		<label>make chocolate milks</label>
 		<description>Mix Milk or Soy Milk with Chocolate for tastier beverages. Produces 10.</description>
 		<jobString>Making Chocolate Milks.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -203,7 +203,7 @@
 	
 <RecipeDef>
 	<defName>BrewTea</defName>
-	<label>Brew Cups of Tea</label>
+	<label>brew cups of tea</label>
 	<description>Prepare Tea Leaves and brew them into cups of tea. Produces 3.</description>
 	<jobString>Brewing cups of Tea.</jobString>
 	<workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -255,7 +255,7 @@
 	
 <RecipeDef>
 	<defName>BrewCoffee</defName>
-	<label>Brew Cups of Coffee</label>
+	<label>brew cups of coffee</label>
 	<description>Brews cups of Coffee. Produces 5.</description>
 	<jobString>Brewing Coffee.</jobString>
 	<workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -298,7 +298,7 @@
 
 	<RecipeDef>
 		<defName>MakeFruitDrink</defName>
-		<label>Make Fruit Drinks</label>
+		<label>make fruit drinks</label>
 		<description>Press fruit to make a tasty fruit drinks. Produces 3.</description>
 		<jobString>Making Fruit Drinks.</jobString>
 		<workSpeedStat>BrewingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Ingridients.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Ingridients.xml
@@ -3,7 +3,7 @@
 
   <RecipeDef>
     <defName>MakeSugar</defName>
-    <label>Grind Sugarcane</label>
+    <label>grind sugarcane</label>
     <description>Beat and grind those canes to get at that sugar! Produces 3.</description>
     <jobString>Grinding Sugarcane into Sugar.</jobString>
     <workAmount>500</workAmount>
@@ -44,7 +44,7 @@
    
   <RecipeDef>
     <defName>MakeFlour</defName>
-    <label>Grind Flour</label>
+    <label>grind flour</label>
     <description>Grind Wheat, Corn, Rice or Oats into Flour. Produces 6.</description>
     <jobString>Grinding Flour.</jobString>
     <workSpeedStat>CookSpeed</workSpeedStat>
@@ -91,7 +91,7 @@
   
 	<RecipeDef>
 		<defName>CraftCornmeal</defName>
-		<label>Grind corn</label>
+		<label>grind corn</label>
 		<description>Grind corn into cornmeal. Produces 4.</description>
 		<jobString>Grinding corn.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -126,7 +126,7 @@
   
   <RecipeDef>
     <defName>Makesoymilk</defName>
-    <label>Make Soy Milk</label>
+    <label>make soy milk</label>
     <description>Press Beans into Soy Milk. Produces 4.</description>
     <jobString>Pressing Beans into Soy Milk.</jobString>
     <workSpeedStat>CookSpeed</workSpeedStat>
@@ -166,7 +166,7 @@
 
 	<RecipeDef>
 		<defName>MakeChocolate</defName>
-		<label>Make Chocolates</label>
+		<label>Make chocolates</label>
 		<description>Roast Cocoa Beans and Sugar to make Chocolate, a sweet treat. Produces 5.</description>
 		<jobString>Making Chocolates.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -220,7 +220,7 @@
 
 	<RecipeDef>
 		<defName>MakeCaramel</defName>
-		<label>Make Caramel Snacks</label>
+		<label>make caramel snacks</label>
 		<description>Turns sugar into a Caramel Snacks. Produces 3.</description>
 		<jobString>Making Caramel Snacks.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -263,7 +263,7 @@
 	
 	<RecipeDef>
 		<defName>MakeBread</defName>
-		<label>Bake Bread Loaves</label>
+		<label>bake bread loaves</label>
 		<description>Bakes Loaves of Bread. Produces 2.</description>
 		<jobString>Baking Bread Loaves.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -300,7 +300,7 @@
 	
 	<RecipeDef>
 		<defName>Makecheese</defName>
-		<label>Make Cheese</label>
+		<label>make cheese</label>
 		<description>Turns Milk or Soy Milk into cheese. Produces 4.</description>
 		<jobString>Pressing Cheese.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Livestock.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Livestock.xml
@@ -3,7 +3,7 @@
 
  	<RecipeDef Name="CookCatFood">
 		<defName>CookCatFood</defName>
-		<label>Make Cat Food</label>
+		<label>make cat food</label>
 		<description>Creates Cat Food from raw meat and plant ingredients. Your cats are guaranteed to love it! Produces 20.</description>
 		<jobString>Making Cat Food.</jobString>
     	<workAmount>100</workAmount>
@@ -69,7 +69,7 @@
 	
 		<RecipeDef>
 		<defName>MakeSilage</defName>
-		<label>Make Silage</label>
+		<label>make silage</label>
 		<description>Make Silage from Hay and plant ingredients for animal food. It is more nutritional than hay. Produces 30.</description>
 		<jobString>Making Silage.</jobString>
 		<workSpeedStat>BrewingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Medicals.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Medicals.xml
@@ -4,7 +4,7 @@
 	
   <RecipeDef>
     <defName>MakeTincture</defName>
-    <label>Make Mushroom Tincture</label>
+    <label>make mushroom tincture</label>
     <description>Instill mushrooms into tincture. Useful for medicine. Produces 1.</description>
     <jobString>Making Mushroom Tincture.</jobString>
     <workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -47,7 +47,7 @@
   
     <RecipeDef>
     <defName>MakeTincture_Bulk</defName>
-    <label>Make bottles of Mushroom Tincture</label>
+    <label>make bottles of mushroom tincture</label>
     <description>Instill a few bottles of tincture from mushrooms. Useful for medicine. Produces 4.</description>
     <jobString>Making bottles of Mushroom Tincture.</jobString>
     <workSpeedStat>BrewingSpeed</workSpeedStat>
@@ -93,7 +93,7 @@
 
   <RecipeDef>
     <defName>BrewMedicalDrink</defName>
-    <label>Brew Medical Drink</label>
+    <label>brew medical drink</label>
     <description>Brew a bottle of healthy medical drink from Healroot and Hops. Produces 1.</description>
     <jobString>Brewing Medical Drink.</jobString>
     <workSpeedStat>BrewingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Mushrooms.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Mushrooms.xml
@@ -4,7 +4,7 @@
 	
 	<RecipeDef>
 		<defName>MakeRoastwMushrooms</defName>
-		<label>Cook Pot Roast and Mushrooms</label>
+		<label>cook pot roast and mushrooms</label>
 		<description>Prepare a roast with seared mushrooms on top. Produces 1.</description>
 		<jobString>Cooking Pot Roast and Mushrooms.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -83,7 +83,7 @@
 	
 	<RecipeDef>
 		<defName>MakeRoastwMushrooms_Bulk</defName>
-		<label>Cook a bulk of Pot Roast and Mushrooms</label>
+		<label>cook pot roast and mushrooms (x4)</label>
 		<description>Prepare a couple of pots and throw in a roast and a couple of mushrooms in each one and wait ... Bam! Post Roast and Mushrooms. Produces 4.</description>
 		<jobString>Cooking Pot Roast and Mushrooms.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -165,7 +165,7 @@
 	
 	<RecipeDef>
 		<defName>MakeStewMushrooms</defName>
-		<label>Cook Mushroom Stew</label>
+		<label>cook mushroom stew</label>
 		<description>Prepares a hearty stew of mushrooms. Produces 1.</description>
 		<jobString>Cooking Mushroom Stew.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -218,7 +218,7 @@
 	
 	<RecipeDef>
 		<defName>MakeStewMushrooms_Bulk</defName>
-		<label>Cook Mushroom Stews</label>
+		<label>cook mushroom stew (x4)</label>
 		<description>Prepares hearty stews of mushrooms. Produces 4.</description>
 		<jobString>Cooking Mushroom Stews.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -276,7 +276,7 @@
 
 	<RecipeDef>
 		<defName>MakeSaladwMushrooms</defName>
-		<label>Make Mushroom Salad</label>
+		<label>make mushroom salad</label>
 		<description>Prepares a salad of mushrooms. Produces 1.</description>
 		<jobString>Making Mushroom Salad.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -344,7 +344,7 @@
 	
 		<RecipeDef>
 		<defName>MakeSaladwMushrooms_Bulk</defName>
-		<label>Make Mushroom Salads</label>
+		<label>make mushroom salads (x4)</label>
 		<description>Prepares several salads of mushrooms. Produces 4.</description>
 		<jobString>Making Mushroom Salads.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorBrick.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorBrick.xml
@@ -100,7 +100,7 @@
 	
   <TerrainDef>
     <DefName>ClayBrickTile</DefName>
-    <label>Clay Tile</label>
+    <label>clay tile</label>
     <Description>Solid clay tiles for a castle feeling.
 Beauty: 2.</Description>
     <color>(163,109,64)</color>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorCarpet.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorCarpet.xml
@@ -5,7 +5,7 @@
 		<PathCost>-1</PathCost>
 		<statBases>
 			<WorkToBuild>1200</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 		<Fertility>0</Fertility>
@@ -26,62 +26,62 @@
 		</CostList>
 		<statBases>
 			<WorkToBuild>1200</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 	</TerrainDef>
 
 
 	<TerrainDef ParentName="CarpetBase">
 		<DefName>CarpetBeige</DefName>
-		<label>Beige Carpet</label>
+		<label>beige carpet</label>
 		<RenderPrecedence>197</RenderPrecedence>
 		<Description>Stunning beige carpet that is soft and relaxing. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CarpetBeige</texturePath>
 	</TerrainDef>	
 
 	<TerrainDef ParentName="CarpetBase">
 		<DefName>CarpetRed</DefName>
-		<label>Red Carpet</label>
+		<label>red carpet</label>
 		<RenderPrecedence>200</RenderPrecedence>
 		<Description>Plush carpet in a lovely rose hue. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<color>(118,49,57)</color>
 	</TerrainDef>
 
 	<TerrainDef ParentName="CarpetBase">
 		<DefName>CarpetGreen</DefName>
-		<label>Green Carpet</label>
+		<label>green carpet</label>
 		<RenderPrecedence>199</RenderPrecedence>
 		<Description>Naturalistic-feeling green carpet. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<color>(89,105,62)</color>
 	</TerrainDef>
 
 	<TerrainDef ParentName="CarpetBase">
 		<DefName>CarpetBlue</DefName>
-		<label>Blue Carpet</label>
+		<label>blue carpet</label>
 		<RenderPrecedence>198</RenderPrecedence>
 		<Description>Toe-hugging plush carpet in a cool blue color. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<color>(24,65,121)</color>
 	</TerrainDef>
 
 	<TerrainDef ParentName="CarpetBase">
 		<DefName>CarpetCream</DefName>
-		<label>Cream Carpet</label>
+		<label>cream carpet</label>
 		<RenderPrecedence>197</RenderPrecedence>
 		<Description>Inviting cream-colored carpet. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<color>(195,192,176)</color>
 	</TerrainDef>
 
 	<TerrainDef ParentName="CarpetBase">
 		<DefName>CarpetDark</DefName>
-		<label>Dark Carpet</label>
+		<label>dark carpet</label>
 		<RenderPrecedence>196</RenderPrecedence>
 		<Description>Professional-looking dark gray carpet. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<color>(81,81,81)</color>
 	</TerrainDef>
 
@@ -91,10 +91,10 @@ Beauty: 4.</Description>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CarpetOrange</DefName>
-		<Label>Orange Carpet</Label>
+		<Label>orange carpet</Label>
 		<RenderPrecedence>199</RenderPrecedence>
 		<Description>Soft carpet with a vivid marigold tint. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/Carpet</texturePath>
 		<researchPrerequisites><li>CarpetMaking</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -104,17 +104,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CarpetYellow</DefName>
-		<Label>Yellow Carpet</Label>
+		<Label>yellow carpet</Label>
 		<RenderPrecedence>198</RenderPrecedence>
 		<Description>A summer yellow-coloured carpet. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/Carpet</texturePath>
 		<researchPrerequisites><li>CarpetMaking</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -124,17 +124,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CarpetTurquoise</DefName>
-		<Label>Turquoise Carpet</Label>
+		<Label>turquoise carpet</Label>
 		<RenderPrecedence>197</RenderPrecedence>
 		<Description>A soothing blue-green carpet. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/Carpet</texturePath>
 		<researchPrerequisites><li>CarpetMaking</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -144,17 +144,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CarpetPurple</DefName>
-		<Label>Purple Carpet</Label>
+		<Label>purple carpet</Label>
 		<RenderPrecedence>196</RenderPrecedence>
 		<Description>Carpet in a majestic purple shade. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/Carpet</texturePath>
 		<researchPrerequisites><li>CarpetMaking</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -164,17 +164,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CarpetWhite</DefName>
-		<Label>White Carpet</Label>
+		<Label>white carpet</Label>
 		<RenderPrecedence>195</RenderPrecedence>
 		<Description>Undyed white carpet. Comfortable underfoot but stains easily. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/Carpet</texturePath>
 		<researchPrerequisites><li>CarpetMaking</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -183,17 +183,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CarpetBlack</DefName>
-		<Label>Black Carpet</Label>
+		<Label>black Carpet</Label>
 		<RenderPrecedence>194</RenderPrecedence>
 		<Description>A carpet in brooding black. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/Carpet</texturePath>
 		<researchPrerequisites><li>CarpetMaking</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -203,7 +203,7 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
@@ -215,10 +215,10 @@ Beauty: 4.</Description>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CheckCarpetRed</DefName>
-		<Label>Red Checkered Carpet</Label>
+		<Label>red checkered carpet</Label>
 		<RenderPrecedence>190</RenderPrecedence>
 		<Description>Checker board pattern carpet in a lovely rose hue. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CheckCarpet</texturePath>
 		<researchPrerequisites><li>CarpetMakingII</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -228,17 +228,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CheckCarpetOrange</DefName>
-		<Label>Orange Checkered Carpet</Label>
+		<Label>orange checkered carpet</Label>
 		<RenderPrecedence>189</RenderPrecedence>
 		<Description>Carpeting with a checker board pattern in a vivid marigold tint. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CheckCarpet</texturePath>
 		<researchPrerequisites><li>CarpetMakingII</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -248,17 +248,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CheckCarpetYellow</DefName>
-		<Label>Yellow Checkered Carpet</Label>
+		<Label>yellow checkered carpet</Label>
 		<RenderPrecedence>188</RenderPrecedence>
 		<Description>Summer yellow-colored checker board pattern carpet.
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CheckCarpet</texturePath>
 		<researchPrerequisites><li>CarpetMakingII</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -268,17 +268,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CheckCarpetGreen</DefName>
-		<Label>Green Checkered Carpet</Label>
+		<Label>green checkered carpet</Label>
 		<RenderPrecedence>187</RenderPrecedence>
 		<Description>Naturalistic-feeling green checker board pattern carpet. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CheckCarpet</texturePath>
 		<researchPrerequisites><li>CarpetMakingII</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -288,17 +288,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CheckCarpetTurquoise</DefName>
-		<Label>Turquoise Checkered Carpet</Label>
+		<Label>turquoise checkered carpet</Label>
 		<RenderPrecedence>186</RenderPrecedence>
 		<Description>A soothing blue-green checker board pattern carpet. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CheckCarpet</texturePath>
 		<researchPrerequisites><li>CarpetMakingII</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -308,17 +308,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CheckCarpetBlue</DefName>
-		<Label>Blue Checkered Carpet</Label>
+		<Label>blue checkered carpet</Label>
 		<RenderPrecedence>185</RenderPrecedence>
 		<Description>Toe-hugging plush checker board pattern carpet in a cool blue color. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CheckCarpet</texturePath>
 		<researchPrerequisites><li>CarpetMakingII</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -328,17 +328,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CheckCarpetPurple</DefName>
-		<Label>Purple Checkered Carpet</Label>
+		<Label>purple checkered carpet</Label>
 		<RenderPrecedence>184</RenderPrecedence>
 		<Description>Checker board pattern carpet in a majestic purple shade. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CheckCarpet</texturePath>
 		<researchPrerequisites><li>CarpetMakingII</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -348,17 +348,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CheckCarpetWhite</DefName>
-		<Label>White Checkered Carpet</Label>
+		<Label>white checkered carpet</Label>
 		<RenderPrecedence>183</RenderPrecedence>
 		<Description>Undyed white checker board pattern carpet. Comfortable underfoot but stains easily. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CheckCarpet</texturePath>
 		<researchPrerequisites><li>CarpetMakingII</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -367,17 +367,17 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>CheckCarpetBlack</DefName>
-		<Label>Black Checkered Carpet</Label>
+		<Label>black checkered carpet</Label>
 		<RenderPrecedence>182</RenderPrecedence>
 		<Description>A checker board pattern carpet in brooding black. 
-Beauty: 4.</Description>
+Beauty: 3.</Description>
 		<texturePath>Terrain/Surfaces/CheckCarpet</texturePath>
 		<researchPrerequisites><li>CarpetMakingII</li></researchPrerequisites>
 		<PathCost>-1</PathCost>
@@ -387,7 +387,7 @@ Beauty: 4.</Description>
 		</CostList>
 		<statBases>
 			<WorkToBuild>1500</WorkToBuild>
-			<Beauty>4</Beauty>
+			<Beauty>3</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 	</TerrainDef>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorMetallic.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorMetallic.xml
@@ -3,7 +3,7 @@
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>SilverTile</DefName>
-		<label>Silver Tile</label>
+		<label>silver tile</label>
 		<RenderPrecedence>241</RenderPrecedence>
 		<Description>Expensive and slow to build. Soft grey tiles with a grey bordering. 
 Beauty: 3.</Description>
@@ -23,7 +23,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>SterileTile</DefName>
-		<label>Sterile Tile</label>
+		<label>sterile tile</label>
 		<RenderPrecedence>243</RenderPrecedence>
 		<Description>Sterile tiles are clean, light grey squares. Very useful in hospitals to help prevent infections. Quite slow to build. 
 Beauty: 0.</Description>
@@ -44,7 +44,7 @@ Beauty: 0.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>MetalTile</DefName>
-		<label>White Metal Tile</label>
+		<label>white metal tile</label>
 		<RenderPrecedence>240</RenderPrecedence>
 		<Description>White metal square tiles, for that spaceship look. 
 Beauty: 3.</Description>
@@ -62,7 +62,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>MetalTile2</DefName>
-		<label>Black Metal Tile</label>
+		<label>black metal tile</label>
 		<RenderPrecedence>240</RenderPrecedence>
 		<Description>Black metal square tiles, for that spaceship look. 
 Beauty: 3.</Description>
@@ -80,7 +80,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>MetalTile3</DefName>
-		<label>Grey Metal Tile</label>
+		<label>grey metal tile</label>
 		<RenderPrecedence>240</RenderPrecedence>
 		<Description>Square grey metal tiles with thin borders. 
 Beauty: 3.</Description>
@@ -98,7 +98,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>MetalTile4</DefName>
-		<label>Patterned Metal Tile</label>
+		<label>patterned metal tile</label>
 		<RenderPrecedence>240</RenderPrecedence>
 		<Description>Grey metal tiles with fancy patterns. 
 Beauty: 3.</Description>
@@ -185,7 +185,7 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>GoldTile</DefName>
-		<label>Gold Tile</label>
+		<label>gold tile</label>
 		<RenderPrecedence>240</RenderPrecedence>
 		<Description>Gold tiles, because you're worth it. 
 Beauty: 5.</Description>
@@ -205,7 +205,7 @@ Beauty: 5.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>GoldSolid</DefName>
-		<label>Solid Gold</label>
+		<label>solid gold</label>
 		<RenderPrecedence>240</RenderPrecedence>
 		<Description>Solid gold, because you're wasteful.
 Beauty: 10.</Description>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorStone.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorStone.xml
@@ -3,11 +3,11 @@
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsSandstone</DefName>
-		<Label>Stone Slabs (Sandstone)</Label>
+		<Label>sandstone slabs</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>270</RenderPrecedence>
-		<Description>Stone flooring made with square slabs. Sandstone version. 
-Beauty: 3.</Description>
+		<Description>Sandstone flooring made with square slabs. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites><li>FloorArtIII</li></researchPrerequisites>
 		<CostList>
@@ -18,11 +18,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsGranite</DefName>
-		<Label>Stone Slabs (Granite)</Label>
+		<Label>granite slabs</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>270</RenderPrecedence>
-		<Description>Stone flooring made with square slabs. Granite version.
-Beauty: 3.</Description>
+		<Description>Granite flooring made with square slabs.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites><li>FloorArtIII</li></researchPrerequisites>
 		<CostList>
@@ -33,11 +33,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsLimestone</DefName>
-		<Label>Stone Slabs (Limestone)</Label>
+		<Label>limestone slabs</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>270</RenderPrecedence>
-		<Description>Stone flooring made with square slabs. Limestone version. 
-Beauty: 3.</Description>
+		<Description>Limestone flooring made with square slabs. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites><li>FloorArtIII</li></researchPrerequisites>
 		<CostList>
@@ -48,11 +48,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsSlate</DefName>
-		<Label>Stone Slabs (Slate)</Label>
+		<Label>slate slabs</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>270</RenderPrecedence>
-		<Description>Stone flooring made with square slabs. Slate version. 
-Beauty: 3.</Description>
+		<Description>Slate flooring made with square slabs. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites><li>FloorArtIII</li></researchPrerequisites>
 		<CostList>
@@ -63,11 +63,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<DefName>FloorStoneSlabsMarble</DefName>
-		<Label>Stone Slabs (Marble)</Label>
+		<Label>marble slabs</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>270</RenderPrecedence>
-		<Description>Stone flooring made with square slabs. Marble version. 
-Beauty: 3.</Description>
+		<Description>Marble flooring made with square slabs. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites><li>FloorArtIII</li></researchPrerequisites>
 		<CostList>
@@ -80,11 +80,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexSandstone</defName>
-		<Label>Hex Paving (Sandstone)</Label>
+		<Label>sandstone hex paving</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Sandstone version. 
-Beauty: 3.</Description>
+		<Description>Sandstone paving with hexagonal tiles. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -95,11 +95,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexGranite</defName>
-		<Label>Hex Paving (Granite)</Label>
+		<Label>granite hex paving</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Granite version. 
-Beauty: 3.</Description>
+		<Description>Granite paving with hexagonal tiles.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -110,11 +110,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexLimestone</defName>
-		<Label>Hex Paving (Limestone)</Label>
+		<Label>limestone hex paving</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Limestone version. 
-Beauty: 3.</Description>
+		<Description>Limestone paving with hexagonal tiles. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -125,11 +125,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexSlate</defName>
-		<Label>Hex Paving (Slate)</Label>
+		<Label>slate hex paving</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Slate version. 
-Beauty: 3.</Description>
+		<Description>Slate paving with hexagonal tiles. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -140,11 +140,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneHexMarble</defName>
-		<Label>Hex Paving (Marble)</Label>
+		<Label>marble hex paving</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>269</RenderPrecedence>
-		<Description>Stone paving with hexagonal tiles. Marble version. 
-Beauty: 3.</Description>
+		<Description>Marble paving with hexagonal tiles. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -157,11 +157,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicSandstone</defName>
-		<Label>Mosaic Paving (Sandstone)</Label>
+		<Label>sandstone mosaic paving</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Sandstone version. 
-Beauty: 3.</Description>
+		<Description>Sandstone paving with a light/dark mosaic. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -172,11 +172,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicGranite</defName>
-		<Label>Mosaic Paving (Granite)</Label>
+		<Label>granite mosaic paving</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Granite version. 
-Beauty: 3.</Description>
+		<Description>Granite paving with a light/dark mosaic. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -187,11 +187,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicLimestone</defName>
-		<Label>Mosaic Paving (Limestone)</Label>
+		<Label>limestone mosaic paving</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Limestone version. 
-Beauty: 3.</Description>
+		<Description>Limestone paving with a light/dark mosaic. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -202,11 +202,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicSlate</defName>
-		<Label>Mosaic Paving (Slate)</Label>
+		<Label>slate mosaic paving</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Slate version. 
-Beauty: 3.</Description>
+		<Description>Slate paving with a light/dark mosaic. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -217,11 +217,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneMosaicMarble</defName>
-		<Label>Mosaic Paving (Marble)</Label>
+		<Label>marble mosaic paving</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>268</RenderPrecedence>
-		<Description>Stone paving with a light/dark mosaic. Marble version. 
-Beauty: 3.</Description>
+		<Description>Marble paving with a light/dark mosaic. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites><li>FloorArtIV</li></researchPrerequisites>
 		<CostList>
@@ -234,11 +234,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughSandstone</defName>
-		<Label>Rough Paving (Sandstone)</Label>
+		<Label>rough sandstone paving</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Sandstone version. 
-Beauty: 3.</Description>
+		<Description>Sandstone stone paving. 
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
 		<CostList>
@@ -249,11 +249,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughGranite</defName>
-		<Label>Rough Paving (Granite)</Label>
+		<Label>rough granite paving</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Granite version. 
-Beauty: 3.</Description>
+		<Description>Rough stone paving.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
 		<CostList>
@@ -264,11 +264,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughLimestone</defName>
-		<Label>Rough Paving (Limestone)</Label>
+		<Label>rough limestone paving</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Limestone version. 
-Beauty: 3.</Description>
+		<Description>Rough stone paving.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
 		<CostList>
@@ -279,11 +279,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughSlate</defName>
-		<Label>Rough Paving (Slate)</Label>
+		<Label>rough slate paving</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Slate version. 
-Beauty: 3.</Description>
+		<Description>Rough stone paving.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
 		<CostList>
@@ -294,11 +294,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRoughMarble</defName>
-		<Label>Rough Paving (Marble)</Label>
+		<Label>rough marble paving</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>267</RenderPrecedence>
-		<Description>Rough stone paving. Marble version. 
-Beauty: 3.</Description>
+		<Description>Rough stone paving.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites><li>FloorArt</li></researchPrerequisites>
 		<CostList>
@@ -311,11 +311,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomSandstone</defName>
-		<Label>Random Paving (Sandstone)</Label>
+		<Label>random sandstone paving</Label>
 		<color>(126,104,94)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Sandstone version. 
-Beauty: 3.</Description>
+		<Description>Stone paving with random square and rectangular slabs.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>
 		<CostList>
@@ -326,11 +326,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomGranite</defName>
-		<Label>Random Paving (Granite)</Label>
+		<Label>random granite paving</Label>
 		<color>(105,95,97)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Granite version. 
-Beauty: 3.</Description>
+		<Description>Stone paving with random square and rectangular slabs.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>
 		<CostList>
@@ -341,11 +341,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomLimestone</defName>
-		<Label>Random Paving (Limestone)</Label>
+		<Label>random limestone paving</Label>
 		<color>(158,153,135)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Limestone version. 
-Beauty: 3.</Description>
+		<Description>Stone paving with random square and rectangular slabs.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>
 		<CostList>
@@ -356,11 +356,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomSlate</defName>
-		<Label>Random Paving (Slate)</Label>
+		<Label>random slate paving</Label>
 		<color>(70,70,70)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Slate version. 
-Beauty: 3.</Description>
+		<Description>Stone paving with random square and rectangular slabs.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>
 		<CostList>
@@ -371,11 +371,11 @@ Beauty: 3.</Description>
 
 	<TerrainDef ParentName="TileStoneBase">
 		<defName>FloorStoneRandomMarble</defName>
-		<Label>Random Paving (Marble)</Label>
+		<Label>random marble paving</Label>
 		<color>(132,135,132)</color>
 		<RenderPrecedence>266</RenderPrecedence>
-		<Description>Stone paving with random square and rectangular slabs. Marble version.
-Beauty: 3.</Description>
+		<Description>Stone paving with random square and rectangular slabs.
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites><li>FloorArtII</li></researchPrerequisites>
 		<CostList>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
@@ -6,14 +6,14 @@
 
 	<TerrainDef ParentName="FloorBase">
 		<DefName>ClutterWoodTileA</DefName>
-		<Label>Dark Wood Tiles</Label>
+		<Label>dark wood tiles</Label>
 		<RenderPrecedence>245</RenderPrecedence>
 		<Description>Dark wood panels with a dark border around each tile.
-Beauty: 3.</Description>
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/FloorA</texturePath>
 		<uiIconPath>Terrain/Surfaces/FloorAI</uiIconPath>
 		<statBases>
-			<Beauty>3</Beauty>
+			<Beauty>2</Beauty>
 		</statBases>
 		<CostList>
 			<WoodPlank>3</WoodPlank>
@@ -24,13 +24,13 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>WoodPlankFloor</DefName>
-		<label>Oak Planks</label>
+		<label>oak planks</label>
 		<RenderPrecedence>250</RenderPrecedence>
 		<Description>Unfinished oak. Long horizontal planks with a light coloring.
-Beauty: 3.</Description>
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/WoodFloor2</texturePath>
 		<statBases>
-			<Beauty>3</Beauty>
+			<Beauty>2</Beauty>
 		</statBases>
 		<CostList>
 			<WoodPlank>3</WoodPlank>
@@ -41,13 +41,13 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>WoodPlankFloor2</DefName>
-		<label>Brown Wood Floor</label>
+		<label>brown wood floor</label>
 		<RenderPrecedence>250</RenderPrecedence>
 		<Description>Thin vertical brown planks. For that warm homey feeling.
-Beauty: 3.</Description>
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/WoodFloor</texturePath>
 		<statBases>
-			<Beauty>3</Beauty>
+			<Beauty>2</Beauty>
 		</statBases>
 		<CostList>
 			<WoodPlank>3</WoodPlank>
@@ -58,13 +58,13 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>WoodPlankFloor3</DefName>
-		<label>Light Wood Planks</label>
+		<label>light wood planks</label>
 		<RenderPrecedence>250</RenderPrecedence>
 		<Description>Staggered joint, light colored wood flooring in short, horizontal planks.
-Beauty: 3.</Description>
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/WoodFloor3</texturePath>
 		<statBases>
-			<Beauty>3</Beauty>
+			<Beauty>2</Beauty>
 		</statBases>
 		<CostList>
 			<WoodPlank>3</WoodPlank>
@@ -75,13 +75,13 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>WoodPlankFloor4</DefName>
-		<label>Styled Wood Floor</label>
+		<label>styled wood floor</label>
 		<RenderPrecedence>250</RenderPrecedence>
 		<Description>Three small planks per tile that alternate from horizontal to vertical every other tile. Reddish brown in color.
-Beauty: 3.</Description>
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/WoodFloor4</texturePath>
 		<statBases>
-			<Beauty>3</Beauty>
+			<Beauty>2</Beauty>
 		</statBases>
 		<CostList>
 			<WoodPlank>3</WoodPlank>
@@ -92,13 +92,13 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>WoodPlankFloor5</DefName>
-		<label>Brown Wood Planks</label>
+		<label>brown wood planks</label>
 		<RenderPrecedence>250</RenderPrecedence>
 		<Description>Vertical medium sized planks with staggered joints. Brown in color.
-Beauty: 3.</Description>
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/WoodFloor5</texturePath>
 		<statBases>
-			<Beauty>3</Beauty>
+			<Beauty>2</Beauty>
 		</statBases>
 		<CostList>
 			<WoodPlank>3</WoodPlank>
@@ -109,13 +109,13 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>WoodPlankFloor6</DefName>
-		<label>Tan Wood Planks</label>
+		<label>tan wood planks</label>
 		<RenderPrecedence>250</RenderPrecedence>
 		<Description>Medium sized planks in a horizontal pattern with a tanned wood look.
-Beauty: 3.</Description>
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/WoodFloor1</texturePath>
 		<statBases>
-			<Beauty>3</Beauty>
+			<Beauty>2</Beauty>
 		</statBases>
 		<CostList>
 			<WoodPlank>3</WoodPlank>
@@ -126,13 +126,14 @@ Beauty: 3.</Description>
 
 	<TerrainDef  ParentName="FloorBase">
 		<DefName>ParquetFloor</DefName>
-		<label>Parquet</label>
+		<label>parquet</label>
 		<RenderPrecedence>250</RenderPrecedence>
 		<Description>Herringbone flooring. Regal elegance for the sophisticated colonist. Takes some time to build. 
-Beauty: 3.</Description>
+Beauty: 2.</Description>
 		<texturePath>Terrain/Surfaces/Parquet</texturePath>
 		<statBases>
-			<Beauty>3</Beauty>
+			<WorkToBuild>235</WorkToBuild>
+			<Beauty>2</Beauty>
 		</statBases>
 		<CostList>
 			<WoodPlank>4</WoodPlank>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_Natural.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_Natural.xml
@@ -3,7 +3,7 @@
 
 	<TerrainDef>
 		<defName>SoilRich</defName>
-		<label>Rich Soil</label>
+		<label>rich soil</label>
 		<texturePath>Terrain/Surfaces/Soilnew</texturePath>
 		<Description>Soil that has been enriched with Compost to improve crop growth.
 Fertility: 150%.</Description>
@@ -35,7 +35,7 @@ Fertility: 150%.</Description>
 
   <TerrainDef>
     <defName>Sand</defName>
-    <label>Sand</label>
+    <label>sand</label>
 	<Description>Sand is finely divided rock and mineral particles. Naturally found on beaches and deserts.
 Beauty: -1.</Description>
     <texturePath>Terrain/Surfaces/Sand</texturePath>
@@ -112,7 +112,7 @@ Beauty: -1.</Description>
  
    <TerrainDef>
     <defName>Gravel</defName>
-    <label>Gravel</label>
+    <label>gravel</label>
 	<Description>Gravel is a composition of small rocks of varying sizes. Rubble can be gathered from it.
 Beauty: -1.</Description>
     <texturePath>Terrain/Surfaces/Gravel</texturePath>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_NaturalNew.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_NaturalNew.xml
@@ -3,7 +3,7 @@
 
 	<TerrainDef>
 		<defName>SoilTilled</defName>
-		<label>Tilled Soil</label>
+		<label>tilled soil</label>
 		<Description>Tilled soil is enriched with Compost and synthetic ammonia for maximum fertility. It will allow you to plant crops properly.
 Fertility: 200%.</Description>
 		<texturePath>Terrain/Surfaces/SoilTilled</texturePath>
@@ -37,7 +37,7 @@ Fertility: 200%.</Description>
 	
   <TerrainDef>
     <defName>PoorSoil</defName>
-    <label>Poor Soil</label>
+    <label>poor soil</label>
 	<Description>Poor soil lacks the nutrients required to support plant growth.
 Fertility: 30%.</Description>
     <texturePath>Terrain/Surfaces/PoorSoil</texturePath>
@@ -62,7 +62,7 @@ Fertility: 30%.</Description>
 
   <TerrainDef>
     <defName>MarginalSoil</defName>
-    <label>Marginal Soil</label>
+    <label>marginal soil</label>
 	<Description>Marginal soil lacks enough nutrients to support plant growth.
 Fertility: 70%.</Description>
     <texturePath>Terrain/Surfaces/MarginalSoil</texturePath>
@@ -87,7 +87,7 @@ Fertility: 70%.</Description>
   
   <TerrainDef>
     <defName>DustySoil</defName>
-    <label>Dusty Soil</label>
+    <label>dusty soil</label>
     <Description>Dusty soil, too dry and barren to support plant growth.
 Fertility: 40%.</Description>
     <texturePath>Terrain/Surfaces/DustySoil</texturePath>
@@ -112,7 +112,7 @@ Fertility: 40%.</Description>
  
   <TerrainDef>
     <defName>Seabeach</defName>
-    <label>Seabeach</label>
+    <label>seabeach</label>
 	<Description>Sand is finely divided rock and mineral particles. Naturally found on beaches and deserts.
 Beauty: -1.</Description>
     <texturePath>Terrain/Surfaces/Seabeach</texturePath>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
@@ -5,7 +5,7 @@
 		<PathCost>-2</PathCost>
 		<statBases>
 			<WorkToBuild>400</WorkToBuild>
-			<Beauty>2</Beauty>
+			<Beauty>1</Beauty>
 		</statBases>
 		<designationCategory>Floors</designationCategory>
 		<Fertility>0</Fertility>
@@ -18,10 +18,10 @@
 
   <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>TikiFloorBamboo</DefName>
-    <label>Tiki Floor (Bamboo)</label>
+    <label>bamboo tiki floor</label>
     <RenderPrecedence>250</RenderPrecedence>
-    <Description>A nice tiki floor. 
-Beauty: 2.</Description>
+    <Description>A nice bamboo tiki floor. 
+Beauty: 1.</Description>
     <texturePath>Terrain/Surfaces/TikiFloorBamboo</texturePath>
 	<uiIconPath>Terrain/Surfaces/TikiFloorBambooIco</uiIconPath>
     <CostList>
@@ -32,10 +32,10 @@ Beauty: 2.</Description>
 
   <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>TikiFloorDark</DefName>
-    <label>Tiki Floor (Dark)</label>
+    <label>dark tiki floor</label>
     <RenderPrecedence>250</RenderPrecedence>
     <Description>A nice dark tiki floor. 
-Beauty: 2.</Description>
+Beauty: 1.</Description>
     <texturePath>Terrain/Surfaces/TikiFloorDark</texturePath>
 	<uiIconPath>Terrain/Surfaces/TikiFloorDarkIco</uiIconPath>
     <CostList>
@@ -46,10 +46,10 @@ Beauty: 2.</Description>
 
   <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>TikiFloorLight</DefName>
-    <label>Tiki Floor (Light)</label>
+    <label>light tiki floor</label>
     <RenderPrecedence>250</RenderPrecedence>
     <Description>A nice light tiki floor.
-Beauty: 2.</Description>
+Beauty: 1.</Description>
     <texturePath>Terrain/Surfaces/TikiFloorLight</texturePath>
 	<uiIconPath>Terrain/Surfaces/TikiFloorLightIco</uiIconPath>	
     <CostList>
@@ -60,7 +60,7 @@ Beauty: 2.</Description>
 
   <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>TikiFloorFancy</DefName>
-    <label>Tiki Floor (Fancy)</label>
+    <label>fancy tiki floor</label>
     <RenderPrecedence>250</RenderPrecedence>
     <Description>A nice fancy tiki floor with gold inlays.
 Beauty: 3.</Description>
@@ -79,10 +79,10 @@ Beauty: 3.</Description>
 
   <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>LogFloor</DefName>
-    <label>Log Floor</label>
+    <label>log floor</label>
     <RenderPrecedence>250</RenderPrecedence>
     <Description>A simple log floor.
-Beauty: 2.</Description>
+Beauty: 1.</Description>
     <texturePath>Terrain/Surfaces/LogFloor</texturePath>
 	<uiIconPath>Terrain/Surfaces/LogFloorIco</uiIconPath>	
     <CostList>
@@ -93,10 +93,10 @@ Beauty: 2.</Description>
 
   <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>ThatchFloor</DefName>
-    <label>Thatch Floor</label>
+    <label>thatch floor</label>
     <RenderPrecedence>250</RenderPrecedence>
     <Description>A primitive thatch floor.
-Beauty: 2.</Description>
+Beauty: 1.</Description>
     <texturePath>Terrain/Surfaces/ThatchFloor</texturePath>
 	<uiIconPath>Terrain/Surfaces/ThatchFloorIco</uiIconPath>	
     <CostList>
@@ -107,10 +107,10 @@ Beauty: 2.</Description>
 
  <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>WeaveFloor</DefName>
-    <label>Weave Floor</label>
+    <label>weave floor</label>
     <RenderPrecedence>250</RenderPrecedence>
     <Description>A nice woven floor.
-Beauty: 2.</Description>
+Beauty: 1.</Description>
     <texturePath>Terrain/Surfaces/WeaveFloor</texturePath>
 	<uiIconPath>Terrain/Surfaces/WeaveFloorIco</uiIconPath>	
     <CostList>
@@ -122,10 +122,10 @@ Beauty: 2.</Description>
 
  <TerrainDef  ParentName="PrimitiveFloorBase">
     <DefName>WovenLeafFloor</DefName>
-    <label>Woven Leaf Floor</label>
+    <label>woven leaf floor</label>
     <RenderPrecedence>250</RenderPrecedence>
     <Description>A nice woven leaf floor.
-Beauty: 2.</Description>
+Beauty: 1.</Description>
     <texturePath>Terrain/Surfaces/WovenLeafFloor</texturePath>
 	<uiIconPath>Terrain/Surfaces/WovenLeafFloorIco</uiIconPath>	
     <CostList>


### PR DESCRIPTION
Meals are ready. Will do the rest later.

This update now also includes rebalance to the floors. The stone floors' description stated a beauty of 3, but it was really set at 2. I noticed that vanilla also uses beauty 2 for stone, so I just updated the descriptions to match.

I then rebalanced the other floors to better align with this:
primitive floors: 1 (from 2)
all "regular" floors (stone, wood, bricks): 2 (from 3)
carpets: 3 (from 4)
floors involving components and silver: 3 (unchanged)
gold: 4+ (unchanged)

This better aligns with the vanilla balance and shouldn't make rooms so easily beautiful now as it was before.