### PR TITLE
Cheese empire rebalance

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -224,8 +224,6 @@
 			<li>MakeTofu</li>
 			<li>Makesoymilk</li>
 			<li>MakeSugar</li>
-			<li>MakeFlour</li>
-			<li>Makecheese</li>
 			<li>MakeFruitDrink</li>
 			<li>MakeHerbMedicine</li>
 			<li>MakeKibble</li>
@@ -283,7 +281,6 @@
 			<li>Makesoymilk</li>
 			<li>MakeSugar</li>
 			<li>MakeFlour</li>
-			<li>Makecheese</li>
 			<li>MakeFruitDrink</li>
 			<li>MakeHerbMedicine</li>
 			<li>MakeKibble</li>
@@ -346,6 +343,7 @@
 			<li>MakeVegetables</li>
             <li>MakeBurgerCheese</li>
             <li>MakeCheeseGrilled</li>
+			<li>Makecheese</li>
 			<li>CookMealSalad</li>
 			<li>CookMealSimple</li>
 			<li>CookMealFine</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
@@ -48,6 +48,7 @@
 			<li>MakeRoastwMushrooms</li>
             <li>MakeBurgerCheese</li>
             <li>MakeCheeseGrilled</li>
+			<li>Makecheese</li>
 			<li>CookMealSalad</li>
 			<li>CookRoastedMeat</li>
 			<li>CookMealSimple</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Bakery.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Bakery.xml
@@ -3,7 +3,7 @@
 
 	<ThingDef ParentName="MealRottable">
     <defName>bread</defName>
-    <label>Bread</label>
+    <label>bread</label>
     <description>A freshly baked loaf of bread.</description>
     <graphicData>
       <texPath>Things/Item/Meal/Meal_Bread</texPath>
@@ -26,7 +26,7 @@
 
   <ThingDef ParentName="MealRottable">
       <defName>Cheese</defName>
-      <label>Cheese</label>
+      <label>cheese</label>
       <description>A block of cheese.</description>
       <graphicData>
       <texPath>Things/Item/Meal/Meal_Cheese</texPath>
@@ -42,13 +42,13 @@
       <foodType>Meal, Processed</foodType>
       <maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
          <preferability>MealSimple</preferability>
-         <nutrition>0.25</nutrition>
+         <nutrition>0.2</nutrition>
          <ingestEffect>EatVegetarian</ingestEffect>
          <ingestSound>Meal_Eat</ingestSound>
       </ingestible>
     <comps>
       <li Class="CompProperties_Rottable">
-        <daysToRotStart>60</daysToRotStart>
+        <daysToRotStart>30</daysToRotStart>
         <rotDestroys>true</rotDestroys>
       </li>
     </comps> 
@@ -56,7 +56,7 @@
 
   <ThingDef ParentName="MealRottable">
     <defName>CheeseBurger</defName>
-    <label>Cheese Burger</label>
+    <label>cheese burger</label>
       <description>Two slices of bread with grilled meat and cheese melt. \n\nFood Effects: Metabolism.</description>
     <graphicData>
       <texPath>Things/Item/Meal/Meal_BurgerCheese</texPath>
@@ -87,7 +87,7 @@
 
   <ThingDef ParentName="MealRottable">
       <defName>GrilledCheese</defName>
-      <label>Grilled Cheese Sandwich</label>
+      <label>grilled cheese sandwich</label>
       <description>Two slices of bread grilled with cheese melt in the middle. \n\nFood Effects: Metabolism.</description>
       <graphicData>
         <texPath>Things/Item/Meal/Meal_CheeseGrilled</texPath>
@@ -117,7 +117,7 @@
 
    <ThingDef ParentName="MealRottable">
       <defName>Pizza</defName>
-      <label>Pizza</label>
+      <label>pizza</label>
       <description>Pizza in 30 minutes or less! \n\nFood Effects: Consciousness and Metabolism.</description>
       <graphicData>
         <texPath>Things/Item/Meal/Meal_Pizza</texPath>
