### PR TITLE
Fix caribou size

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -516,9 +516,9 @@
     <race>
       <body>QuadrupedAnimalWithHooves</body>
       <herdAnimal>true</herdAnimal>
-      <baseBodySize>1.9</baseBodySize>
+      <baseBodySize>0.9</baseBodySize>
       <baseHungerRate>0.95</baseHungerRate>
-      <baseHealthScale>1.9</baseHealthScale>
+      <baseHealthScale>1.7</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
       <leatherColor>(173,99,77)</leatherColor>
       <leatherInsulation>1.0</leatherInsulation>


### PR DESCRIPTION
They're nearly twice as large as elk. But irl, caribou are smaller than elk.