### PR TITLE
Gleamcap balance

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_CaveFlora/Items_Resource_Organic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_CaveFlora/Items_Resource_Organic.xml
@@ -89,7 +89,7 @@
       <MaxHitPoints>100</MaxHitPoints>
       <MarketValue>5.5</MarketValue>
       <Flammability>1.0</Flammability>
-      <MedicalPotency>0.85</MedicalPotency>
+      <MedicalPotency>0.5</MedicalPotency>
       <DeteriorationRate>10</DeteriorationRate>
     </statBases>
     <thingCategories>


### PR DESCRIPTION
85% medical potency was way too high compared to other, higher effort options. Even herbal medical kits aren't that high. 50% would put it in line with aloe (which is 45%).