@@ -148,7 +148,7 @@
 
 <ThingDef ParentName="MealRottable">
       <defName>Taffy</defName>
-      <label>Taffy</label>
+      <label>taffy</label>
       <description>A sweet, chewy candy.</description>
       <graphicData>
       <texPath>Things/Item/Meal/Meal_Taffy</texPath>
@@ -184,7 +184,7 @@
   
 <ThingDef ParentName="MealRottable">
     <defName>cookie</defName>
-    <label>Cookie</label>
+    <label>cookie</label>
     <description>Freshly baked cookies!</description>
     <graphicData>
       <texPath>Things/Item/cookie</texPath>
@@ -221,7 +221,7 @@
 
 <ThingDef ParentName="MealRottable">
       <defName>PieBlueberry</defName>
-      <label>Blueberry Pie Slice</label>
+      <label>blueberry pie slice</label>
       <description>A slice of blueberry pie.</description>
       <graphicData>
       <texPath>Things/Item/Meal/Meal_PieBlueberry</texPath>
@@ -258,7 +258,7 @@
 
 <ThingDef ParentName="MealRottable">
       <defName>PiePumpkin</defName>
-      <label>Pumpkin Pie Slice</label>
+      <label>pumpkin pie slice</label>
       <description>A slice of pumpkin pie.</description>
       <graphicData>
       <texPath>Things/Item/Meal/Meal_PiePumpkin</texPath>
@@ -295,8 +295,8 @@
 
 <ThingDef ParentName="MealRottable">
       <defName>SweetBun</defName>
-      <label>Sweet Bun</label>
-      <description>A sweet roll covered in sugary icying. \n\nFood Effects: Consciousness and Moving.</description>
+      <label>sweet bun</label>
+      <description>A sweet roll covered in sugary icing. \n\nFood Effects: Consciousness and Moving.</description>
       <graphicData>
       <texPath>Things/Item/Meal/Meal_SweetBun</texPath>
       <graphicClass>Graphic_Single</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Arid.xml
@@ -28,11 +28,11 @@
         <li Class="CompProperties_Milkable">
         <milkDef>Milk</milkDef>
         <milkIntervalDays>2</milkIntervalDays>
-        <milkAmount>30</milkAmount>
+        <milkAmount>9</milkAmount>
       </li>
         <li Class="CompProperties_Shearable">
         <woolDef>MuffaloWool</woolDef>
-        <shearIntervalDays>25</shearIntervalDays>
+        <shearIntervalDays>35</shearIntervalDays>
         <woolAmount>100</woolAmount>
       </li>
     </comps>
@@ -46,7 +46,7 @@
 	  <meatLabel>Muffalo Beef</meatLabel>
 	  <leatherLabel>Muffalo Leather</leatherLabel>
       <leatherColor>(67,103,115)</leatherColor>
-      <manhunterOnDamageChance>0</manhunterOnDamageChance>
+      <manhunterOnDamageChance>0.1</manhunterOnDamageChance>
       <leatherInsulation>1.5</leatherInsulation>
       <leatherMarketValueFactor>6.0</leatherMarketValueFactor>
       <leatherStatFactors>
@@ -627,7 +627,7 @@
   <ThingDef ParentName="AnimalThingBase">
     <defName>Dromedary</defName>
     <label>Dromedary</label>
-    <description>A Dromedary or camel is a distant cousin to horses that has adapted to survive in harsh desert climates. It has a distinctive hump in the middle of its back. It can go several days without food and water by regulating its internal temperature to avoid persperating in hot temperatures.</description>
+    <description>A Dromedary or camel is a distant cousin to horses that has adapted to survive in harsh desert climates. It has a distinctive hump in the middle of its back. It can go several days without food and water by regulating its internal temperature to avoid perspiring in hot temperatures.</description>
     <statBases>
 	  <Mass>120</Mass>
       <MoveSpeed>3.4</MoveSpeed>
@@ -640,7 +640,7 @@
         <li Class="CompProperties_Milkable">
         <milkDef>Milk</milkDef>
         <milkIntervalDays>4</milkIntervalDays>
