### PR TITLE
Fill out leather stat factors for the megabadger and wooly rhino.

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Giants.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Giants.xml
@@ -497,6 +497,21 @@
       <leatherLabel>megabadger pelt</leatherLabel>
       <leatherColor>(130,102,50)</leatherColor>
       <leatherInsulation>1</leatherInsulation>
+      <leatherMarketValueFactor>7.0</leatherMarketValueFactor>
+      <leatherStatFactors>
+        <MaxHitPoints>1.7</MaxHitPoints>
+        <Beauty>1.5</Beauty>
+        <MarketValue>1.8</MarketValue>
+        <ArmorRating_Blunt>1.9</ArmorRating_Blunt>
+        <ArmorRating_Sharp>2.0</ArmorRating_Sharp>
+        <ArmorRating_Electric>1.2</ArmorRating_Electric>
+        <ArmorRating_Heat>1.3</ArmorRating_Heat>
+        <Insulation_Cold>1.2</Insulation_Cold>
+        <Insulation_Heat>1.0</Insulation_Heat>
+        <WorkToMake>1.8</WorkToMake>
+        <BedRestEffectiveness>0.85</BedRestEffectiveness>
+        <ImmunityGainSpeedFactor>1.0</ImmunityGainSpeedFactor>
+      </leatherStatFactors>
       <gestationPeriodDays>60</gestationPeriodDays>
       <wildness>0.98</wildness>
       <manhunterOnTameFailChance>0.10</manhunterOnTameFailChance>
@@ -623,10 +638,20 @@
       <leatherColor>(96,80,59)</leatherColor>
       <leatherLabel>wooly rhinohide</leatherLabel>
       <leatherInsulation>0.9</leatherInsulation>
-      <leatherMarketValueFactor>2</leatherMarketValueFactor>
+      <leatherMarketValueFactor>7</leatherMarketValueFactor>
       <leatherStatFactors>
+        <MaxHitPoints>1.6</MaxHitPoints>
+        <Beauty>0.9</Beauty>
+        <MarketValue>1.8</MarketValue>
         <ArmorRating_Blunt>2.5</ArmorRating_Blunt>
         <ArmorRating_Sharp>2.5</ArmorRating_Sharp>
+        <ArmorRating_Electric>1.0</ArmorRating_Electric>
+        <ArmorRating_Heat>1.5</ArmorRating_Heat>
+        <Insulation_Cold>1.4</Insulation_Cold>
+        <Insulation_Heat>0.4</Insulation_Heat>
+        <WorkToMake>1.7</WorkToMake>
+        <BedRestEffectiveness>0.8</BedRestEffectiveness>
+        <ImmunityGainSpeedFactor>0.75</ImmunityGainSpeedFactor>
       </leatherStatFactors>
       <useMeatFrom>Rhinoceros</useMeatFrom>
       <wildness>0.90</wildness>


### PR DESCRIPTION
The megabadger is in line with the megasloth, with slightly better blunt/sharp ratings and somewhat worse others. relative to rhino hide, the wooly rhino hide is slightly tougher, uglier/less valuable, and biased toward cold rather than heat insulation.