### PR TITLE
Touch up the burst-fire sniper rifles

### DIFF
--- a/Mods/CombatRealism/Defs/RecipeDefs_Ammo/Recipes_AmmoHighCaliber.xml
+++ b/Mods/CombatRealism/Defs/RecipeDefs_Ammo/Recipes_AmmoHighCaliber.xml
@@ -14,13 +14,13 @@
 	</recipeUsers>
   </RecipeDef>
   
-  <!-- ==================== 9x39mm Soviet sniper standart ========================== -->
+  <!-- ==================== 9x39mm Soviet sniper standard ========================== -->
 
   <RecipeDef ParentName="AmmoRecipeHighCaliber">
     <defName>MakeAmmo_9x39Soviet_FMJ</defName>
-    <label>make 9x39mm Soviet sniper standart cartridge x60</label>
-    <description>Craft 60 9x39mm Soviet sniper standart cartridges.</description>
-    <jobString>Making 9x39mm Soviet sniper standart cartridges.</jobString>
+    <label>make 9x39mm Soviet sniper standard cartridge x60</label>
+    <description>Craft 60 9x39mm Soviet sniper standard cartridges.</description>
+    <jobString>Making 9x39mm Soviet sniper standard cartridges.</jobString>
     <ingredients>
       <li>
         <filter>
@@ -71,9 +71,9 @@
   
   <RecipeDef ParentName="AmmoRecipeHighCaliber">
     <defName>MakeAmmo_9x39Soviet_SH</defName>
-    <label>make 9x39mm Soviet sniper standart cartridge x60</label>
-    <description>Craft 60 9x39mm Soviet sniper standart cartridges.</description>
-    <jobString>Making 9x39mm Soviet sniper standart cartridges.</jobString>
+    <label>make 9x39mm Soviet sniper shock cartridge x60</label>
+    <description>Craft 60 9x39mm Soviet sniper shock cartridges.</description>
+    <jobString>Making 9x39mm Soviet sniper shock cartridges.</jobString>
     <ingredients>
       <li>
         <filter>

--- a/Mods/Core_SK/Defs/ThingDefs_CR/Ammo.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_CR/Ammo.xml
@@ -216,7 +216,7 @@
   
   <ThingDef Class="Combat_Realism.AmmoDef" ParentName="9x39mmBase">
     <defName>Ammo_9x39Soviet_FMJ</defName>
-    <label>9x39mm Soviet sniper standart</label>
+    <label>9x39mm Soviet sniper standard</label>
     <description>It is based on the Russian 7.62×39 mm round, but with an expanded neck to accommodate a 9 mm (.356 caliber) bullet. Since the bullet weighs about twice as much as that of the 9×19mm Parabellum, its muzzle energy is about twice as high as that of a subsonic 9×19mm Parabellum bullet, e.g. when fired from a HK MP5SD.</description>
     <graphicData>
       <texPath>Things/Ammo/Rifle/AP</texPath>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SniperRifles.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SniperRifles.xml
@@ -171,6 +171,8 @@
         <projectileDef>Bullet_9x39Soviet_FMJ</projectileDef>
         <burstShotCount>3</burstShotCount>
         <ticksBetweenBurstShots>16</ticksBetweenBurstShots>
+        <recoilPattern>Regular</recoilPattern>
+        <recoilAmount>0.35</recoilAmount>
         <warmupTime>0.55</warmupTime>
         <range>54</range>
         <soundCast>SK_shotVintorez</soundCast>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SniperRiflesAdvanced.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SniperRiflesAdvanced.xml
@@ -336,12 +336,14 @@
         <projectileDef>Bullet_145x114mm_FMJ</projectileDef>
         <warmupTime>1.03</warmupTime>
         <range>70</range>
-		<burstShotCount>2</burstShotCount>
-		<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
-		<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
-		<targetParams>
-			<canTargetLocations>true</canTargetLocations>
-		</targetParams>
+        <burstShotCount>2</burstShotCount>
+        <ticksBetweenBurstShots>20</ticksBetweenBurstShots>
+        <recoilPattern>Regular</recoilPattern>
+        <recoilAmount>0.95</recoilAmount>
+        <ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
+        <targetParams>
+          <canTargetLocations>true</canTargetLocations>
+        </targetParams>
         <soundCast>SRSFire</soundCast>
         <soundCastTail>GunTail_Heavy</soundCastTail>
         <muzzleFlashScale>9</muzzleFlashScale>


### PR DESCRIPTION
Fix some labels for the 9x39mm ammo, and add missing recoil definitions for the VSS Vintorez and SRS99.