-        <milkAmount>28</milkAmount>
+        <milkAmount>18</milkAmount>
       </li>
         <li Class="CompProperties_Shearable">
         <woolDef>CamelHair</woolDef>
@@ -669,7 +669,7 @@
       <body>QuadrupedAnimalWithHoovesAndHump</body>
       <herdAnimal>true</herdAnimal>
       <baseHungerRate>0.6</baseHungerRate>
-      <baseBodySize>1.4</baseBodySize>
+      <baseBodySize>1.25</baseBodySize>
       <baseHealthScale>1.7</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
 	  <meatLabel>Dromedary Meat</meatLabel>
@@ -783,12 +783,12 @@
   <ThingDef ParentName="AnimalThingBase">
     <defName>Buffalo</defName>
     <label>Buffalo</label>
-    <description>An Buffalo is larger variation of Muffalo that has survived the harsh landscape of a rimworld. Males have white wool and a pair of horns on their head. Females have brown wool and long, frontal tusks. They can be somewhat aggressive if you get too close.</description>
+    <description>An Buffalo is larger variation of muffalo that has survived the harsh landscape of a rimworld. They are known for their thick, brown wool, and the male's distinguished frontal tusks. They can be somewhat aggressive if you get too close.</description>
     <statBases>
 	  <Mass>155</Mass>
       <MoveSpeed>2.75</MoveSpeed>
       <ComfyTemperatureMin>-52</ComfyTemperatureMin>
-	  <MarketValue>1400</MarketValue>
+	  <MarketValue>1000</MarketValue>
       <ImmunityGainSpeed>1.15</ImmunityGainSpeed>
 	  <ArmorPenetration>0.2</ArmorPenetration>
     </statBases>
@@ -805,26 +805,26 @@
         <li Class="CompProperties_Milkable">
         <milkDef>Milk</milkDef>
         <milkIntervalDays>2</milkIntervalDays>
-        <milkAmount>28</milkAmount>
+        <milkAmount>9</milkAmount>
       </li>
         <li Class="CompProperties_Shearable">
         <woolDef>MuffaloWool</woolDef>
         <shearIntervalDays>35</shearIntervalDays>
-        <woolAmount>160</woolAmount>
+        <woolAmount>80</woolAmount>
       </li>
     </comps>
     <race>
 	  <packAnimal>true</packAnimal>
       <herdAnimal>true</herdAnimal>
       <body>QuadrupedAnimalWithHooves</body>
-      <baseBodySize>1.4</baseBodySize>
-      <baseHungerRate>1.5</baseHungerRate>
+      <baseBodySize>1.6</baseBodySize>
+      <baseHungerRate>1.1</baseHungerRate>
       <baseHealthScale>2.2</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
 	  <meatLabel>Buffalo Beef</meatLabel>
 	  <leatherLabel>Buffalo Leather</leatherLabel>
       <leatherColor>(67,103,115)</leatherColor>
-      <leatherMarketValueFactor>8.0</leatherMarketValueFactor>
+      <leatherMarketValueFactor>6.0</leatherMarketValueFactor>
       <leatherStatFactors>
 		<MaxHitPoints>1.3</MaxHitPoints>
         <Beauty>1.1</Beauty>
@@ -842,8 +842,8 @@
       <leatherInsulation>1.5</leatherInsulation>
 	  <gestationPeriodDays>22.5</gestationPeriodDays>
 	  <wildness>0.6</wildness>
-      <manhunterOnDamageChance>0</manhunterOnDamageChance>
-	  <manhunterOnTameFailChance>0.01</manhunterOnTameFailChance>
+      <manhunterOnDamageChance>0.2</manhunterOnDamageChance>
+	  <manhunterOnTameFailChance>0.05</manhunterOnTameFailChance>
       <nuzzleMtbHours>120</nuzzleMtbHours>
 	  <lifeExpectancy>15</lifeExpectancy>
 	  <lifeStageAges>
