### PR TITLE
Balance changes for barrels, baskets and chests

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -614,6 +614,10 @@
 			<exceptedCategories>
 				<li>Corpses</li>
 				<li>Chunks</li>
+				<li>StoneBlocks</li>
+				<li>Wooden</li>
+				<li>Woody</li>
+				<li>Metallic</li>
 			</exceptedCategories>
         </filter>
       </fixedStorageSettings>
@@ -660,6 +664,10 @@
 			<exceptedCategories>
 				<li>Corpses</li>
 				<li>Chunks</li>
+				<li>StoneBlocks</li>
+                                <li>Wooden</li>
+                                <li>Woody</li>
+                                <li>Metallic</li>			
 			</exceptedCategories>
         </filter>
       </fixedStorageSettings>
@@ -706,6 +714,10 @@
 			<exceptedCategories>
 				<li>Corpses</li>
 				<li>Chunks</li>
+				<li>StoneBlocks</li>
+                                <li>Wooden</li>
+                                <li>Woody</li>
+                                <li>Metallic</li>			
 			</exceptedCategories>
         </filter>
       </fixedStorageSettings>


### PR DESCRIPTION
They probably shouldn't be able to store very bulky resources like stone blocks, lumber and ingots. This is what the Skips are intended to be used for.