### PR TITLE
Cow value

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
@@ -313,7 +313,7 @@
 	  <Mass>120</Mass>
       <MoveSpeed>3.15</MoveSpeed>
       <ComfyTemperatureMin>-14</ComfyTemperatureMin>
-      <MarketValue>830</MarketValue>
+      <MarketValue>1500</MarketValue>
 	  <ArmorPenetration>0.16</ArmorPenetration>
     </statBases>
     <comps>


### PR DESCRIPTION
Since cows tend to be a late game animal only acquired via trade, and one cow can sustain one pawn, they should probably cost more.