@@ -963,7 +963,7 @@
 	  <Mass>40</Mass>
       <MoveSpeed>4.84</MoveSpeed>
       <ComfyTemperatureMin>-40</ComfyTemperatureMin>
-	  <MarketValue>500</MarketValue>
+	  <MarketValue>400</MarketValue>
       <ImmunityGainSpeed>1.15</ImmunityGainSpeed>
 	  <ArmorPenetration>0.07</ArmorPenetration>
     </statBases>
@@ -986,18 +986,18 @@
 	<comps>
 		<li Class="CompProperties_Milkable">
         	<milkDef>Milk</milkDef>
-        	<milkIntervalDays>2</milkIntervalDays>
-        	<milkAmount>10</milkAmount>
+        	<milkIntervalDays>3</milkIntervalDays>
+        	<milkAmount>9</milkAmount>
       		</li>
       		<li Class="CompProperties_Shearable">
         	<woolDef>RamWool</woolDef>
-        	<shearIntervalDays>35</shearIntervalDays>
-        	<woolAmount>120</woolAmount>
+        	<shearIntervalDays>10</shearIntervalDays>
+        	<woolAmount>40</woolAmount>
       		</li>
     	</comps>
     <race>
 	  <herdAnimal>true</herdAnimal>
-      <baseHungerRate>0.25</baseHungerRate>
+      <baseHungerRate>0.35</baseHungerRate>
       <body>QuadrupedAnimalWithHooves</body>
       <baseBodySize>0.45</baseBodySize>
       <baseHealthScale>1.0</baseHealthScale>
@@ -1023,7 +1023,7 @@
       </leatherStatFactors>
       <leatherInsulation>1.5</leatherInsulation>
       <wildness>0.05</wildness>
-      <manhunterOnDamageChance>0</manhunterOnDamageChance>
+      <manhunterOnDamageChance>0.05</manhunterOnDamageChance>
       <nuzzleMtbHours>120</nuzzleMtbHours>
       <gestationPeriodDays>22.5</gestationPeriodDays>
       <lifeExpectancy>15</lifeExpectancy>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
@@ -6,7 +6,7 @@
   <ThingDef ParentName="AnimalThingBase">
     <defName>Chicken</defName>
     <label>Chicken</label>
-    <description>Being the most traditional domesticated farm bird, the Chicken is raised for its eggs and meat.</description>
+    <description>Being the most traditional domesticated farm bird, the chicken is raised for its eggs and meat.</description>
     <statBases>
 	  <Mass>3</Mass>
       <MoveSpeed>2.1</MoveSpeed>
@@ -64,7 +64,7 @@
         </li>
         <li>
           <def>AnimalAdult</def>
-          <minAge>0.3</minAge>
+          <minAge>0.45</minAge>
           <soundWounded>Pawn_Chicken_Wounded</soundWounded>
           <soundDeath>Pawn_Chicken_Death</soundDeath>
           <soundCall>Pawn_Chicken_Call</soundCall>
@@ -141,7 +141,7 @@
   <ThingDef ParentName="AnimalThingBase">
     <defName>Pig</defName>
     <label>Pig</label>
-    <description>The Pig was one of the first animals domesticated by humans. It is commonly raised for meat and leather. While capable of being an omnivore, domesticated Pigs are raised as herbivores.</description>
+    <description>The pig was one of the first animals domesticated by humans. It is commonly raised for meat and leather. While capable of being an omnivore, domesticated pigs are raised as herbivores.</description>
     <statBases>
 	  <Mass>30</Mass>
       <MoveSpeed>3.6</MoveSpeed>
@@ -160,8 +160,8 @@
     </verbs>
     <race>
       <body>QuadrupedAnimalWithHooves</body>
-      <baseHungerRate>0.45</baseHungerRate>
-      <baseBodySize>0.45</baseBodySize>
+      <baseHungerRate>0.35</baseHungerRate>
+      <baseBodySize>0.55</baseBodySize>
       <baseHealthScale>1.3</baseHealthScale>
       <foodType>OmnivoreRoughAnimal</foodType>
       <leatherColor>(201,167,135)</leatherColor>
@@ -319,8 +319,8 @@
     <comps>
         <li Class="CompProperties_Milkable">
         <milkDef>Milk</milkDef>
-        <milkIntervalDays>2</milkIntervalDays>
-        <milkAmount>36</milkAmount>
+        <milkIntervalDays>1</milkIntervalDays>
+        <milkAmount>12</milkAmount>
       </li>
     </comps>
     <verbs>
@@ -488,7 +488,7 @@
   <ThingDef ParentName="AnimalThingBase">
     <defName>Alpaca</defName>
     <label>Alpaca</label>
-    <description>A medium-sized ungulate closely related to the llama, the Alpaca is often farmed for its remarkably soft wool.</description>
+    <description>A medium-sized ungulate closely related to the llama, the alpaca is often farmed for its remarkably soft wool.</description>
     <statBases>
 	  <Mass>90</Mass>
       <MoveSpeed>3.8</MoveSpeed>
@@ -516,15 +516,15 @@
     <comps>
         <li Class="CompProperties_Shearable">
         <woolDef>AlpacaWool</woolDef>
-        <shearIntervalDays>15</shearIntervalDays>
-        <woolAmount>60</woolAmount>
+        <shearIntervalDays>10</shearIntervalDays>
+        <woolAmount>50</woolAmount>
       </li>
     </comps>
     <race>
       <body>QuadrupedAnimalWithHooves</body>
       <herdAnimal>true</herdAnimal>
-      <baseBodySize>1.1</baseBodySize>
-      <baseHungerRate>0.6</baseHungerRate>
+      <baseBodySize>0.65</baseBodySize>
+      <baseHungerRate>0.3</baseHungerRate>
       <baseHealthScale>1.2</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
 	  <meatLabel>Alpaca Meat</meatLabel>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Horse.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Horse.xml
@@ -7,13 +7,13 @@
     <statBases>
       <MoveSpeed>8.5</MoveSpeed>
       <ComfyTemperatureMin>-20</ComfyTemperatureMin>
-      <MarketValue>500</MarketValue>
+      <MarketValue>1200</MarketValue>
     </statBases>
     <comps>
       <li Class="CompProperties_Milkable">
         <milkDef>Milk</milkDef>
-        <milkIntervalDays>1</milkIntervalDays>
-        <milkAmount>12</milkAmount>
+        <milkIntervalDays>3</milkIntervalDays>
+        <milkAmount>13</milkAmount>
       </li>
     </comps>
     <verbs>
@@ -44,7 +44,7 @@
       <herdAnimal>true</herdAnimal>
       <packAnimal>true</packAnimal>
       <baseBodySize>1.2</baseBodySize>
-      <baseHungerRate>0.5</baseHungerRate>
+      <baseHungerRate>0.8</baseHungerRate>
       <baseHealthScale>1.6</baseHealthScale>
       <petness>0.5</petness>
       <foodType>VegetarianRoughAnimal</foodType>
@@ -164,24 +164,24 @@
     </lifeStages>
   </PawnKindDef>
   
-  <!-- ======================== Wooly Horse ==================================-->
+  <!-- ======================== Woolly Horse ==================================-->
   
   
     <ThingDef ParentName="AnimalThingBase">
     <defName>WoolyHorse</defName>
-    <label>woolyhorse</label>
-    <description>A plump horse covered in a thick fur fit for much colder climates. Oddly enough, woolyhorses have a throwback to their slower ancestors- actual toed feet; though much larger and further splayed, so as to act as a snowshoe. Odder yet, woolyhorses seem to be omnivorous, with a set of large canines to boot.</description>
+    <label>woolly horse</label>
+    <description>A plump horse covered in a thick fur fit for much colder climates. Oddly enough, woolly horses have a throwback to their slower ancestors- actual toed feet; though much larger and further splayed, so as to act as a snowshoe. Odder yet, they seem to be omnivorous, with a set of large canines to boot.</description>
     <statBases>
       <MoveSpeed>6.5</MoveSpeed>
       <ComfyTemperatureMin>-40</ComfyTemperatureMin>
       <ComfyTemperatureMax>15</ComfyTemperatureMax>
-      <MarketValue>650</MarketValue>
+      <MarketValue>1400</MarketValue>
     </statBases>
     <comps>
       <li Class="CompProperties_Milkable">
         <milkDef>Milk</milkDef>
-        <milkIntervalDays>1</milkIntervalDays>
-        <milkAmount>16</milkAmount>
+        <milkIntervalDays>3</milkIntervalDays>
+        <milkAmount>13</milkAmount>
       </li>
     </comps>
     <verbs>
@@ -235,8 +235,8 @@
       <body>QuadrupedAnimalWithPawsAndTail</body>
       <herdAnimal>true</herdAnimal>
       <packAnimal>true</packAnimal>
-      <baseBodySize>1.5</baseBodySize>
-      <baseHungerRate>0.5</baseHungerRate>
+      <baseBodySize>1.4</baseBodySize>
+      <baseHungerRate>0.9</baseHungerRate>
       <baseHealthScale>1.6</baseHealthScale>
       <foodType>VegetarianRoughAnimal, CarnivoreAnimal</foodType>
       <leatherColor>(255,255,255)</leatherColor>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -6,7 +6,7 @@
     <ThingDef ParentName="AnimalThingBase">
     <defName>Deer</defName>
     <label>Deer</label>
-    <description>A Deer is a medium-sized herding herbivore. It is generally peaceful unless disturbed.</description>
+    <description>A deer is a medium-sized herding herbivore. It is generally peaceful unless disturbed.</description>
     <statBases>
 	  <Mass>60</Mass>
       <MoveSpeed>4.84</MoveSpeed>
@@ -34,8 +34,8 @@
     <race>
       <body>QuadrupedAnimalWithHooves</body>
       <herdAnimal>true</herdAnimal>
-      <baseBodySize>1.0</baseBodySize>
-      <baseHungerRate>0.45</baseHungerRate>
+      <baseBodySize>0.8</baseBodySize>
+      <baseHungerRate>0.4</baseHungerRate>
       <baseHealthScale>1.4</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
       <leatherColor>(162,106,57)</leatherColor>
@@ -164,7 +164,7 @@
   <ThingDef ParentName="AnimalThingBase">
     <defName>Ibex</defName>
     <label>Ibex</label>
-    <description>The hardy wild ancestor of the domesticated goat. Ibexes live on marginal territory that most antelopes couldn't survive, eating lichens and sparse mountain plants. They're famous for dextrously hopping across bare cliff faces - and for their violent ramming attack.</description>
+    <description>The hardy wild ancestor of the domesticated goat. Ibexes live on marginal territory that most antelopes couldn't survive, eating lichens and sparse mountain plants. They're famous for dexterously hopping across bare cliff faces - and for their violent ramming attack.</description>
     <statBases>
 	  <Mass>70</Mass>
       <MoveSpeed>4.4</MoveSpeed>
@@ -175,8 +175,8 @@
     <comps>
         <li Class="CompProperties_Milkable">
         <milkDef>Milk</milkDef>
-        <milkIntervalDays>2</milkIntervalDays>
-        <milkAmount>16</milkAmount>
+        <milkIntervalDays>1</milkIntervalDays>
+        <milkAmount>6</milkAmount>
       </li>
     </comps>
     <verbs>
@@ -198,7 +198,7 @@
     <race>
       <body>QuadrupedAnimalWithHooves</body>
       <herdAnimal>true</herdAnimal>
-      <baseBodySize>0.85</baseBodySize>
+      <baseBodySize>0.65</baseBodySize>
       <baseHungerRate>0.35</baseHungerRate>
       <baseHealthScale>0.85</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
@@ -331,14 +331,14 @@
 	  <Mass>80</Mass>
       <MoveSpeed>4.84</MoveSpeed>
       <ComfyTemperatureMin>-45</ComfyTemperatureMin>
-      <MarketValue>560</MarketValue>
+      <MarketValue>750</MarketValue>
       <ImmunityGainSpeed>1.35</ImmunityGainSpeed>
     </statBases>
     <comps>
         <li Class="CompProperties_Milkable">
         <milkDef>Milk</milkDef>
         <milkIntervalDays>3</milkIntervalDays>
-        <milkAmount>22</milkAmount>
+        <milkAmount>12</milkAmount>
       </li>
     </comps>
     <verbs>
@@ -361,7 +361,7 @@
       <body>QuadrupedAnimalWithHooves</body>
       <herdAnimal>true</herdAnimal>
       <baseBodySize>1.0</baseBodySize>
-      <baseHungerRate>0.56</baseHungerRate>
+      <baseHungerRate>0.76</baseHungerRate>
       <baseHealthScale>1.6</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
       <leatherColor>(162,106,57)</leatherColor>
@@ -384,7 +384,7 @@
       </leatherStatFactors>
       <meatLabel>Elk Venison</meatLabel>
       <wildness>0.7</wildness>
-      <manhunterOnDamageChance>0</manhunterOnDamageChance>
+      <manhunterOnDamageChance>0.12</manhunterOnDamageChance>
       <gestationPeriodDays>25</gestationPeriodDays>
       <lifeExpectancy>18</lifeExpectancy>
       <lifeStageAges>
@@ -501,7 +501,7 @@
       <li Class="CompProperties_Milkable">
         <milkDef>Milk</milkDef>
         <milkIntervalDays>3</milkIntervalDays>
-        <milkAmount>24</milkAmount>
+        <milkAmount>12</milkAmount>
       </li>
     </comps>
     <verbs>
@@ -524,7 +524,7 @@
       <body>QuadrupedAnimalWithHooves</body>
       <herdAnimal>true</herdAnimal>
       <baseBodySize>0.9</baseBodySize>
-      <baseHungerRate>0.95</baseHungerRate>
+      <baseHungerRate>0.56</baseHungerRate>
       <baseHealthScale>1.7</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
       <leatherColor>(173,99,77)</leatherColor>
@@ -651,13 +651,6 @@
         <linkedBodyPartsGroup>TuskAttackTool</linkedBodyPartsGroup>
       </li>
     </verbs>
-	<comps>
-        <li Class="CompProperties_Shearable">
-        <woolDef>RamWool</woolDef>
-        <shearIntervalDays>35</shearIntervalDays>
-        <woolAmount>120</woolAmount>
-      </li>
-	</comps>
     <race>
       <body>QuadrupedAnimalWithHoovesAndTusks</body>
       <baseBodySize>0.45</baseBodySize>
@@ -667,11 +660,11 @@
       <leatherColor>(117,109,93)</leatherColor>
       <leatherLabel>Boar Hide</leatherLabel>
       <leatherInsulation>1.15</leatherInsulation> 
-      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
+      <leatherMarketValueFactor>3.5</leatherMarketValueFactor>
       <useMeatFrom>Pig</useMeatFrom>
       <useLeatherFrom>Pig</useLeatherFrom>
       <wildness>0.40</wildness>
-      <manhunterOnDamageChance>0</manhunterOnDamageChance>
+      <manhunterOnDamageChance>0.3</manhunterOnDamageChance>
       <trainableIntelligence>Advanced</trainableIntelligence>
       <manhunterOnTameFailChance>0.005</manhunterOnTameFailChance>
       <meatLabel>Wild Boar Pork</meatLabel>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -629,8 +629,8 @@
 	    <comps>
 	      <li Class="CompProperties_Milkable">
 	        <milkDef>Milk</milkDef>
-	        <milkIntervalDays>2</milkIntervalDays>
-	        <milkAmount>14</milkAmount>
+	        <milkIntervalDays>3</milkIntervalDays>
+	        <milkAmount>12</milkAmount>
 	      </li>
 	    </comps>    
 	    <verbs>
@@ -658,7 +658,7 @@
 	    </verbs>
 	    <race>
 	      <body>QuadrupedAnimalWithHooves</body>      
-	      <baseBodySize>1.3</baseBodySize>
+	      <baseBodySize>1</baseBodySize>
 	      <baseHungerRate>0.8</baseHungerRate>
 	      <baseHealthScale>1.2</baseHealthScale>
 	      <foodType>VegetarianRoughAnimal</foodType>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Ingridients.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Ingridients.xml
@@ -4,7 +4,7 @@
   
   <ThingDef ParentName="CropsBase">
     <defName>Sugar</defName>
-    <label>Sugar</label>
+    <label>sugar</label>
     <description>Sugar is the milled product of Sugarcanes. It is used in baking, typically for desserts and candies.</description>
    <graphicData>
       <texPath>Things/Item/sugar</texPath>
@@ -33,7 +33,7 @@
 
   <ThingDef ParentName="CropsBase">
     <defName>Flour</defName>
-    <label>Flour</label>
+    <label>flour</label>
     <description>Flour ground from raw Wheat or Oats. It can be used for baking breads.</description>
     <graphicData>
       <texPath>Things/Item/flour</texPath>
@@ -62,7 +62,7 @@
   
   <ThingDef ParentName="CropsBase">
     <defName>Milk</defName>
-    <label>Milk</label>
+    <label>milk</label>
     <description>Milk is a pale liquid produced by the mammary glands of mammals. It can be consumed as a beverage.</description>
     <graphicData>
       <texPath>Things/Item/Resource/Milk</texPath>
@@ -87,7 +87,7 @@
     <tickerType>Rare</tickerType>
     <comps>
       <li Class="CompProperties_Rottable">
-        <daysToRotStart>14</daysToRotStart>
+        <daysToRotStart>4</daysToRotStart>
       </li>
     </comps>
   </ThingDef>
@@ -95,8 +95,8 @@
   
   <ThingDef ParentName="CropsBase">
     <defName>SoyMilk</defName>
-    <label>Soy Milk</label>
-    <description>Soy Milk is a pale liquid produced from grinding Beans. It is similar to an animal's Milk, just produced from plants instead.</description>
+    <label>soy milk</label>
+    <description>Soy milk is a pale liquid produced from grinding Beans. It is similar to an animal's milk, just produced from plants instead.</description>
     <graphicData>
       <texPath>Things/Item/SoyMilk</texPath>
       <graphicClass>Graphic_Single</graphicClass>
@@ -127,7 +127,7 @@
   
   <ThingDef ParentName="CropsBase">
       <defName>coconutmilk</defName>
-      <label>Coconut milk</label>
+      <label>coconut milk</label>
       <description>Milk harvested from the coconut fruit.</description>
       <graphicData>
       <texPath>Things/Item/CoconutMilk</texPath>
@@ -158,8 +158,8 @@
   
   <ThingDef ParentName="CropsBase">
     <defName>Tofu</defName>
-    <label>Tofu</label>
-    <description>Raw protein-rich Tofu, produced from Bean Pods. Acceptable to eat when raw.</description>
+    <label>tofu</label>
+    <description>Raw protein-rich tofu, produced from bean pods. Acceptable to eat when raw.</description>
     <graphicData>
       <texPath>Things/Item/Meal_Tofu</texPath>
       <graphicClass>Graphic_Single</graphicClass>


### PR DESCRIPTION
This patch is the result of a day of discussion in the discord channel and documentation on the spreadsheet found here: https://docs.google.com/spreadsheets/d/12S8CbrwwbircwbaUqkPMy4qptjDuqqxn0ldeNJTZii8/

As well as a handful of minor fixes and tweaks that were made along the way, it mostly addresses how overpowered the milk and cheese industry was. This was due to HCSK creatures producing about 5x more milk compared to vanilla, combined with how good cheese was all around.

Animals now produce about 50% more milk than vanilla instead, and cheese production takes more effort now.