### PR TITLE
Leather and meat overhaul (WILL BREAK SAVES)

### DIFF
--- a/Mods/Core_SK/Defs/BiomeDefs/Biomes_Cold.xml
+++ b/Mods/Core_SK/Defs/BiomeDefs/Biomes_Cold.xml
@@ -105,11 +105,11 @@
     </baseWeatherCommonalities>
     <wildPlants>
 	  <PlantAlgae>0.2</PlantAlgae>
-	  <PlantStrawberry>0.2</PlantStrawberry>
-	  <Plantblueberry>0.2</Plantblueberry>
-	  <Plantcloudberry>0.2</Plantcloudberry>
-	  <Plantgooseberry>0.2</Plantgooseberry>
-      <PlantRaspberry>2.0</PlantRaspberry>
+	  <PlantStrawberry>0.05</PlantStrawberry>
+	  <Plantblueberry>0.05</Plantblueberry>
+	  <Plantcloudberry>0.1</Plantcloudberry>
+	  <Plantgooseberry>0.1</Plantgooseberry>
+      <PlantRaspberry>1.7</PlantRaspberry>
       <PlantBush>3.0</PlantBush>
       <PlantGrass>8.0</PlantGrass>
       <PlantMoss>4.0</PlantMoss>
@@ -120,8 +120,8 @@
       <PlantAstragalus>0.35</PlantAstragalus>
       <PlantCrocus>0.2</PlantCrocus>
       <PlantTreePoplar>0.3</PlantTreePoplar>
-      <PlantTreePine>5.0</PlantTreePine>
-      <PlantTreeBirch>1.5</PlantTreeBirch>
+      <PlantTreePine>6.0</PlantTreePine>
+      <PlantTreeBirch>1.3</PlantTreeBirch>
 	  <PlantBlueMushroom>0.22</PlantBlueMushroom>
       <PlantRedMushroom>0.17</PlantRedMushroom>
     </wildPlants>

--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Cloth.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Cloth.xml
@@ -3,7 +3,7 @@
 
 	<RecipeDef>
 		<defName>MakeCloth</defName>
-		<label>Make Cloth</label>
+		<label>make cloth</label>
 		<description>Make cloth from raw cotton. Produces 20.</description>
 		<jobString>Making cloth.</jobString>
 		<workAmount>600</workAmount>
@@ -40,7 +40,7 @@
 	
 	<RecipeDef>
 		<defName>MakeLinen</defName>
-		<label>Make linen cloth</label>
+		<label>make linen cloth</label>
 		<description>Make linen cloth from raw flax. \n\nMakes 10 cloth.</description>
 		<jobString>Making linen cloth.</jobString>
 		<workAmount>600</workAmount>
@@ -70,7 +70,7 @@
 	
 	  <RecipeDef>
     <defName>MakeHempCloth</defName>
-    <label>Make Weed Cloth (Hemp)</label>
+    <label>make hemp cloth</label>
     <description>Turn your weed into a useful textile called hemp. Produces 15.</description>
     <jobString>Making hemp from weed.</jobString>
 	<workSpeedStat>TailoringSpeed</workSpeedStat>
@@ -110,9 +110,9 @@
 	
 	<RecipeDef>
 		<defName>MakeSynthreadCloth</defName>
-		<label>Make Synthread Cloth</label>
-		<description>Make synthread cloth from raw cotton and synthetic fibers. Produces 10.</description>
-		<jobString>Making synthread cloth.</jobString>
+		<label>make synthread</label>
+		<description>Make synthread from raw cotton and synthetic fibers. Produces 10.</description>
+		<jobString>Making synthread.</jobString>
 		<workAmount>600</workAmount>
 		<workSpeedStat>TailoringSpeed</workSpeedStat>
 		<effectWorking>Tailor</effectWorking>
@@ -158,7 +158,7 @@
 	
 	<RecipeDef>
 		<defName>MakeDevilstrand</defName>
-		<label>Make Devilstrand Cloth</label>
+		<label>make devilstrand cloth</label>
 		<description>Make devilstrand cloth from synthetic fibers. Produces 15.</description>
 		<jobString>Making devilstrand cloth.</jobString>
 		<workAmount>600</workAmount>
@@ -206,7 +206,7 @@
 	
 	<RecipeDef>
 		<defName>MakeHyperweaveCloth</defName>
-		<label>Make Hyperweave Cloth</label>
+		<label>make hyperweave cloth</label>
 		<description>Make hyperweave cloth from synthread and devilstrand cloth. Produces 10.</description>
 		<jobString>Making hyperweave cloth.</jobString>
 		<workAmount>600</workAmount>
@@ -253,8 +253,8 @@
 	
   <RecipeDef>
     <defName>MakeVelour</defName>
-    <label>Craft Velour</label>
-    <description>Crafts Velour. Produces 25.</description>
+    <label>make velour</label>
+    <description>Crafts velour, a plush woven fabric resembling velvet, chiefly used for soft furnishings, casual clothing, and hats. Produces 25.</description>
     <jobString>Crafting Velour.</jobString>
     <workAmount>1800</workAmount>
 	<workSpeedStat>TailoringSpeed</workSpeedStat>
@@ -309,13 +309,12 @@
 		</recipeUsers>
 		<researchPrerequisite>SK_Petrochemistry</researchPrerequisite>
   </RecipeDef>
-  
 
-
-
+ <!--
+ Removed for now until we can figure out how to implement the leather processing system with the new leather resources
   <RecipeDef>
     <defName>MakeTannedleather</defName>
-    <label>Craft Tanned leather</label>
+    <label>make tanned leather</label>
     <description>Crafts tanned leather. Produces 20.</description>
     <jobString>Crafting tanned leather.</jobString>
     <workAmount>1200</workAmount>
@@ -360,12 +359,13 @@
 			<li>TableLoom</li>
 		</recipeUsers>
   </RecipeDef>
+ -->
 	
 <!-- Hex cell -->
   <RecipeDef>
     <defName>MakeHexcell</defName>
-    <label>Craft Hex-Cells</label>
-    <description>Crafts Hex-Cells. This is a power source for some armors. Produces 10.</description>
+    <label>make hex-cells</label>
+    <description>Crafts hex-cells. This is a power source for some armors. Produces 10.</description>
     <jobString>Crafting Hex-Cell.</jobString>
     <workAmount>6000</workAmount>
 	<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>

--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Misc.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Misc.xml
@@ -4,7 +4,7 @@
   
 	<RecipeDef>
 		<defName>MakePainting</defName>
-		<label>Create a Painting</label>
+		<label>create a painting</label>
 		<description>Create a painting by using cloth and painting supplies. Produces 1.</description>
 		<jobString>Painting.</jobString>
 		<workAmount>15000</workAmount>
@@ -45,7 +45,7 @@
 
 	<RecipeDef>
 		<defName>CookPaint</defName>
-		<label>Create Painting Supplies</label>
+		<label>create painting supplies</label>
 		<description>Creates paint by boiling flowers until the gum and pigments bind and then combine it with wood to finish the set. Produces 1.</description>
 		<jobString>Creating paint set.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -99,7 +99,7 @@
 	
   <RecipeDef>
     <defName>MakeDrillHead</defName>
-    <label>Make Drill Head</label>
+    <label>make drill head</label>
     <description>Makes a drill head for use with the hi-tech drilling rig. Produces 1.</description>
     <jobString>Making a drill head.</jobString>
     <workAmount>2600</workAmount>
@@ -140,7 +140,7 @@
 	
 	<RecipeDef>
     <defName>MakeRobotParts</defName>
-    <label>Make Robot Parts</label>
+    <label>make robot parts</label>
     <description>Make Robot Parts. Produces 25.</description>
     <jobString>Making a Robot Parts.</jobString>
     <workAmount>8000</workAmount>

--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_PrepareFishes.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_PrepareFishes.xml
@@ -13,7 +13,7 @@
       <li>
         <filter>
           <thingDefs>
-            <li>ThingDefFishMashgon_Meat</li>
+            <li>ThingDefFishMashgon_Corpse</li>
           </thingDefs>
         </filter>
         <count>1</count>
@@ -21,14 +21,14 @@
     </ingredients>
     <fixedIngredientFilter>
       <thingDefs>
-        <li>ThingDefFishMashgon_Meat</li>
+        <li>ThingDefFishMashgon_Corpse</li>
       </thingDefs>
       <specialFiltersToDisallow>
         <li>AllowRotten</li>
       </specialFiltersToDisallow>
     </fixedIngredientFilter>
     <products>
-      <ThingDefFishMashgon_Meat>1</ThingDefFishMashgon_Meat>
+      <ThingDefFishMashgon_Corpse>1</ThingDefFishMashgon_Corpse>
     </products>
   </RecipeDef>
 
@@ -42,7 +42,7 @@
       <li>
         <filter>
           <thingDefs>
-            <li>ThingDefFishBlueblade_Meat</li>
+            <li>ThingDefFishBlueblade_Corpse</li>
           </thingDefs>
         </filter>
         <count>1</count>
@@ -50,14 +50,14 @@
     </ingredients>
     <fixedIngredientFilter>
       <thingDefs>
-        <li>ThingDefFishBlueblade_Meat</li>
+        <li>ThingDefFishBlueblade_Corpse</li>
       </thingDefs>
       <specialFiltersToDisallow>
         <li>AllowRotten</li>
       </specialFiltersToDisallow>
     </fixedIngredientFilter>
     <products>
-      <ThingDefFishBlueblade_Meat>1</ThingDefFishBlueblade_Meat>
+      <ThingDefFishBlueblade_Corpse>1</ThingDefFishBlueblade_Corpse>
     </products>
   </RecipeDef>
 
@@ -71,7 +71,7 @@
       <li>
         <filter>
           <thingDefs>
-            <li>ThingDefFishTailteeth_Meat</li>
+            <li>ThingDefFishTailteeth_Corpse</li>
           </thingDefs>
         </filter>
         <count>1</count>
@@ -79,14 +79,14 @@
     </ingredients>
     <fixedIngredientFilter>
       <thingDefs>
-        <li>ThingDefFishTailteeth_Meat</li>
+        <li>ThingDefFishTailteeth_Corpse</li>
       </thingDefs>
       <specialFiltersToDisallow>
         <li>AllowRotten</li>
       </specialFiltersToDisallow>
     </fixedIngredientFilter>
     <products>
-      <ThingDefFishTailteeth_Meat>1</ThingDefFishTailteeth_Meat>
+      <ThingDefFishTailteeth_Corpse>1</ThingDefFishTailteeth_Corpse>
     </products>
   </RecipeDef>
 
@@ -124,7 +124,9 @@
       </specialFiltersToDisallow>
     </fixedIngredientFilter>
     <recipeUsers>
-      <li>Campfire</li>
+	  <!--
+      <li>Campfire</li> is this recipe even needed?
+	  -->
     </recipeUsers>
     <workSkill>Cooking</workSkill>
   </RecipeDef>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
@@ -160,11 +160,7 @@
 				<li>AnimalProductRaw</li>
 			</categories>
             <exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -224,10 +220,6 @@
 			<exceptedThingDefs>
                 <li>Human_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Gnawler_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
         <li>EggsFertilized</li>
@@ -284,11 +276,7 @@
 				<li>AnimalProductRaw</li>
 			</categories>
             <exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -345,11 +333,7 @@
 				<li>MeatRaw</li>
 			</categories>
             <exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -405,11 +389,7 @@
 				<li>BasicPlantFoodRaw</li>
 			</categories>
 			<exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -468,11 +448,7 @@
 				<li>BasicPlantFoodRaw</li>
 			</categories>
 			<exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -544,11 +520,7 @@
 				<li>BasicPlantFoodRaw</li>				
 			</categories>
 			<exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -617,11 +589,7 @@
 				<li>BasicPlantFoodRaw</li>				
 			</categories>
 			<exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -655,9 +623,11 @@
 			<li>
 				<filter>
 					<categories>
-						<li>MeatRaw</li>
 						<li>AnimalProductRaw</li>
 					</categories>
+					<thingDefs>
+						<li>Muffalo_Meat</li>
+					</thingDefs>
 				</filter>
 				<count>3</count>
 			</li>
@@ -685,9 +655,11 @@
 			<categories>
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
-				<li>MeatRaw</li>
 				<li>AnimalProductRaw</li>
 			</categories>
+			<thingDefs>
+				<li>Muffalo_Meat</li>
+			</thingDefs>
       <disallowedSpecialFilters>
         <li>AllowPlantFood</li>
       </disallowedSpecialFilters>
@@ -696,15 +668,13 @@
 			<categories>
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
-				<li>MeatRaw</li>
 				<li>AnimalProductRaw</li>
 			</categories>
+			<thingDefs>
+				<li>Muffalo_Meat</li>
+			</thingDefs>
 			<exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -736,9 +706,11 @@
 			<li>
 				<filter>
 					<categories>
-						<li>MeatRaw</li>
 						<li>AnimalProductRaw</li>
 					</categories>
+					<thingDefs>
+						<li>Muffalo_Meat</li>
+					</thingDefs>
 				</filter>
 				<count>12</count>
 			</li>
@@ -766,26 +738,26 @@
 			<categories>
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
-				<li>MeatRaw</li>
 				<li>AnimalProductRaw</li>
 			</categories>
-      <disallowedSpecialFilters>
-        <li>AllowPlantFood</li>
-      </disallowedSpecialFilters>
+			<thingDefs>
+				<li>Muffalo_Meat</li>
+			</thingDefs>
+			  <disallowedSpecialFilters>
+				<li>AllowPlantFood</li>
+			  </disallowedSpecialFilters>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<categories>
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
-				<li>MeatRaw</li>
 				<li>AnimalProductRaw</li>
 			</categories>
+			<thingDefs>
+				<li>Muffalo_Meat</li>
+			</thingDefs>
 			<exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -818,9 +790,11 @@
 			<li>
 				<filter>
 					<categories>
-						<li>MeatRaw</li>
 						<li>AnimalProductRaw</li>
 					</categories>
+					<thingDefs>
+						<li>Muffalo_Meat</li>
+					</thingDefs>
 				</filter>
 				<count>3</count>
 			</li>
@@ -858,12 +832,12 @@
 			   <li>Hypericum</li>
 			   <li>MintLeaves</li>   
 			   <li>Rawonion</li>
+			   <li>Muffalo_Meat</li>
 			</thingDefs>
 			<categories>
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>LuxuryStuffs</li>
-				<li>MeatRaw</li>
 				<li>AnimalProductRaw</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -873,20 +847,16 @@
 			   <li>Hypericum</li>
 			   <li>MintLeaves</li>   
 			   <li>Rawonion</li>
+			   <li>Muffalo_Meat</li>
 			</thingDefs>
 			<categories>
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>LuxuryStuffs</li>
-				<li>MeatRaw</li>
 				<li>AnimalProductRaw</li>
 			</categories>
 			<exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>
@@ -917,9 +887,11 @@
 			<li>
 				<filter>
 					<categories>
-						<li>MeatRaw</li>
 						<li>AnimalProductRaw</li>
 					</categories>
+					<thingDefs>
+						<li>Muffalo_Meat</li>
+					</thingDefs>
 				</filter>
 				<count>12</count>
 			</li>
@@ -957,12 +929,12 @@
 			   <li>Hypericum</li>
 			   <li>MintLeaves</li>   
 			   <li>Rawonion</li>
+			   <li>Muffalo_Meat</li>
 			</thingDefs>
 			<categories>
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>LuxuryStuffs</li>
-				<li>MeatRaw</li>
 				<li>AnimalProductRaw</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -972,20 +944,16 @@
 			   <li>Hypericum</li>
 			   <li>MintLeaves</li>   
 			   <li>Rawonion</li>
+			   <li>Muffalo_Meat</li>
 			</thingDefs>
 			<categories>
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>LuxuryStuffs</li>
-				<li>MeatRaw</li>
 				<li>AnimalProductRaw</li>
 			</categories>
 			<exceptedThingDefs>
-                <li>Gnawler_Meat</li>
 				<li>Megaspider_Meat</li>
-                <li>Antis_Meat</li>
-                <li>Mosquito_Meat</li>
-                <li>Crashbug_Meat</li>
 				<li>Human_Meat</li>
 			</exceptedThingDefs>
       <exceptedCategories>

--- a/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Races_Animal_Fish.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Races_Animal_Fish.xml
@@ -70,6 +70,7 @@
       <ComfyTemperatureMin>-5</ComfyTemperatureMin>
       <MarketValue>100</MarketValue>
       <Mass>3</Mass>
+	  <LeatherAmount>0</LeatherAmount>
     </statBases>
     <verbs>
       <li>
@@ -92,14 +93,13 @@
       <body>Squid</body>
       <predator>true</predator>
       <maxPreyBodySize>0.35</maxPreyBodySize>
-      <baseBodySize>0.20</baseBodySize>
+      <baseBodySize>0.15</baseBodySize>
       <baseHealthScale>0.30</baseHealthScale>
       <baseHungerRate>0.07</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>CarnivoreAnimal</foodType>
-      <leatherColor>(74,140,140)</leatherColor>
-      <leatherInsulation>0.3</leatherInsulation>
-      <meatLabel>sduiggles tentacles</meatLabel>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.99</wildness>
       <manhunterOnTameFailChance>0.005</manhunterOnTameFailChance>
       <manhunterOnDamageChance>0.25</manhunterOnDamageChance>
@@ -196,6 +196,7 @@
       <ComfyTemperatureMin>-10</ComfyTemperatureMin>
       <MarketValue>80</MarketValue>
       <Mass>4</Mass>
+	  <LeatherAmount>0</LeatherAmount>
     </statBases>
     <verbs>
       <li>
@@ -217,14 +218,14 @@
     <race>
       <body>Fish</body>
       <predator>false</predator>
-      <baseBodySize>0.30</baseBodySize>
+      <baseBodySize>0.25</baseBodySize>
       <baseHealthScale>0.35</baseHealthScale>
       <baseHungerRate>0.07</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>OmnivoreAnimal</foodType>
-      <leatherColor>(26,47,61)</leatherColor>
       <leatherInsulation>1.0</leatherInsulation>
-      <meatLabel>seasnake filet</meatLabel>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.99</wildness>
       <manhunterOnTameFailChance>0.015</manhunterOnTameFailChance>
       <manhunterOnDamageChance>0.75</manhunterOnDamageChance>
@@ -321,6 +322,7 @@
       <ComfyTemperatureMin>-20</ComfyTemperatureMin>
       <MarketValue>50</MarketValue>
       <Mass>2</Mass>
+	  <LeatherAmount>0</LeatherAmount>
     </statBases>
     <verbs>
       <li>
@@ -343,15 +345,14 @@
       <body>Fish</body>
       <predator>true</predator>
       <maxPreyBodySize>0.20</maxPreyBodySize>
-      <baseBodySize>0.15</baseBodySize>
+      <baseBodySize>0.10</baseBodySize>
       <baseHealthScale>0.45</baseHealthScale>
       <baseHungerRate>0.07</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>OmnivoreAnimal</foodType>
-      <leatherColor>(221,123,23)</leatherColor>
       <leatherInsulation>0.7</leatherInsulation>
-      <meatLabel>shelled mashgon</meatLabel>
-      <meatColor>(221,123,23)</meatColor>
+      <useMeatFrom>Muffalo</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.99</wildness>
       <manhunterOnTameFailChance>0.03</manhunterOnTameFailChance>
       <manhunterOnDamageChance>0.85</manhunterOnDamageChance>
@@ -449,6 +450,8 @@
       <ComfyTemperatureMin>-5</ComfyTemperatureMin>
       <MarketValue>80</MarketValue>
       <Mass>4</Mass>
+	  <MeatAmount>10</MeatAmount>
+	  <LeatherAmount>0</LeatherAmount>
     </statBases>
     <verbs>
       <li>
@@ -475,9 +478,8 @@
       <baseHungerRate>0.07</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>OmnivoreAnimal</foodType>
-      <leatherColor>(56,114,190)</leatherColor>
-      <leatherInsulation>1.2</leatherInsulation>
-      <meatLabel>blueblade filet</meatLabel>
+      <useMeatFrom>Muffalo</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.99</wildness>
       <manhunterOnTameFailChance>0.015</manhunterOnTameFailChance>
       <manhunterOnDamageChance>0.15</manhunterOnDamageChance>
@@ -568,12 +570,14 @@
   <ThingDef ParentName="FishThingBase">
     <defName>ThingDefFishTailteeth</defName>
     <label>tailteeth</label>
-    <description>This ferocious predator owns its name to its vicious tactics. Slowly approaching its unaware drinking preys, it uses its massive tail to attract them into deep water. The teeth is generaly the last vision you can get from this terrible creature.</description>
+    <description>This ferocious predator owns its name to its vicious tactics. Slowly approaching its unaware drinking preys, it uses its massive tail to attract them into deep water. The teeth is generally the last vision you can get from this terrible creature.</description>
     <statBases>
       <MoveSpeed>0.01</MoveSpeed>
       <ComfyTemperatureMin>-10</ComfyTemperatureMin>
       <MarketValue>500</MarketValue>
       <Mass>120</Mass>
+	  <MeatAmount>60</MeatAmount>
+	  <LeatherAmount>0</LeatherAmount>
     </statBases>
     <verbs>
       <li>
@@ -601,9 +605,8 @@
       <baseHungerRate>0.07</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>CarnivoreAnimal</foodType>
-      <leatherColor>(59,86,49)</leatherColor>
-      <leatherInsulation>1.5</leatherInsulation>
-      <meatLabel>tailteeth steak</meatLabel>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.99</wildness>
       <manhunterOnTameFailChance>0.05</manhunterOnTameFailChance>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Mushrooms.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Mushrooms.xml
@@ -3,7 +3,7 @@
 
   <ThingDef ParentName="ResBase">
     <defName>MushroomTincture</defName>
-    <label>Mushroom Tincture</label>
+    <label>mushroom tincture</label>
     <description>A concentrated extract from mushrooms. A good, natural medicine source.</description>
     <thingClass>Medicine</thingClass>
     <graphicData>
@@ -53,7 +53,7 @@
   
   <ThingDef ParentName="ResBase">
     <defName>HealrootTincture</defName>
-    <label>Healroot Tincture</label>
+    <label>healroot tincture</label>
     <description>A concentrated extract from healroot. A good, natural medicine source.</description>
     <thingClass>Medicine</thingClass>
     <graphicData>
@@ -103,7 +103,7 @@
 
 	<ThingDef ParentName="MealRottable">
 		<defName>StewMushrooms</defName>
-		<label>Mushroom Stews</label>
+		<label>mushroom stews</label>
 		<description>A stew containing mushrooms.</description>
     <graphicData>
 		<texPath>Things/Item/Meal/Mushrooms</texPath>
@@ -133,7 +133,7 @@
 
 	<ThingDef ParentName="MealRottable">
 		<defName>SaladwMushrooms</defName>
-		<label>Salad with Mushrooms</label>
+		<label>salad with mushrooms</label>
 		<description>A salad with mushrooms mixed in.</description>
     <graphicData>
 		<texPath>Things/Item/Meal/Meal_Salad</texPath>
@@ -159,7 +159,7 @@
 
 	<ThingDef ParentName="MealRottable">
 		<defName>RoastwMushrooms</defName>
-		<label>Pot Roast and Mushrooms</label>
+		<label>pot roast and mushrooms</label>
 		<description>A meaty roast with mushrooms mixed in.</description>
     <graphicData>
 		<texPath>Things/Item/Meal/RoastM</texPath>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Synthetic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Synthetic.xml
@@ -3,7 +3,7 @@
 
   <ThingDef ParentName="MealRottable">
     <defName>MealNutrientPaste</defName>
-    <label>Nutrient Paste Meal</label>
+    <label>nutrient paste meal</label>
     <description>A synthetic mixture of protein, carbohydrates, vitamins, amino acids and minerals. Everything the body needs with an absolutely disgusting taste.</description>
     <graphicData>
 	  <texPath>Things/Item/Meal/Meal_NutrientPaste</texPath>
@@ -27,7 +27,7 @@
   
   <ThingDef ParentName="MealRottable">
     <defName>soylentgreen</defName>
-    <label>Soylent Green</label>
+    <label>soylent green</label>
     <description>Soylent Green is made from people, corpses that is. The taste varies from person to person.</description>
     <graphicData>
       <texPath>Things/Item/Resource/soylent</texPath>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Arid.xml
@@ -5,8 +5,8 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Muffalo</defName>
-    <label>Muffalo</label>
-    <description>A Muffalo is a large herding herbivore that descended from Buffalo and has adapted to some exotic environments. It is peaceful unless disturbed.</description>
+    <label>muffalo</label>
+    <description>A muffalo is a large herding herbivore that descended from Buffalo and has adapted to some exotic environments. It is peaceful unless disturbed.</description>
     <statBases>
       <MoveSpeed>3.6</MoveSpeed>
       <ComfyTemperatureMin>-70</ComfyTemperatureMin>
@@ -41,27 +41,27 @@
       <herdAnimal>true</herdAnimal>
       <body>QuadrupedAnimalWithHooves</body>
       <baseBodySize>1.5</baseBodySize>
-      <baseHealthScale>1.6</baseHealthScale>
+      <baseHealthScale>1.5</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Muffalo Beef</meatLabel>
-	  <leatherLabel>Muffalo Leather</leatherLabel>
-      <leatherColor>(67,103,115)</leatherColor>
-      <manhunterOnDamageChance>0.1</manhunterOnDamageChance>
+	  <meatLabel>prime meat</meatLabel>
+	  <leatherLabel>common leather</leatherLabel>
+      <leatherColor>(90,103,115)</leatherColor>
+      <manhunterOnDamageChance>0.04</manhunterOnDamageChance>
       <leatherInsulation>1.5</leatherInsulation>
-      <leatherMarketValueFactor>6.0</leatherMarketValueFactor>
+      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
       <leatherStatFactors>
 		<MaxHitPoints>1.0</MaxHitPoints>
         <Beauty>1.1</Beauty>
-        <MarketValue>1.7</MarketValue>
+        <MarketValue>1.5</MarketValue>
         <ArmorRating_Blunt>1.4</ArmorRating_Blunt>
         <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
         <ArmorRating_Electric>1</ArmorRating_Electric>
         <ArmorRating_Heat>1.2</ArmorRating_Heat>
-        <Insulation_Cold>1.32</Insulation_Cold>
-        <Insulation_Heat>0.58</Insulation_Heat>
+        <Insulation_Cold>1.25</Insulation_Cold>
+        <Insulation_Heat>1</Insulation_Heat>
 		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
+		<BedRestEffectiveness>1</BedRestEffectiveness>
+		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
       </leatherStatFactors>
       <gestationPeriodDays>30</gestationPeriodDays>
       <wildness>0.4</wildness>
@@ -99,7 +99,7 @@
   
   <PawnKindDef Name="Muffalo" ParentName="AnimalKindBase">
     <defName>Muffalo</defName>
-    <label>Muffalo</label>
+    <label>muffalo</label>
     <race>Muffalo</race>
     <combatPower>110</combatPower>
     <wildSpawn_spawnWild>true</wildSpawn_spawnWild>
@@ -176,7 +176,7 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Gazelle</defName>
-    <label>Gazelle</label>
+    <label>gazelle</label>
     <description>A small, extremely quick antelope known for its amazingly long leap.</description>
     <statBases>
 	  <Mass>80</Mass>
@@ -210,8 +210,8 @@
       <foodType>VegetarianRoughAnimal</foodType>
       <leatherColor>(214,134,59)</leatherColor>
       <leatherInsulation>0.75</leatherInsulation>
-      <useMeatFrom>Deer</useMeatFrom>
-      <useLeatherFrom>Deer</useLeatherFrom>
+      <useMeatFrom>Muffalo</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.75</wildness>
       <gestationPeriodDays>20</gestationPeriodDays>
       <lifeExpectancy>12</lifeExpectancy>
@@ -298,15 +298,15 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Iguana</defName>
-    <label>Iguana</label>
+    <label>iguana</label>
     <description>An Iguana is a large lizard that normally feeds on plant matter. However when angered, their tough hide and sharp claws can make them quite dangerous.</description>
     <statBases>
 	  <Mass>50</Mass>
       <MoveSpeed>3.23</MoveSpeed>
       <ComfyTemperatureMin>0</ComfyTemperatureMin>
-      <MarketValue>1600</MarketValue>
+      <MarketValue>160</MarketValue>
       <ImmunityGainSpeed>1.5</ImmunityGainSpeed>
-      <MeatAmount>60</MeatAmount>
+      <MeatAmount>25</MeatAmount>
 	  <ArmorPenetration>0.15</ArmorPenetration>
     </statBases>
     <verbs>
@@ -358,26 +358,9 @@
       <baseBodySize>0.7</baseBodySize>
       <baseHealthScale>1.1</baseHealthScale>
       <foodType>CarnivoreAnimal, CarnivoreAnimalStrict, OmnivoreRoughAnimal</foodType>
-	  <meatLabel>Iguana Meat</meatLabel>
-      <leatherColor>(101,116,58)</leatherColor>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
-      <leatherLabel>Iguana Skin</leatherLabel>
-      <leatherInsulation>0.75</leatherInsulation>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.2</MaxHitPoints>
-        <Beauty>1.4</Beauty>
-        <MarketValue>1.7</MarketValue>
-        <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.4</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.2</ArmorRating_Heat>
-        <Insulation_Cold>0.5</Insulation_Cold>
-        <Insulation_Heat>1.5</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>0.8</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.23</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Squirrel</useLeatherFrom>
       <wildness>0.45</wildness>
       <nuzzleMtbHours>120</nuzzleMtbHours>
       <gestationPeriodDays>14</gestationPeriodDays>
@@ -420,7 +403,7 @@
 
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>Iguana</defName>
-    <label>Iguana</label>
+    <label>iguana</label>
     <race>Iguana</race>
     <combatPower>90</combatPower>
     <wildSpawn_EcoSystemWeight>0.33</wildSpawn_EcoSystemWeight>
@@ -469,8 +452,8 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Rhinoceros</defName>
-    <label>Rhinoceros</label>
-    <description>A Rhinoceros is a large land mammal with a horn on its nose. While it is typically quite peaceful, it will not hesitate to charge with its horn to fend off trespassers.</description>
+    <label>rhinoceros</label>
+    <description>A rhinoceros is a large land mammal with a horn on its nose. While it is typically quite peaceful, it will not hesitate to charge with its horn to fend off trespassers.</description>
     <statBases>
 	  <Mass>220</Mass>
       <MoveSpeed>3.8</MoveSpeed>
@@ -510,27 +493,10 @@
       <baseBodySize>1.7</baseBodySize>
       <baseHealthScale>2.3</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Rhinoceros Meat</meatLabel>
-      <leatherColor>(150,150,150)</leatherColor>
-      <leatherLabel>Rhinoceros Hide</leatherLabel>
-      <leatherInsulation>0.9</leatherInsulation>
-      <leatherMarketValueFactor>8.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.5</MaxHitPoints>
-        <Beauty>1.2</Beauty>
-        <MarketValue>2.0</MarketValue>
-        <ArmorRating_Blunt>2.2</ArmorRating_Blunt>
-        <ArmorRating_Sharp>2.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.4</ArmorRating_Heat>
-        <Insulation_Cold>0.6</Insulation_Cold>
-        <Insulation_Heat>1.15</Insulation_Heat>
-		<WorkToMake>1.7</WorkToMake>
-		<BedRestEffectiveness>0.8</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+      <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Elephant</useLeatherFrom>
       <wildness>0.50</wildness>
-      <manhunterOnTameFailChance>0.1</manhunterOnTameFailChance>
+      <manhunterOnTameFailChance>0.2</manhunterOnTameFailChance>
       <manhunterOnDamageChance>0.4</manhunterOnDamageChance>
       <nuzzleMtbHours>120</nuzzleMtbHours>
       <gestationPeriodDays>45</gestationPeriodDays>
@@ -568,7 +534,7 @@
 
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>Rhinoceros</defName>
-    <label>Rhinoceros</label>
+    <label>rhinoceros</label>
     <race>Rhinoceros</race>
     <combatPower>180</combatPower>
     <wildSpawn_EcoSystemWeight>0.2</wildSpawn_EcoSystemWeight>
@@ -626,8 +592,8 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Dromedary</defName>
-    <label>Dromedary</label>
-    <description>A Dromedary or camel is a distant cousin to horses that has adapted to survive in harsh desert climates. It has a distinctive hump in the middle of its back. It can go several days without food and water by regulating its internal temperature to avoid perspiring in hot temperatures.</description>
+    <label>dromedary</label>
+    <description>A dromedary or camel is a distant cousin to horses that has adapted to survive in harsh desert climates. It has a distinctive hump in the middle of its back. It can go several days without food and water by regulating its internal temperature to avoid perspiring in hot temperatures.</description>
     <statBases>
 	  <Mass>120</Mass>
       <MoveSpeed>3.4</MoveSpeed>
@@ -672,24 +638,8 @@
       <baseBodySize>1.25</baseBodySize>
       <baseHealthScale>1.7</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Dromedary Meat</meatLabel>
-	  <leatherLabel>Dromedary Leather</leatherLabel>
-      <leatherColor>(204,180,150)</leatherColor>
-      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.1</MaxHitPoints>
-        <Beauty>1.3</Beauty>
-        <MarketValue>1.3</MarketValue>
-        <ArmorRating_Blunt>1.3</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.6</ArmorRating_Heat>
-        <Insulation_Cold>1.0</Insulation_Cold>
-        <Insulation_Heat>1.3</Insulation_Heat>
-		<WorkToMake>1.3</WorkToMake>
-		<BedRestEffectiveness>1.1</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
       <leatherInsulation>1.25</leatherInsulation>
       <wildness>0.2</wildness>
@@ -724,7 +674,7 @@
 
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>Dromedary</defName>
-    <label>Dromedary</label>
+    <label>dromedary</label>
     <race>Dromedary</race>
     <combatPower>95</combatPower>
     <wildSpawn_EcoSystemWeight>0.2</wildSpawn_EcoSystemWeight>
@@ -782,8 +732,8 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Buffalo</defName>
-    <label>Buffalo</label>
-    <description>An Buffalo is larger variation of muffalo that has survived the harsh landscape of a rimworld. They are known for their thick, brown wool, and the male's distinguished frontal tusks. They can be somewhat aggressive if you get too close.</description>
+    <label>buffalo</label>
+    <description>A buffalo is a larger variation of muffalo that has survived the harsh landscape of a rimworld. They are known for their thick, brown wool, and the male's distinguished frontal tusks. They can be somewhat aggressive if you get too close.</description>
     <statBases>
 	  <Mass>155</Mass>
       <MoveSpeed>2.75</MoveSpeed>
@@ -821,28 +771,11 @@
       <baseHungerRate>1.1</baseHungerRate>
       <baseHealthScale>2.2</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Buffalo Beef</meatLabel>
-	  <leatherLabel>Buffalo Leather</leatherLabel>
-      <leatherColor>(67,103,115)</leatherColor>
-      <leatherMarketValueFactor>6.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.3</MaxHitPoints>
-        <Beauty>1.1</Beauty>
-        <MarketValue>1.6</MarketValue>
-        <ArmorRating_Blunt>1.7</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.4</ArmorRating_Sharp>
-        <ArmorRating_Electric>1</ArmorRating_Electric>
-        <ArmorRating_Heat>1</ArmorRating_Heat>
-        <Insulation_Cold>1.41</Insulation_Cold>
-        <Insulation_Heat>0.53</Insulation_Heat>
-		<WorkToMake>1.3</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <leatherInsulation>1.5</leatherInsulation>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
 	  <gestationPeriodDays>22.5</gestationPeriodDays>
 	  <wildness>0.6</wildness>
-      <manhunterOnDamageChance>0.2</manhunterOnDamageChance>
+      <manhunterOnDamageChance>0.1</manhunterOnDamageChance>
 	  <manhunterOnTameFailChance>0.05</manhunterOnTameFailChance>
       <nuzzleMtbHours>120</nuzzleMtbHours>
 	  <lifeExpectancy>15</lifeExpectancy>
@@ -879,7 +812,7 @@
 
 	<PawnKindDef ParentName="AnimalKindBase">
     <defName>Buffalo</defName>
-    <label>Buffalo</label>
+    <label>buffalo</label>
     <race>Buffalo</race>
     <combatPower>110</combatPower>
     <wildSpawn_spawnWild>true</wildSpawn_spawnWild>
@@ -957,7 +890,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Rimram</defName>
-    <label>Rimram</label>
+    <label>rimram</label>
     <description>The thick wool on these rams makes them very common sight in cold climates. They are known for their ability to climb nearly vertical, sheer cliff faces. They have no fear of falling.</description>
     <statBases>
 	  <Mass>40</Mass>
@@ -1002,26 +935,8 @@
       <baseBodySize>0.45</baseBodySize>
       <baseHealthScale>1.0</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Rimram Mutton</meatLabel>
-      <leatherColor>(162,145,116)</leatherColor>
-      <leatherLabel>Ram Leather</leatherLabel>
-      <leatherInsulation>1.5</leatherInsulation>
-	  <leatherMarketValueFactor>3</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.0</MaxHitPoints>
-        <Beauty>1.2</Beauty>
-        <MarketValue>1.5</MarketValue>
-        <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.3</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.2</ArmorRating_Heat>
-        <Insulation_Cold>1.31</Insulation_Cold>
-        <Insulation_Heat>0.71</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.15</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.0</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <leatherInsulation>1.5</leatherInsulation>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.05</wildness>
       <manhunterOnDamageChance>0.05</manhunterOnDamageChance>
       <nuzzleMtbHours>120</nuzzleMtbHours>
@@ -1057,7 +972,7 @@
 
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>Rimram</defName>
-    <label>Rimram</label>
+    <label>rimram</label>
     <race>Rimram</race>
     <combatPower>60</combatPower>
     <wildSpawn_EcoSystemWeight>0.5</wildSpawn_EcoSystemWeight>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Bears.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Bears.xml
@@ -116,10 +116,8 @@
     <race>
 	  <packAnimal>true</packAnimal>
       <wildness>0.80</wildness>
-      <leatherColor>(112,82,65)</leatherColor>
-      <leatherInsulation>1.0</leatherInsulation>
-      <leatherLabel>bearskin</leatherLabel>
-      <meatLabel>bear meat</meatLabel>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
     </race>
   </ThingDef>
 
@@ -190,10 +188,8 @@
     <race>
 	  <packAnimal>true</packAnimal>
       <wildness>0.85</wildness>
-      <leatherColor>(180,180,180)</leatherColor>
-      <leatherInsulation>1.0</leatherInsulation>
-      <leatherLabel>polarbearskin</leatherLabel>
-      <useMeatFrom>GrizzlyBear</useMeatFrom>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
     </race>
   </ThingDef>
 
@@ -289,10 +285,8 @@
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
       <foodType>VegetarianRoughAnimal, OmnivoreAnimal, OvivoreAnimal</foodType>
       <wildness>0.30</wildness>
-      <leatherColor>(112,82,65)</leatherColor>
-      <leatherInsulation>1.0</leatherInsulation>
-      <useleatherFrom>GrizzlyBear</useleatherFrom>
-      <useMeatFrom>GrizzlyBear</useMeatFrom>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
 	  <hediffGiverSets>
         <li>ThickPassiveSet</li>
       </hediffGiverSets>  
@@ -414,10 +408,8 @@
       <lifeExpectancy>25</lifeExpectancy>
       <gestationPeriodDays>45</gestationPeriodDays>
       <manhunterOnTameFailChance>0.010</manhunterOnTameFailChance>
-      <leatherColor>(80,80,80)</leatherColor>
-      <leatherInsulation>0.8</leatherInsulation>
-      <leatherLabel>bearskin</leatherLabel>
-      <useMeatFrom>GrizzlyBear</useMeatFrom>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
     </race>
   </ThingDef>
 

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_BigCats.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_BigCats.xml
@@ -67,22 +67,6 @@
       <baseHungerRate>0.3</baseHungerRate>
       <baseHealthScale>1.8</baseHealthScale>
       <foodType>CarnivoreAnimal,  CarnivoreAnimalStrict, OvivoreAnimal</foodType>
-      <leatherInsulation>0.9</leatherInsulation>
-      <leatherMarketValueFactor>7.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.2</MaxHitPoints>
-        <Beauty>1.35</Beauty>
-        <MarketValue>2.0</MarketValue>
-        <ArmorRating_Blunt>1.4</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.3</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.0</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.42</Insulation_Cold>
-        <Insulation_Heat>0.91</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.22</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.98</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <nuzzleMtbHours>80</nuzzleMtbHours>
       <wildness>0.80</wildness>
       <manhunterOnTameFailChance>0.025</manhunterOnTameFailChance>
@@ -133,9 +117,8 @@
       <MarketValue>1050</MarketValue>
     </statBases>
     <race>
-      <leatherColor>(177,136,112)</leatherColor>
-      <leatherInsulation>1.1</leatherInsulation>
-      <leatherLabel>Cougar Hide</leatherLabel>
+		<useMeatFrom>Elephant</useMeatFrom>
+		<useLeatherFrom>Elephant</useLeatherFrom>
     </race>
   </ThingDef>
   
@@ -199,8 +182,8 @@
       <MarketValue>1200</MarketValue>
     </statBases>
     <race>
-      <leatherLabel>pantherskin</leatherLabel>
-      <leatherColor>(60,60,60)</leatherColor>
+		<useMeatFrom>Elephant</useMeatFrom>
+		<useLeatherFrom>Elephant</useLeatherFrom>
     </race>
   </ThingDef>
 
@@ -322,9 +305,8 @@
       <baseHungerRate>0.19</baseHungerRate>
       <baseHealthScale>0.8</baseHealthScale>
       <foodType>CarnivoreAnimal, OvivoreAnimal</foodType>
-      <leatherColor>(173,155,138)</leatherColor>
-      <leatherInsulation>1.15</leatherInsulation>
-      <leatherLabel>lynxskin</leatherLabel>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <wildness>0.80</wildness>
       <manhunterOnTameFailChance>0.025</manhunterOnTameFailChance>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>
@@ -464,24 +446,8 @@
       <baseHungerRate>0.75</baseHungerRate>
       <baseHealthScale>1.3</baseHealthScale>
       <foodType>OmnivoreAnimal, OvivoreAnimal</foodType>
-      <leatherColor>(255,153,51)</leatherColor>
-      <leatherLabel>Tiger Fur</leatherLabel>
-      <leatherInsulation>2.0</leatherInsulation>
-	  <leatherMarketValueFactor>8</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.3</MaxHitPoints>
-        <Beauty>1.5</Beauty>
-        <MarketValue>1.8</MarketValue>
-        <ArmorRating_Blunt>1.7</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.5</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.2</ArmorRating_Electric>
-        <ArmorRating_Heat>1.9</ArmorRating_Heat>
-        <Insulation_Cold>1.17</Insulation_Cold>
-        <ArmorRating_Heat>1.12</ArmorRating_Heat>
-		<WorkToMake>1.3</WorkToMake>
-		<BedRestEffectiveness>1.2</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.0</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <gestationPeriodDays>35</gestationPeriodDays>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
       <wildness>0.85</wildness>
@@ -630,24 +596,8 @@
       <baseHungerRate>0.75</baseHungerRate>
       <baseHealthScale>1.3</baseHealthScale>
       <foodType>OmnivoreAnimal, OvivoreAnimal</foodType>
-      <leatherColor>(173,155,138)</leatherColor>
-      <leatherLabel>WhiteTiger Fur</leatherLabel>
-      <leatherInsulation>2.0</leatherInsulation>
-	  <leatherMarketValueFactor>8</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.3</MaxHitPoints>
-        <Beauty>1.5</Beauty>
-        <MarketValue>1.8</MarketValue>
-        <ArmorRating_Blunt>1.7</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.5</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.2</ArmorRating_Electric>
-        <ArmorRating_Heat>1.9</ArmorRating_Heat>
-        <Insulation_Cold>1.17</Insulation_Cold>
-        <ArmorRating_Heat>1.12</ArmorRating_Heat>
-		<WorkToMake>1.3</WorkToMake>
-		<BedRestEffectiveness>1.2</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.0</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <gestationPeriodDays>35</gestationPeriodDays>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
       <wildness>0.85</wildness>
@@ -750,7 +700,7 @@
 	
   <ThingDef ParentName="BigCatThingBase">
     <defName>SnowLeopard</defName>
-    <label>SnowLeopard</label>
+    <label>snow leopard</label>
     <description>An agile and powerful big cat native to the cold biomes. As solitary ambush predators, Snow leopards are masters of taking down both large and small prey. Onlookers tend to focus on their graceful movements, while those in closer contact usually notice their skull-crushing strength.</description>
     <statBases>
       <MoveSpeed>7</MoveSpeed>
@@ -759,8 +709,8 @@
       <MarketValue>1200</MarketValue>
     </statBases>
     <race>
-      <leatherLabel>Leopard skin</leatherLabel>
-      <leatherColor>(173,155,138)</leatherColor>
+		<useMeatFrom>Elephant</useMeatFrom>
+		<useLeatherFrom>Elephant</useLeatherFrom>
     </race>
   </ThingDef>
 
@@ -855,8 +805,8 @@
       <baseBodySize>1.15</baseBodySize>
       <baseHungerRate>0.75</baseHungerRate>
       <baseHealthScale>1.3</baseHealthScale>
-      <leatherLabel>Jaguar skin</leatherLabel>
-      <leatherColor>(173,155,138)</leatherColor>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
     </race>
   </ThingDef>
 

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Bugs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Bugs.xml
@@ -39,8 +39,7 @@
       <foodType>CarnivoreAnimal, Corpse, AnimalProduct, OmnivoreAnimal</foodType>
       <fleshType>Insectoid</fleshType>
       <bloodDef>FilthBloodInsect</bloodDef>
-      <meatColor>(160,150,140)</meatColor>
-	  <meatLabel>Mosquito Meat</meatLabel>
+	  <useMeatFrom>Megaspider</useMeatFrom>
       <petness>0</petness>
       <wildness>0.99</wildness>
       <manhunterOnTameFailChance>0.5</manhunterOnTameFailChance>
@@ -159,11 +158,10 @@
       <baseHungerRate>1.8</baseHungerRate>
       <baseBodySize>0.18</baseBodySize>
       <baseHealthScale>0.4</baseHealthScale>
-      <meatLabel>Crashbug Meat</meatLabel>
+      <useMeatFrom>Megaspider</useMeatFrom>
       <foodType>Corpse</foodType>
       <fleshType>Insectoid</fleshType>
       <bloodDef>FilthBloodInsect</bloodDef>
-      <meatColor>(160,150,140)</meatColor>
       <petness>0.15</petness>
       <wildness>0.85</wildness>
       <manhunterOnTameFailChance>0.01</manhunterOnTameFailChance>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Cats.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Cats.xml
@@ -112,30 +112,15 @@
   
   <ThingDef ParentName="AnimalDomesticCatBase">
     <defName>Cat</defName>
-    <label>Cat</label>
+    <label>common cat</label>
     <description>Cats are small, furry, domesticated, and carnivorous mammals that come in a variety of breeds. With their small sharp claws, they are often referenced as "fluffy balls of DEATH!".</description>
     <race>
       <thinkTreeMain>DomesticCat</thinkTreeMain>
       <body>QuadrupedAnimalWithPawsAndTail</body>
       <predator>true</predator>
       <maxPreyBodySize>0.26</maxPreyBodySize>
-	  <meatLabel>Cat Meat</meatLabel>
-      <leatherLabel>Cat Fur</leatherLabel>
-	  <leatherMarketValueFactor>4</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.7</MaxHitPoints>
-        <Beauty>1.3</Beauty>
-        <MarketValue>1.7</MarketValue>
-        <ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.12</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.3</ArmorRating_Electric>
-        <ArmorRating_Heat>0.7</ArmorRating_Heat>
-        <Insulation_Cold>1.0</Insulation_Cold>
-        <ArmorRating_Heat>0.9</ArmorRating_Heat>
-		<WorkToMake>1.1</WorkToMake>
-		<BedRestEffectiveness>0.9</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.0</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
     </race>
   </ThingDef>
   
@@ -189,7 +174,7 @@
   
 	<PawnKindDef ParentName="AnimalKindBase">
 		<defName>MiniMaineCoon</defName>
-		<label>miniature Maine Coon</label>
+		<label>miniature maine coon</label>
 		<race>Cat</race>
 		<combatPower>35</combatPower>
 		<lifeStages>
@@ -241,7 +226,7 @@
 
 	<PawnKindDef ParentName="AnimalKindBase">
 		<defName>MaineCoon</defName>
-		<label>Maine Coon</label>
+		<label>maine coon</label>
 		<race>Cat</race>
 		<combatPower>30</combatPower>
 		<lifeStages>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Cold.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Cold.xml
@@ -3,8 +3,8 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Snork</defName>
-    <label>Snork</label>
-    <description>There's a distinct resemblance between Snorks and Walruses but it's impossible to tell which came first as lot of the datalogs of Earthen fauna has been poorly kept and corrupted. Their tusks are a very high demand luxury item.</description>
+    <label>snork</label>
+    <description>There's a distinct resemblance between snorks and walruses but it's impossible to tell which came first as lot of the datalogs of Earthen fauna has been poorly kept and corrupted. Their tusks are a very high demand luxury item.</description>
     <statBases>
 	  <Mass>140</Mass>
       <MoveSpeed>1.00</MoveSpeed>
@@ -29,25 +29,8 @@
       <baseBodySize>0.6</baseBodySize>
       <baseHealthScale>1.5</baseHealthScale>
       <foodType>Corpse, AnimalProduct, OvivoreAnimal, OmnivoreAnimal</foodType>
-	  <meatLabel>Snork Blubber</meatLabel>
-      <leatherColor>(101,94,85)</leatherColor>
-      <leatherLabel>Snork Hide</leatherLabel>
-	  <leatherMarketValueFactor>7</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.4</MaxHitPoints>
-        <Beauty>1</Beauty>
-        <MarketValue>1.7</MarketValue>
-        <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.3</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.9</ArmorRating_Electric>
-        <ArmorRating_Heat>0.9</ArmorRating_Heat>
-        <Insulation_Cold>1.43</Insulation_Cold>
-        <ArmorRating_Heat>0.44</ArmorRating_Heat>
-		<WorkToMake>1.7</WorkToMake>
-		<BedRestEffectiveness>0.9</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.14</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <leatherInsulation>1.75</leatherInsulation>
+	  <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
       <gestationPeriodDays>22</gestationPeriodDays>
       <wildness>0.55</wildness>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
@@ -86,7 +69,7 @@
 
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>Snork</defName>
-    <label>Snork</label>
+    <label>snork</label>
     <race>Snork</race>
     <combatPower>60</combatPower>
     <wildSpawn_EcoSystemWeight>0.33</wildSpawn_EcoSystemWeight>
@@ -131,7 +114,7 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Terramorph</defName>
-    <label>Terramorph</label>
+    <label>terramorph</label>
     <description>Terramorphs are a type of large beetle with a pair of sharp tusks, thick chitin plating and a toxic bite. They are well adapted to survive in extreme temperatures, be it glacial environments or scorching deserts.</description> 
     <statBases>
 	  <Mass>170</Mass>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Dogs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Dogs.xml
@@ -89,7 +89,7 @@
   
   <ThingDef ParentName="AnimalDogBase">
     <defName>YorkshireTerrier</defName>
-    <label>Yorkshire Terrier</label>
+    <label>yorkshire terrier</label>
     <description>A small, even-tempered dog. Originally bred to hunt rats, it later became a show and companionship animal. This breed of dog is often nicknamed "Yorkie" to shorten the name.</description>
     <statBases>
 	  <Mass>10</Mass>
@@ -128,23 +128,8 @@
 	  <baseHungerRate>0.25</baseHungerRate>
       <baseHealthScale>0.35</baseHealthScale>
       <foodType>OmnivoreAnimal, OvivoreAnimal</foodType>
-	  <meatLabel>Dog Meat</meatLabel>
-      <leatherLabel>Yorkshire Terrier Fur</leatherLabel>
-      <leatherMarketValueFactor>2.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.7</MaxHitPoints>
-        <Beauty>1</Beauty>
-        <MarketValue>1.2</MarketValue>
-        <ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1</ArmorRating_Heat>
-        <Insulation_Cold>1.13</Insulation_Cold>
-        <Insulation_Heat>0.7</Insulation_Heat>
-		<WorkToMake>1.1</WorkToMake>
-		<BedRestEffectiveness>1.05</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
       <nuzzleMtbHours>18</nuzzleMtbHours>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
       <wildness>0</wildness>
@@ -154,7 +139,7 @@
   
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>YorkshireTerrier</defName>
-    <label>Yorkshire Terrier</label>
+    <label>yorkshire terrier</label>
     <race>YorkshireTerrier</race>
     <combatPower>75</combatPower>
     <lifeStages>
@@ -208,7 +193,7 @@
   
   <ThingDef ParentName="AnimalDogBase">
     <defName>Husky</defName>
-    <label>Husky</label>
+    <label>husky</label>
     <description>A large, energetic dog with a thick fur coat for remaining comfortable in arctic environments.</description>
     <statBases>
       <MoveSpeed>5.2</MoveSpeed>
@@ -217,25 +202,8 @@
       <ImmunityGainSpeed>1.3</ImmunityGainSpeed>
     </statBases>
     <race>
-      <useMeatFrom>YorkshireTerrier</useMeatFrom>
-      <leatherColor>(108,95,70)</leatherColor>
-      <leatherLabel>Husky Fur</leatherLabel>
-      <leatherInsulation>1.6</leatherInsulation>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.0</MaxHitPoints>
-        <Beauty>1.2</Beauty>
-        <MarketValue>1.5</MarketValue>
-        <ArmorRating_Blunt>1.2</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.3</ArmorRating_Electric>
-        <ArmorRating_Heat>0.7</ArmorRating_Heat>
-        <Insulation_Cold>1.39</Insulation_Cold>
-        <Insulation_Heat>0.52</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.0</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
     </race>
   </ThingDef>
   
@@ -297,7 +265,7 @@
   
   <ThingDef ParentName="AnimalDogBase">
     <defName>LabradorRetriever</defName>
-    <label>Labrador Retriever</label>
+    <label>labrador retriever</label>
     <description>A very versatile, medium-sized dog. Originally bred to retrieve birds shot on the hunt, the lab is also an excellent guard dog, play pal, and family friend.</description>
     <statBases>
       <MoveSpeed>5.0</MoveSpeed>
@@ -332,25 +300,8 @@
     <race>
       <baseBodySize>0.6</baseBodySize>
       <baseHealthScale>0.6</baseHealthScale>
-      <useMeatFrom>YorkshireTerrier</useMeatFrom>
-      <leatherColor>(220,198,160)</leatherColor>
-      <leatherLabel>Labrador Retriever Fur</leatherLabel>
-      <leatherInsulation>1.3</leatherInsulation>
-      <leatherMarketValueFactor>3.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.0</MaxHitPoints>
-        <Beauty>1</Beauty>
-        <MarketValue>1.2</MarketValue>
-        <ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.15</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.2</ArmorRating_Electric>
-        <ArmorRating_Heat>1.2</ArmorRating_Heat>
-        <Insulation_Cold>1.25</Insulation_Cold>
-        <Insulation_Heat>0.72</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.0</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
     </race>
   </ThingDef>
 
@@ -409,7 +360,7 @@
  
   <ThingDef ParentName="AnimalDogBase">
     <defName>GermanShepherd</defName>
-    <label>Shepherd</label>
+    <label>shepherd</label>
     <description>A large working dog that is usually tan and black in color. It is one of the most intelligent breeds of dog and they are prized for their trainability.</description>
     <statBases>
       <MoveSpeed>5.6</MoveSpeed>
@@ -453,25 +404,8 @@
       <baseBodySize>0.5</baseBodySize>
       <baseHungerRate>0.8</baseHungerRate>
       <baseHealthScale>0.9</baseHealthScale>
-      <useMeatFrom>YorkshireTerrier</useMeatFrom>
-      <leatherColor>(210,180,140)</leatherColor>
-      <leatherLabel>German Shepherd Fur</leatherLabel>
-      <leatherMarketValueFactor>3.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.0</MaxHitPoints>
-        <Beauty>1</Beauty>
-        <MarketValue>1.2</MarketValue>
-        <ArmorRating_Blunt>1.2</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.15</ArmorRating_Sharp>
-        <ArmorRating_Electric>0.8</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.26</Insulation_Cold>
-        <Insulation_Heat>0.56</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.2</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <leatherInsulation>1.1</leatherInsulation>
+	  <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
       <lifeExpectancy>14</lifeExpectancy>
     </race>
   </ThingDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Exotic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Exotic.xml
@@ -92,7 +92,7 @@
       <baseHungerRate>2</baseHungerRate>
       <baseHealthScale>7</baseHealthScale>
       <foodType>OmnivoreAnimal, OvivoreAnimal</foodType>
-      <meatLabel>dragon meat</meatLabel>
+	  <useMeatFrom>Muffalo</useMeatFrom>
       <leatherColor>(176,102,47)</leatherColor>
       <leatherLabel>feenix leather</leatherLabel>
       <leatherMarketValueFactor>11.0</leatherMarketValueFactor>
@@ -309,7 +309,7 @@
       </leatherStatFactors>
       <leatherInsulation>1.5</leatherInsulation>
       <nuzzleMtbHours>120</nuzzleMtbHours>
-      <useMeatFrom>Feenix</useMeatFrom>
+      <useMeatFrom>Muffalo</useMeatFrom>
       <trainableIntelligence>Intermediate</trainableIntelligence>
       <wildness>0.90</wildness>
       <manhunterOnTameFailChance>0.005</manhunterOnTameFailChance>
@@ -486,7 +486,7 @@
       <baseHungerRate>2</baseHungerRate>
       <baseHealthScale>8</baseHealthScale>
       <foodType>OmnivoreAnimal, OvivoreAnimal</foodType>
-	  <meatLabel>kirin Meat</meatLabel>
+	  <useMeatFrom>Muffalo</useMeatFrom>
       <leatherLabel>kirin hide</leatherLabel>
       <leatherColor>(96,135,34)</leatherColor>
       <leatherMarketValueFactor>9.0</leatherMarketValueFactor>
@@ -696,7 +696,7 @@
       <baseHealthScale>5.8</baseHealthScale>
       <foodType>CarnivoreAnimal, CarnivoreAnimalStrict</foodType>
       <leatherColor>(138,80,154)</leatherColor>
-      <useMeatFrom>Feenix</useMeatFrom>
+      <useMeatFrom>Muffalo</useMeatFrom>
       <leatherLabel>behir leather</leatherLabel>
       <leatherMarketValueFactor>10.0</leatherMarketValueFactor>
       <leatherStatFactors>
@@ -893,9 +893,9 @@
       <petness>0</petness>
       <nameGenerator>NamerAnimalGeneric</nameGenerator>
       <trainableIntelligence>Advanced</trainableIntelligence>
-	  <meatLabel>Barghest Meat</meatLabel>
+	  <useMeatFrom>Elephant</useMeatFrom>
       <leatherColor>(220,220,220)</leatherColor>
-      <leatherLabel>Barghest Fur</leatherLabel>
+      <leatherLabel>barghest fur</leatherLabel>
       <leatherInsulation>1.5</leatherInsulation>
       <leatherMarketValueFactor>8.0</leatherMarketValueFactor>
       <leatherStatFactors>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
@@ -5,7 +5,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Chicken</defName>
-    <label>Chicken</label>
+    <label>chicken</label>
     <description>Being the most traditional domesticated farm bird, the chicken is raised for its eggs and meat.</description>
     <statBases>
 	  <Mass>3</Mass>
@@ -39,7 +39,8 @@
       <baseBodySize>0.23</baseBodySize>
       <baseHealthScale>0.35</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Chicken Meat</meatLabel>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+      <useLeatherFrom>Squirrel</useLeatherFrom>
       <trainableIntelligence>None</trainableIntelligence>
       <wildness>0</wildness>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
@@ -140,7 +141,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Pig</defName>
-    <label>Pig</label>
+    <label>pig</label>
     <description>The pig was one of the first animals domesticated by humans. It is commonly raised for meat and leather. While capable of being an omnivore, domesticated pigs are raised as herbivores.</description>
     <statBases>
 	  <Mass>30</Mass>
@@ -148,6 +149,7 @@
       <ComfyTemperatureMin>-5</ComfyTemperatureMin>
       <MarketValue>310</MarketValue>
 	  <ArmorPenetration>0.03</ArmorPenetration>
+	  <MeatAmount>75</MeatAmount>
     </statBases>
     <verbs>
       <li>
@@ -164,28 +166,12 @@
       <baseBodySize>0.55</baseBodySize>
       <baseHealthScale>1.3</baseHealthScale>
       <foodType>OmnivoreRoughAnimal</foodType>
-      <leatherColor>(201,167,135)</leatherColor>
-      <leatherLabel>Pig Hide</leatherLabel>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.1</MaxHitPoints>
-        <Beauty>0.8</Beauty>
-        <MarketValue>1.5</MarketValue>
-        <ArmorRating_Blunt>1.3</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.4</ArmorRating_Electric>
-        <ArmorRating_Heat>1.6</ArmorRating_Heat>
-        <Insulation_Cold>0.95</Insulation_Cold>
-        <Insulation_Heat>1.11</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>0.95</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <nuzzleMtbHours>80</nuzzleMtbHours>
       <wildness>0.07</wildness>
       <trainableIntelligence>Advanced</trainableIntelligence>
-      <meatLabel>Pork</meatLabel>
       <gestationPeriodDays>13</gestationPeriodDays>
       <litterSizeCurve>
         <points>
@@ -307,7 +293,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Cow</defName>
-    <label>Cow</label>
+    <label>cow</label>
     <description>A Cow is a large, common domestic animal. It can produce large amounts of milk, or can be slaughtered for delicious meat called beef.</description>
     <statBases>
 	  <Mass>120</Mass>
@@ -338,30 +324,13 @@
       <baseHungerRate>1.3</baseHungerRate>
       <baseHealthScale>1.8</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-      <leatherColor>(201,201,201)</leatherColor>
-      <leatherLabel>Cow Hide</leatherLabel>
-      <leatherInsulation>1.4</leatherInsulation>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
       <gestationPeriodDays>50</gestationPeriodDays>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.0</MaxHitPoints>
-        <Beauty>1</Beauty>
-        <MarketValue>1.5</MarketValue>
-        <ArmorRating_Blunt>1.3</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.6</ArmorRating_Heat>
-        <Insulation_Cold>1.27</Insulation_Cold>
-        <Insulation_Heat>1.01</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <wildness>0.05</wildness>
       <nuzzleMtbHours>80</nuzzleMtbHours>
       <trainableIntelligence>Intermediate</trainableIntelligence>
-      <meatLabel>Cow Beef</meatLabel>
       <litterSizeCurve>
         <points>
           <li>(0.5, 0)</li>
@@ -487,7 +456,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Alpaca</defName>
-    <label>Alpaca</label>
+    <label>alpaca</label>
     <description>A medium-sized ungulate closely related to the llama, the alpaca is often farmed for its remarkably soft wool.</description>
     <statBases>
 	  <Mass>90</Mass>
@@ -527,25 +496,8 @@
       <baseHungerRate>0.3</baseHungerRate>
       <baseHealthScale>1.2</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Alpaca Meat</meatLabel>
-      <leatherColor>(237,216,174)</leatherColor>
-      <leatherLabel>Alpaca Leather</leatherLabel>
-      <leatherInsulation>1.3</leatherInsulation>
-      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.9</MaxHitPoints>
-        <Beauty>1.3</Beauty>
-        <MarketValue>1.5</MarketValue>
-        <ArmorRating_Blunt>1.2</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.15</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.8</ArmorRating_Heat>
-        <Insulation_Cold>1.23</Insulation_Cold>
-        <Insulation_Heat>1.01</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.2</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+      <useLeatherFrom>Muffalo</useLeatherFrom>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
       <wildness>0.1</wildness>
       <nuzzleMtbHours>70</nuzzleMtbHours>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Foxes.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Foxes.xml
@@ -64,23 +64,7 @@
       <baseBodySize>0.55</baseBodySize>
       <baseHungerRate>0.12</baseHungerRate>
       <baseHealthScale>0.70</baseHealthScale>
-      <foodType>CarnivoreAnimal, OmnivoreAnimal, OvivoreAnimal</foodType>
-      <leatherInsulation>1.0</leatherInsulation>
-      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.9</MaxHitPoints>
-        <Beauty>1.6</Beauty>
-        <MarketValue>1.4</MarketValue>
-        <ArmorRating_Blunt>1.1</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.2</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.32</Insulation_Cold>
-        <Insulation_Heat>0.5</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.35</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+      <foodType>CarnivoreAnimal, OmnivoreAnimal, OvivoreAnimal</foodType>      
       <gestationPeriodDays>18</gestationPeriodDays>
       <nameOnTameChance>1</nameOnTameChance>
       <trainableIntelligence>Advanced</trainableIntelligence>
@@ -136,12 +120,11 @@
 
   <ThingDef ParentName="ThingBaseFox">
     <defName>FoxFennec</defName>
-    <label>Fennec fox</label>
+    <label>fennec fox</label>
     <description>A small fox originally from the northern part of Earth's Africa continent. It hunts small creatures and has very large ears.</description>
     <race>
-      <leatherColor>(197,161,103)</leatherColor>
-      <leatherLabel>fennec foxskin</leatherLabel>
-      <meatLabel>foxmeat</meatLabel>
+      <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Squirrel</useLeatherFrom>
     </race>
   </ThingDef>
 
@@ -192,12 +175,11 @@
 
   <ThingDef ParentName="ThingBaseFox">
     <defName>FoxRed</defName>
-    <label>Red Fox</label>
+    <label>red fox</label>
     <description>A small solitary canine evolved for hunting small prey in temperate climates.</description>
     <race>
-      <leatherColor>(178,100,34)</leatherColor>
-      <leatherLabel>red foxskin</leatherLabel>
-      <useMeatFrom>FoxFennec</useMeatFrom>
+      <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Squirrel</useLeatherFrom>
     </race>
   </ThingDef>
 
@@ -248,12 +230,11 @@
   
   <ThingDef ParentName="ThingBaseFox">
     <defName>FoxArctic</defName>
-    <label>Arctic fox</label>
+    <label>arctic fox</label>
     <description>A small predator adapted for the far north. It usually hunts small game like mice and voles, sometimes burrowing through a meter of snow to reach its prey.</description>
     <race>
-      <leatherColor>(200,200,200)</leatherColor>
-      <leatherLabel>arctic foxskin</leatherLabel>
-      <useMeatFrom>FoxFennec</useMeatFrom>
+      <useMeatFrom>Elephant</useMeatFrom>
+      <useLeatherFrom>Squirrel</useLeatherFrom>
     </race>
   </ThingDef>
 

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Giants.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Giants.xml
@@ -5,7 +5,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Elephant</defName>
-    <label>Elephant</label>
+    <label>elephant</label>
     <description>An Elephant is the largest unmodified land mammal. It has a pair of long, ivory tusks that can improvise as tools for moving objects or as deadly weapons. It has a long arm-like trunk on its head that can grip and manipulate objects, much like a hand with fingers would.</description>
     <statBases>
 	  <Mass>340</Mass>
@@ -14,6 +14,7 @@
       <MarketValue>3200</MarketValue>
       <ImmunityGainSpeed>1.1</ImmunityGainSpeed>
 	  <ArmorPenetration>0.7</ArmorPenetration>
+	  <MeatAmount>200</MeatAmount>
     </statBases>
     <verbs>
       <li>
@@ -39,23 +40,23 @@
       <body>QuadrupedAnimalWithHoovesTusksAndTrunk</body>
       <baseHungerRate>2.2</baseHungerRate>
       <baseBodySize>1.7</baseBodySize>
-      <baseHealthScale>3.4</baseHealthScale>
+      <baseHealthScale>3.5</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Elephant Meat</meatLabel>
-      <leatherLabel>Elephant Hide</leatherLabel>
-      <leatherColor>(130,126,119)</leatherColor>
-      <leatherMarketValueFactor>9.0</leatherMarketValueFactor>
+	  <meatLabel>raw meat</meatLabel>
+      <leatherLabel>thick leather</leatherLabel>
+      <leatherColor>(162,106,57)</leatherColor>
+      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
       <leatherStatFactors>
 		<MaxHitPoints>1.7</MaxHitPoints>
-        <Beauty>1.5</Beauty>
+        <Beauty>1</Beauty>
         <MarketValue>2</MarketValue>
-        <ArmorRating_Blunt>2.2</ArmorRating_Blunt>
-        <ArmorRating_Sharp>2.3</ArmorRating_Sharp>
+        <ArmorRating_Blunt>1.6</ArmorRating_Blunt>
+        <ArmorRating_Sharp>1.7</ArmorRating_Sharp>
         <ArmorRating_Electric>1.1</ArmorRating_Electric>
         <ArmorRating_Heat>1.4</ArmorRating_Heat>
-        <Insulation_Cold>0.65</Insulation_Cold>
+        <Insulation_Cold>1.0</Insulation_Cold>
         <Insulation_Heat>1.25</Insulation_Heat>
-		<WorkToMake>1.8</WorkToMake>
+		<WorkToMake>2.0</WorkToMake>
 		<BedRestEffectiveness>0.7</BedRestEffectiveness>
 		<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
       </leatherStatFactors>
@@ -166,8 +167,8 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Megasloth</defName>
-    <label>Megasloth</label>
-    <description>A type of ground sloth, megatheria are giant, solitary herbivores. Long extinct after being wiped out by the natives of Earth's America continent, the ground sloth was later brought back using advanced cloning and artificial gestators.</description>
+    <label>megasloth</label>
+    <description>A type of ground sloth, megasloth are giant, solitary herbivores. Long extinct after being wiped out by the natives of Earth's America continent, the ground sloth was later brought back using advanced cloning and artificial gestators.</description>
     <statBases>
 	  <Mass>320</Mass>
       <MoveSpeed>3.5</MoveSpeed>
@@ -197,23 +198,8 @@
       <baseBodySize>4.0</baseBodySize>
       <baseHealthScale>7.0</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-      <leatherColor>(189,161,116)</leatherColor>
-      <leatherInsulation>1.0</leatherInsulation>
-      <leatherMarketValueFactor>7.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.7</MaxHitPoints>
-        <Beauty>1.5</Beauty>
-        <MarketValue>2</MarketValue>
-        <ArmorRating_Blunt>1.8</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.8</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.5</ArmorRating_Electric>
-        <ArmorRating_Heat>1.4</ArmorRating_Heat>
-        <Insulation_Cold>1.2</Insulation_Cold>
-        <Insulation_Heat>1.2</Insulation_Heat>
-		<WorkToMake>1.8</WorkToMake>
-		<BedRestEffectiveness>0.85</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.2</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <gestationPeriodDays>60</gestationPeriodDays>
       <wildness>0.90</wildness>
       <manhunterOnDamageChance>0.5</manhunterOnDamageChance>
@@ -315,7 +301,7 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Thrumbo</defName>
-    <label>Thrumbo</label>
+    <label>thrumbo</label>
     <description>A Thrumbo is a gigantic creature of unknown origin. The Thrumbo is gentle by nature, but extremely dangerous when enraged. Its long fur is exceptionally beautiful and treasured, and its razor-sharp horn is very valuable in most markets. Legends say that an old Thrumbo is the wisest creature in the universe - it simply chooses not to speak.</description>
     <statBases>
 	  <Mass>330</Mass>
@@ -343,11 +329,11 @@
       <baseHungerRate>3.2</baseHungerRate>
       <baseHealthScale>13.0</baseHealthScale>
       <foodType>VegetarianRoughAnimal, DendrovoreAnimal</foodType>
-	  <meatLabel>Thrumbo Meat</meatLabel>
+	  <useMeatFrom>Muffalo</useMeatFrom>
       <leatherColor>(233,233,233)</leatherColor>
       <leatherInsulation>1.6</leatherInsulation>
       <leatherCommonalityFactor>0.1</leatherCommonalityFactor>
-      <leatherLabel>Thrumbo Fur</leatherLabel>
+      <leatherLabel>thrumbo fur</leatherLabel>
       <leatherMarketValueFactor>8.0</leatherMarketValueFactor>
       <leatherStatFactors>
 		<MaxHitPoints>1.8</MaxHitPoints>
@@ -456,12 +442,13 @@
   <ThingDef ParentName="AnimalThingBase">
     <defName>Megabadger</defName>
     <label>megabadger</label>
-    <description>A truly massive badger- roughly the size of an elephant in adulthood. Megabadgers are incredibly dangerous creatures, with jaws able to bite a fully grown tree to splinters and skin thick enough to stop most bullets. They are not without the characteristic vicious attitude known of smaller badger species. \n\nHaving been known to wipe out entire colonies in the rimworlds, it is advisable under almost all circumstances to completely avoid interaction with Megabadgers.</description>
+    <description>A truly massive badger - roughly the size of an elephant in adulthood. Megabadgers are incredibly dangerous creatures, with jaws able to bite a fully grown tree to splinters and skin thick enough to stop most bullets. They are not without the characteristic vicious attitude known of smaller badger species. \n\nHaving been known to wipe out entire colonies in the rimworlds, it is advisable under almost all circumstances to completely avoid interaction with megabadgers.</description>
     <statBases>
 	  <Mass>290</Mass>
       <MoveSpeed>4.5</MoveSpeed>
       <ComfyTemperatureMin>-45</ComfyTemperatureMin>
       <MarketValue>2200</MarketValue>
+	  <MeatAmount>215</MeatAmount>
     </statBases>
     <verbs>
       <li>
@@ -494,24 +481,8 @@
       <packAnimal>true</packAnimal>
       <predator>true</predator>
       <foodType>OmnivoreAnimal, OvivoreAnimal</foodType>
-      <leatherLabel>megabadger pelt</leatherLabel>
-      <leatherColor>(130,102,50)</leatherColor>
-      <leatherInsulation>1</leatherInsulation>
-      <leatherMarketValueFactor>7.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-        <MaxHitPoints>1.7</MaxHitPoints>
-        <Beauty>1.5</Beauty>
-        <MarketValue>1.8</MarketValue>
-        <ArmorRating_Blunt>1.9</ArmorRating_Blunt>
-        <ArmorRating_Sharp>2.0</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.2</ArmorRating_Electric>
-        <ArmorRating_Heat>1.3</ArmorRating_Heat>
-        <Insulation_Cold>1.2</Insulation_Cold>
-        <Insulation_Heat>1.0</Insulation_Heat>
-        <WorkToMake>1.8</WorkToMake>
-        <BedRestEffectiveness>0.85</BedRestEffectiveness>
-        <ImmunityGainSpeedFactor>1.0</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <gestationPeriodDays>60</gestationPeriodDays>
       <wildness>0.98</wildness>
       <manhunterOnTameFailChance>0.10</manhunterOnTameFailChance>
@@ -603,7 +574,7 @@
   
 <ThingDef ParentName="AnimalThingBase">
     <defName>WoolyRhino</defName>
-    <label>wooly rhino</label>
+    <label>woolly rhino</label>
     <description>A rhinocerous almost entirely covered in a coarse fur coat, fit for much colder climates than its hairless cousins.</description>
     <statBases>
 	  <Mass>190</Mass>
@@ -611,6 +582,7 @@
       <ComfyTemperatureMax>15</ComfyTemperatureMax>
       <ComfyTemperatureMin>-40</ComfyTemperatureMin>
       <MarketValue>1200</MarketValue>
+	  <MeatAmount>170</MeatAmount>
     </statBases>
     <verbs>
       <li>
@@ -635,25 +607,8 @@
       <baseBodySize>3.0</baseBodySize>
       <baseHealthScale>3.5</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-      <leatherColor>(96,80,59)</leatherColor>
-      <leatherLabel>wooly rhinohide</leatherLabel>
-      <leatherInsulation>0.9</leatherInsulation>
-      <leatherMarketValueFactor>7</leatherMarketValueFactor>
-      <leatherStatFactors>
-        <MaxHitPoints>1.6</MaxHitPoints>
-        <Beauty>0.9</Beauty>
-        <MarketValue>1.8</MarketValue>
-        <ArmorRating_Blunt>2.5</ArmorRating_Blunt>
-        <ArmorRating_Sharp>2.5</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.0</ArmorRating_Electric>
-        <ArmorRating_Heat>1.5</ArmorRating_Heat>
-        <Insulation_Cold>1.4</Insulation_Cold>
-        <Insulation_Heat>0.4</Insulation_Heat>
-        <WorkToMake>1.7</WorkToMake>
-        <BedRestEffectiveness>0.8</BedRestEffectiveness>
-        <ImmunityGainSpeedFactor>0.75</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <useMeatFrom>Rhinoceros</useMeatFrom>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <wildness>0.90</wildness>
       <manhunterOnTameFailChance>0.10</manhunterOnTameFailChance>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>
@@ -690,10 +645,10 @@
   
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>WoolyRhino</defName>
-    <label>wooly rhino</label>
+    <label>woolly rhino</label>
     <race>WoolyRhino</race>
     <combatPower>290</combatPower>
-    <wildSpawn_EcoSystemWeight>0.2</wildSpawn_EcoSystemWeight>
+    <wildSpawn_EcoSystemWeight>1</wildSpawn_EcoSystemWeight>
     <wildSpawn_spawnWild>true</wildSpawn_spawnWild>
     <wildSpawn_GroupSizeRange>
       <min>1</min>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Hares.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Hares.xml
@@ -74,26 +74,11 @@
   
   <ThingDef ParentName="BaseHare">
     <defName>Hare</defName>
-    <label>Hare</label>
+    <label>hare</label>
     <description>This small, solitary herbivore can swiftly hop away from danger.</description>
     <race>
-      <leatherColor>(131,128,108)</leatherColor>
-      <leatherInsulation>1.2</leatherInsulation>
-      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.7</MaxHitPoints>
-        <Beauty>1.6</Beauty>
-        <MarketValue>1.3</MarketValue>
-        <ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.05</ArmorRating_Sharp>
-        <ArmorRating_Electric>1</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.42</Insulation_Cold>
-        <Insulation_Heat>0.44</Insulation_Heat>
-		<WorkToMake>1.1</WorkToMake>
-		<BedRestEffectiveness>1.4</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
     </race>
   </ThingDef>
   
@@ -145,37 +130,20 @@
 
   <ThingDef ParentName="BaseHare">
     <defName>Snowhare</defName>
-    <label>Snowhare</label>
+    <label>snow hare</label>
     <description>This hardy, animal survives the brutal winters of the north by burrowing through snow and finding prey underneath, or hibernating the worst months away.</description>
     <statBases>
       <ComfyTemperatureMin>-70</ComfyTemperatureMin>
     </statBases>
     <race>
-      <leatherColor>(180,180,180)</leatherColor>
-      <leatherInsulation>1.6</leatherInsulation>
-	  <leatherLabel>Snowhare Fur</leatherLabel>
-      <useMeatFrom>Hare</useMeatFrom>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.7</MaxHitPoints>
-        <Beauty>1.6</Beauty>
-        <MarketValue>1.3</MarketValue>
-        <ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.05</ArmorRating_Sharp>
-        <ArmorRating_Electric>1</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.51</Insulation_Cold>
-        <Insulation_Heat>0.42</Insulation_Heat>
-		<WorkToMake>1.1</WorkToMake>
-		<BedRestEffectiveness>1.4</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
     </race>
   </ThingDef>
   
   <PawnKindDef ParentName="HareBase">
     <defName>Snowhare</defName>
-    <label>snowhare</label>
+    <label>snow hare</label>
     <race>Snowhare</race>
     <lifeStages>
       <li>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Horse.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Horse.xml
@@ -48,24 +48,8 @@
       <baseHealthScale>1.6</baseHealthScale>
       <petness>0.5</petness>
       <foodType>VegetarianRoughAnimal</foodType>
-      <leatherColor>(121,90,58)</leatherColor>
-      <leatherLabel>horsehide</leatherLabel>
-      <leatherInsulation>0.9</leatherInsulation>
-      <leatherStatFactors>
-		<MaxHitPoints>0.8</MaxHitPoints>
-        <Beauty>1.4</Beauty>
-        <MarketValue>1.1</MarketValue>
-        <ArmorRating_Blunt>1.2</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.2</ArmorRating_Heat>
-        <Insulation_Cold>1.26</Insulation_Cold>
-        <Insulation_Heat>0.82</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <meatLabel>horsemeat</meatLabel>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.5</wildness>
       <manhunterOnDamageChance>0.025</manhunterOnDamageChance>
       <manhunterOnTameFailChance>0.01</manhunterOnTameFailChance>
@@ -105,17 +89,17 @@
     <race>Horse</race>
     <combatPower>55</combatPower>
     <wildSpawn_spawnWild>true</wildSpawn_spawnWild>
-    <wildSpawn_EcoSystemWeight>0.7</wildSpawn_EcoSystemWeight>
+    <wildSpawn_EcoSystemWeight>1.0</wildSpawn_EcoSystemWeight>
     <wildSpawn_GroupSizeRange>
-      <min>3</min>
-      <max>8</max>
+      <min>2</min>
+      <max>4</max>
     </wildSpawn_GroupSizeRange>
-    <labelMale>Horse stallion</labelMale>
-    <labelFemale>Horse mare</labelFemale>
+    <labelMale>horse stallion</labelMale>
+    <labelFemale>horse mare</labelFemale>
     <lifeStages>
       <li>
-	<labelMale>Horse colt</labelMale>
-	<labelFemale>Horse filly</labelFemale>
+	<labelMale>horse colt</labelMale>
+	<labelFemale>horse filly</labelFemale>
         <bodyGraphicData>
           <texPath>Things/Pawn/Animal/Horse/Horse</texPath>
           <drawSize>1.4</drawSize>
@@ -128,8 +112,8 @@
         </dessicatedBodyGraphicData>
       </li>
       <li>
-	<labelMale>Horse colt</labelMale>
-	<labelFemale>Horse filly</labelFemale>
+	<labelMale>horse colt</labelMale>
+	<labelFemale>horse filly</labelFemale>
         <bodyGraphicData>
           <texPath>Things/Pawn/Animal/Horse/Horse</texPath>
           <drawSize>1.9</drawSize>
@@ -239,24 +223,8 @@
       <baseHungerRate>0.9</baseHungerRate>
       <baseHealthScale>1.6</baseHealthScale>
       <foodType>VegetarianRoughAnimal, CarnivoreAnimal</foodType>
-      <leatherColor>(255,255,255)</leatherColor>
-      <leatherLabel>woolyhorse hide</leatherLabel>
-      <leatherInsulation>1.2</leatherInsulation>
-      <leatherStatFactors>
-		<MaxHitPoints>0.85</MaxHitPoints>
-        <Beauty>1.5</Beauty>
-        <MarketValue>1.3</MarketValue>
-        <ArmorRating_Blunt>1.2</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.2</ArmorRating_Heat>
-        <Insulation_Cold>1.38</Insulation_Cold>
-        <Insulation_Heat>0.80</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.27</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <useMeatFrom>Horse</useMeatFrom>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.85</wildness>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>
       <manhunterOnTameFailChance>0.075</manhunterOnTameFailChance>
@@ -292,21 +260,21 @@
   
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>WoolyHorse</defName>
-    <label>woolyhorse</label>
+    <label>woolly horse</label>
     <race>WoolyHorse</race>
     <combatPower>65</combatPower>
     <wildSpawn_spawnWild>true</wildSpawn_spawnWild>
-    <wildSpawn_EcoSystemWeight>0.8</wildSpawn_EcoSystemWeight>
+    <wildSpawn_EcoSystemWeight>1.0</wildSpawn_EcoSystemWeight>
     <wildSpawn_GroupSizeRange>
       <min>2</min>
-      <max>5</max>
+      <max>4</max>
     </wildSpawn_GroupSizeRange>
-    <labelMale>Woolyhorse stallion</labelMale>
-    <labelFemale>Woolyhorse mare</labelFemale>
+    <labelMale>woolly horse stallion</labelMale>
+    <labelFemale>woolly horse mare</labelFemale>
     <lifeStages>
       <li>
-	<labelMale>Woolyhorse colt</labelMale>
-	<labelFemale>Woolyhorse filly</labelFemale>
+	<labelMale>woolly horse colt</labelMale>
+	<labelFemale>woolly horse filly</labelFemale>
         <bodyGraphicData>
           <texPath>Things/Pawn/Animal/WoolyHorse/WoolyHorse</texPath>
           <drawSize>1.2</drawSize>
@@ -319,8 +287,8 @@
         </dessicatedBodyGraphicData>
       </li>
       <li>
-	<labelMale>Woolyhorse colt</labelMale>
-	<labelFemale>Woolyhorse filly</labelFemale>
+	<labelMale>woolly horse colt</labelMale>
+	<labelFemale>woolly horse filly</labelFemale>
         <bodyGraphicData>
           <texPath>Things/Pawn/Animal/WoolyHorse/WoolyHorse</texPath>
           <drawSize>2.0</drawSize>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Jackalope.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Jackalope.xml
@@ -23,20 +23,6 @@
       <baseHungerRate>0.23</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-      <leatherStatFactors>
-		<MaxHitPoints>0.65</MaxHitPoints>
-        <Beauty>1.68</Beauty>
-        <MarketValue>1.35</MarketValue>
-        <ArmorRating_Blunt>1.11</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.02</ArmorRating_Sharp>
-        <ArmorRating_Electric>1</ArmorRating_Electric>
-        <ArmorRating_Heat>0.75</ArmorRating_Heat>
-        <Insulation_Cold>1.3</Insulation_Cold>
-        <Insulation_Heat>0.64</Insulation_Heat>
-		<WorkToMake>1.1</WorkToMake>
-		<BedRestEffectiveness>1.4</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <wildness>0.75</wildness>
       <mateMtbHours>4</mateMtbHours>
       <nuzzleMtbHours>120</nuzzleMtbHours>
@@ -90,8 +76,8 @@
     <label>jackalope</label>
     <description>A bizarre type of rabbit, seemingly genetically altered to grow surprisingly sharp antlers from its skull.</description>
     <race>
-      <leatherColor>(185,140,100)</leatherColor>
-      <leatherInsulation>0.95</leatherInsulation>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
     </race>
     <statBases>
       <MarketValue>90</MarketValue>
@@ -189,9 +175,8 @@
 	</li>
       </verbs>
     <race>
-      <useMeatFrom>Hare</useMeatFrom>
-      <leatherColor>(180,180,180)</leatherColor>
-      <leatherInsulation>1.2</leatherInsulation>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
     </race>
   </ThingDef>
 

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Martens.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Martens.xml
@@ -13,9 +13,9 @@
       <body>QuadrupedAnimalWithPawsAndTail</body>
       <herdAnimal>false</herdAnimal>
       <predator>true</predator>
-      <baseBodySize>1.4</baseBodySize>
-      <baseHungerRate>0.3</baseHungerRate>
-      <baseHealthScale>1.8</baseHealthScale>
+      <baseBodySize>0.255</baseBodySize>
+      <baseHungerRate>0.25</baseHungerRate>
+      <baseHealthScale>.75</baseHealthScale>
       <foodType>CarnivoreAnimal, OvivoreAnimal</foodType>
       <leatherInsulation>0.9</leatherInsulation>
       <wildness>0.80</wildness>
@@ -116,24 +116,8 @@
       </li>
     </verbs>
     <race>
-      <leatherLabel>fisherpelt</leatherLabel>
-      <leatherColor>(82,61,45)</leatherColor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.8</MaxHitPoints>
-        <Beauty>1.65</Beauty>
-        <MarketValue>1.15</MarketValue>
-        <ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.05</ArmorRating_Sharp>
-        <ArmorRating_Electric>1</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.28</Insulation_Cold>
-        <Insulation_Heat>0.7</Insulation_Heat>
-		<WorkToMake>1.1</WorkToMake>
-		<BedRestEffectiveness>1.4</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <baseBodySize>0.255</baseBodySize>
-      <baseHealthScale>1.25</baseHealthScale>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <leatherInsulation>0.9</leatherInsulation>
       <manhunterOnTameFailChance>0.075</manhunterOnTameFailChance>
       <wildness>0.90</wildness>
@@ -268,24 +252,8 @@
       </li>
     </verbs>
     <race>
-      <leatherLabel>ermine pelt</leatherLabel>
-      <leatherColor>(255,255,255)</leatherColor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.7</MaxHitPoints>
-        <Beauty>1.6</Beauty>
-        <MarketValue>1.3</MarketValue>
-        <ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.05</ArmorRating_Sharp>
-        <ArmorRating_Electric>1</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.42</Insulation_Cold>
-        <Insulation_Heat>0.44</Insulation_Heat>
-		<WorkToMake>1.1</WorkToMake>
-		<BedRestEffectiveness>1.4</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <baseBodySize>0.2</baseBodySize>
-      <baseHealthScale>1.25</baseHealthScale>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <leatherInsulation>0.7</leatherInsulation>
       <wildness>0.55</wildness>
       <gestationPeriodDays>55</gestationPeriodDays>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Meerkat.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Meerkat.xml
@@ -119,21 +119,8 @@
 			<baseHealthScale>0.8</baseHealthScale>
 			<foodType>CarnivoreAnimal, OvivoreAnimal, AnimalProduct</foodType>
 			<leatherInsulation>0.5</leatherInsulation>
-			<leatherColor>(178, 152, 138)</leatherColor>
-		  <leatherStatFactors>
-			<MaxHitPoints>0.7</MaxHitPoints>
-			<Beauty>1.2</Beauty>
-			<MarketValue>1.1</MarketValue>
-			<ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-			<ArmorRating_Sharp>1.05</ArmorRating_Sharp>
-			<ArmorRating_Electric>1</ArmorRating_Electric>
-			<ArmorRating_Heat>0.9</ArmorRating_Heat>
-			<Insulation_Cold>1.22</Insulation_Cold>
-			<Insulation_Heat>1.04</Insulation_Heat>
-			<WorkToMake>1.1</WorkToMake>
-			<BedRestEffectiveness>1.4</BedRestEffectiveness>
-			<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-		  </leatherStatFactors>
+			<useMeatFrom>Elephant</useMeatFrom>
+			<useLeatherFrom>Squirrel</useLeatherFrom>
 			<wildness>0.7</wildness>
 			<petness>1</petness>
 			<trainableIntelligence>Simple</trainableIntelligence>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Ptarmigan.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Ptarmigan.xml
@@ -121,10 +121,12 @@
     </comps>
     <race>
       <body>Bird</body>
-      <baseHungerRate>0.25</baseHungerRate>
+      <baseHungerRate>0.12</baseHungerRate>
       <baseBodySize>0.25</baseBodySize>
       <baseHealthScale>0.35</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <trainableIntelligence>None</trainableIntelligence>
       <wildness>0.05</wildness>
       <gestationPeriodDays>7</gestationPeriodDays>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Rodentlike.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Rodentlike.xml
@@ -5,8 +5,8 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Squirrel</defName>
-    <label>Squirrel</label>
-    <description>A Squirrel is one of the many hardy, versatile rodent species that follows humankind everywhere it spreads.</description>
+    <label>squirrel</label>
+    <description>A squirrel is one of the many hardy, versatile rodent species that follows humankind everywhere it spreads.</description>
     <statBases>
 	  <Mass>1</Mass>
       <MoveSpeed>6.00</MoveSpeed>
@@ -44,24 +44,24 @@
       <baseHungerRate>0.12</baseHungerRate>
       <baseHealthScale>0.3</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Squirrel Meat</meatLabel>
+	  <useMeatFrom>Elephant</useMeatFrom>
       <leatherColor>(140,85,36)</leatherColor>
-      <leatherLabel>Squirrel Hide</leatherLabel>
+      <leatherLabel>soft hide</leatherLabel>
       <leatherInsulation>1.25</leatherInsulation>
       <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
       <leatherStatFactors>
 		<MaxHitPoints>0.7</MaxHitPoints>
-        <Beauty>1.8</Beauty>
+        <Beauty>2.0</Beauty>
         <MarketValue>1.6</MarketValue>
-        <ArmorRating_Blunt>1.3</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
+        <ArmorRating_Blunt>1</ArmorRating_Blunt>
+        <ArmorRating_Sharp>1</ArmorRating_Sharp>
         <ArmorRating_Electric>1.0</ArmorRating_Electric>
         <ArmorRating_Heat>0.7</ArmorRating_Heat>
-        <Insulation_Cold>1.43</Insulation_Cold>
-        <Insulation_Heat>0.45</Insulation_Heat>
+        <Insulation_Cold>1</Insulation_Cold>
+        <Insulation_Heat>1</Insulation_Heat>
 		<WorkToMake>1.15</WorkToMake>
 		<BedRestEffectiveness>1.4</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
+		<ImmunityGainSpeedFactor>1.2</ImmunityGainSpeedFactor>
       </leatherStatFactors>
       <wildness>0.7</wildness>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
@@ -105,7 +105,7 @@
   
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>Squirrel</defName>
-    <label>Squirrel</label>
+    <label>squirrel</label>
     <race>Squirrel</race>
     <combatPower>10</combatPower>
     <wildSpawn_EcoSystemWeight>0.1</wildSpawn_EcoSystemWeight>
@@ -153,7 +153,7 @@
  
   <ThingDef ParentName="AnimalThingBase">
     <defName>Alphabeaver</defName>
-    <label>Alphabeaver</label>
+    <label>alphabeaver</label>
     <description>A large beaver derivative genetically engineered to harvest wood with machine-like efficiency. In the absence of specialized feed, these animals will enter a manic state that compels them to eat trees whole.</description>
     <statBases>
 	  <Mass>5</Mass>
@@ -192,26 +192,9 @@
       <baseBodySize>0.35</baseBodySize>
       <baseHungerRate>5.0</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <foodType>DendrovoreAnimal</foodType>
-	  <meatLabel>Alphabeaver Meat</meatLabel>
-      <leatherColor>(140,85,36)</leatherColor>
-      <leatherLabel>Alphabeaver Hide</leatherLabel>
-      <leatherInsulation>1.3</leatherInsulation>
-      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.8</MaxHitPoints>
-        <Beauty>1.2</Beauty>
-        <MarketValue>1.3</MarketValue>
-        <ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.4</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.37</Insulation_Cold>
-        <Insulation_Heat>0.51</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.15</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.2</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <wildness>0.7</wildness>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
       <gestationPeriodDays>14</gestationPeriodDays>
@@ -302,8 +285,8 @@
     
   <ThingDef ParentName="AnimalThingBase">
     <defName>Capybara</defName>
-    <label>Capybara</label>
-    <description>A Cabybara is the largest known natural rodent. Capybaras are well-adapted for hot environments, such as steaming jungles.</description>
+    <label>capybara</label>
+    <description>A cabybara is the largest known natural rodent. Capybaras are well-adapted for hot environments, such as steaming jungles.</description>
     <statBases>
 	  <Mass>8</Mass>
       <MoveSpeed>3.5</MoveSpeed>
@@ -342,25 +325,8 @@
       <baseHungerRate>0.27</baseHungerRate>
       <baseHealthScale>0.7</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Capybara Meat</meatLabel>
-      <leatherColor>(185,125,79)</leatherColor>
-      <leatherLabel>Capybara Hide</leatherLabel>
-      <leatherInsulation>1.1</leatherInsulation>
-      <leatherMarketValueFactor>3.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.8</MaxHitPoints>
-        <Beauty>1.2</Beauty>
-        <MarketValue>1.1</MarketValue>
-        <ArmorRating_Blunt>1.1</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.2</ArmorRating_Electric>
-        <ArmorRating_Heat>1.2</ArmorRating_Heat>
-        <Insulation_Cold>1.21</Insulation_Cold>
-        <Insulation_Heat>0.64</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.2</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <wildness>0.55</wildness>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
       <nuzzleMtbHours>120</nuzzleMtbHours>
@@ -456,7 +422,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Chinchilla</defName>
-    <label>Chinchilla</label>
+    <label>chinchilla</label>
     <description>A Chinchilla is a small but quick rodent that is famous for its exceptionally soft fur.</description>
     <statBases>
 	  <Mass>2</Mass>
@@ -495,24 +461,8 @@
       <baseHungerRate>0.12</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Chinchilla Meat</meatLabel>
-      <leatherLabel>Chinchilla Fur</leatherLabel>
-      <leatherInsulation>1.2</leatherInsulation>
-      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.9</MaxHitPoints>
-        <Beauty>1.6</Beauty>
-        <MarketValue>1.2</MarketValue>
-        <ArmorRating_Blunt>1.3</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.2</ArmorRating_Electric>
-        <ArmorRating_Heat>1.1</ArmorRating_Heat>
-        <Insulation_Cold>1.43</Insulation_Cold>
-        <Insulation_Heat>0.44</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.35</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <wildness>0.45</wildness>
       <mateMtbHours>5</mateMtbHours>
       <nuzzleMtbHours>72</nuzzleMtbHours>
@@ -548,7 +498,7 @@
 
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>Chinchilla</defName>
-    <label>Chinchilla</label>
+    <label>chinchilla</label>
     <race>Chinchilla</race>
     <combatPower>25</combatPower>
     <wildSpawn_spawnWild>true</wildSpawn_spawnWild>
@@ -601,7 +551,7 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Boomrat</defName>
-    <label>Boomrat</label>
+    <label>boomrat</label>
     <description>Either by deliberate genetic weaponization, or as an unusual defense mechanism these rodent-like creatures create a powerful fire-starting explosion when killed.</description>
     <statBases>
 	  <Mass>4</Mass>
@@ -649,25 +599,8 @@
       <baseHungerRate>0.35</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>OmnivoreRoughAnimal</foodType>
-	  <meatLabel>Boomrat Meat</meatLabel>
-      <leatherColor>(115,37,28)</leatherColor>
-	  <leatherLabel>Boomrat Leather</leatherLabel>
-      <leatherInsulation>1.25</leatherInsulation>
-      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.7</MaxHitPoints>
-        <Beauty>0.8</Beauty>
-        <MarketValue>1.4</MarketValue>
-        <ArmorRating_Blunt>1.1</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.05</ArmorRating_Sharp>
-        <ArmorRating_Electric>1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.7</ArmorRating_Heat>
-        <Insulation_Cold>1.12</Insulation_Cold>
-        <Insulation_Heat>1.41</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>0.85</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.22</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <executionRange>4</executionRange>
       <wildness>0.65</wildness>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
@@ -765,7 +698,7 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Raccoon</defName>
-    <label>Raccoon</label>
+    <label>raccoon</label>
     <description>A small, hardy animal that ranges wide across forests and shrubland. Eats almost anything.</description>
     <statBases>
 	  <Mass>1</Mass>
@@ -803,23 +736,8 @@
       <baseHungerRate>0.35</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>OmnivoreRoughAnimal</foodType>
-      <leatherColor>(174,172,174)</leatherColor>
-      <leatherInsulation>0.7</leatherInsulation>
-      <leatherMarketValueFactor>3.7</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.9</MaxHitPoints>
-        <Beauty>1.5</Beauty>
-        <MarketValue>1.3</MarketValue>
-        <ArmorRating_Blunt>1.1</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.2</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.28</Insulation_Cold>
-        <Insulation_Heat>0.5</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.33</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <wildness>0.75</wildness>
       <mateMtbHours>4</mateMtbHours>
       <gestationPeriodDays>12</gestationPeriodDays>
@@ -909,7 +827,7 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Rat</defName>
-    <label>Rat</label>
+    <label>rat</label>
     <description>A rodent famous for soiling kitchens and spreading disease. Eats almost anything; lives almost anywhere.</description>
     <statBases>
 	  <Mass>0.7</Mass>
@@ -947,23 +865,8 @@
       <baseHungerRate>0.20</baseHungerRate>
       <baseHealthScale>0.29</baseHealthScale>
       <foodType>OmnivoreRoughAnimal</foodType>
-      <leatherColor>(110,95,82)</leatherColor>
-      <leatherInsulation>0.7</leatherInsulation>
-      <leatherMarketValueFactor>1.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.9</MaxHitPoints>
-        <Beauty>1.0</Beauty>
-        <MarketValue>0.8</MarketValue>
-        <ArmorRating_Blunt>1.12</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.25</ArmorRating_Electric>
-        <ArmorRating_Heat>1.1</ArmorRating_Heat>
-        <Insulation_Cold>1.0</Insulation_Cold>
-        <Insulation_Heat>0.9</Insulation_Heat>
-		<WorkToMake>1.1</WorkToMake>
-		<BedRestEffectiveness>0.8</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.7</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <wildness>0.50</wildness>
       <mateMtbHours>3</mateMtbHours>
       <gestationPeriodDays>12</gestationPeriodDays>
@@ -975,7 +878,7 @@
           <li>(5.5, 0)</li>
         </points>
       </litterSizeCurve>
-      <lifeExpectancy>8</lifeExpectancy>
+      <lifeExpectancy>3</lifeExpectancy>
       <lifeStageAges>
         <li>
           <def>AnimalBaby</def>
@@ -1090,6 +993,8 @@
       <baseHungerRate>0.13</baseHungerRate>
       <baseHealthScale>0.20</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Squirrel</useLeatherFrom>
       <wildness>0.65</wildness>
       <mateMtbHours>8</mateMtbHours>
       <gestationPeriodDays>10</gestationPeriodDays>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_SmilodonPop.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_SmilodonPop.xml
@@ -3,7 +3,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>SmilodonPop</defName>
-    <label>Sabretooth Cat</label>
+    <label>sabretooth cat</label>
     <description>The prehistoric Smilodon Populator (LUND, A.D. 1842), also known as the biggest of the true sabre-toothed cats, still has a legedary reputation across the whole galaxy. Having already been extinct when humanity had cemented its global-player position in the foodchain of Old Earth, some scientists apparently thought it was a good idea to revive this hominid's Nemesis through advanced cloning techniques. 
 
 It is still relatively unclear what specific function the enormous canine teeth fulfill, as their comparably frail static forbids regular and successful use as a weapon; The proportions and angles of the jaw and teeth's points suggest though, that Smilodon hunted very large, herbivorous animals with slashing bites after subduing its prey, possibly still puncturing the jugular vein and/or carotid artery like recent big cats do during their death-bite to the throat. 
@@ -68,28 +68,13 @@ Tribal cultures on planets where a wild population could establish itself, worsh
       <body>QuadrupedAnimalWithPawsAndTail</body>
       <herdAnimal>false</herdAnimal>
       <predator>true</predator>
-      <baseBodySize>2.00</baseBodySize>
-      <baseHungerRate>0.4</baseHungerRate>
+      <baseBodySize>1.5</baseBodySize>
+      <baseHungerRate>1</baseHungerRate>
       <baseHealthScale>2.75</baseHealthScale>
       <foodType>CarnivoreAnimal, OvivoreAnimal</foodType>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <leatherInsulation>1.5</leatherInsulation>
-	<leatherCommonalityFactor>0.25</leatherCommonalityFactor>
-	      <leatherMarketValueFactor>2.5</leatherMarketValueFactor>
-      <leatherMarketValueFactor>9.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.3</MaxHitPoints>
-        <Beauty>1.35</Beauty>
-        <MarketValue>2.3</MarketValue>
-        <ArmorRating_Blunt>1.55</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.4</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.0</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.47</Insulation_Cold>
-        <Insulation_Heat>0.95</Insulation_Heat>
-		<WorkToMake>1.35</WorkToMake>
-		<BedRestEffectiveness>1.24</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.98</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <wildness>0.95</wildness>
       <manhunterOnTameFailChance>0.020</manhunterOnTameFailChance>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>
@@ -124,9 +109,6 @@ Tribal cultures on planets where a wild population could establish itself, worsh
       <soundMeleeHitPawn>Pawn_Melee_BigBash_HitPawn</soundMeleeHitPawn>
       <soundMeleeHitBuilding>Pawn_Melee_BigBash_HitBuilding</soundMeleeHitBuilding>
       <soundMeleeMiss>Pawn_Melee_BigBash_Miss</soundMeleeMiss>
-     <leatherLabel>big smilodonskin</leatherLabel>
-      <leatherColor>(177,136,112)</leatherColor>
-	<meatLabel>smilodon meat</meatLabel>
     </race>
 	<tradeTags>
       <li>StandardAnimal</li>
@@ -136,7 +118,7 @@ Tribal cultures on planets where a wild population could establish itself, worsh
 
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>SmilodonPop</defName>
-    <label>Sabretooth Cat</label>
+    <label>sabretooth cat</label>
     <race>SmilodonPop</race>
 	<combatPower>185</combatPower>
     	<wildSpawn_spawnWild>true</wildSpawn_spawnWild>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Temperate.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Temperate.xml
@@ -5,7 +5,7 @@
   
     <ThingDef ParentName="AnimalThingBase">
     <defName>Deer</defName>
-    <label>Deer</label>
+    <label>deer</label>
     <description>A deer is a medium-sized herding herbivore. It is generally peaceful unless disturbed.</description>
     <statBases>
 	  <Mass>60</Mass>
@@ -38,25 +38,9 @@
       <baseHungerRate>0.4</baseHungerRate>
       <baseHealthScale>1.4</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-      <leatherColor>(162,106,57)</leatherColor>
-      <leatherLabel>Deer Hide</leatherLabel>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <leatherInsulation>1.25</leatherInsulation>
-      <leatherMarketValueFactor>3.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.8</MaxHitPoints>
-        <Beauty>1.4</Beauty>
-        <MarketValue>1.1</MarketValue>
-        <ArmorRating_Blunt>1.2</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.2</ArmorRating_Heat>
-        <Insulation_Cold>1.26</Insulation_Cold>
-        <Insulation_Heat>0.82</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <meatLabel>Deer Venison</meatLabel>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
       <wildness>0.7</wildness>
       <nuzzleMtbHours>120</nuzzleMtbHours>
@@ -163,7 +147,7 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Ibex</defName>
-    <label>Ibex</label>
+    <label>ibex</label>
     <description>The hardy wild ancestor of the domesticated goat. Ibexes live on marginal territory that most antelopes couldn't survive, eating lichens and sparse mountain plants. They're famous for dexterously hopping across bare cliff faces - and for their violent ramming attack.</description>
     <statBases>
 	  <Mass>70</Mass>
@@ -202,24 +186,8 @@
       <baseHungerRate>0.35</baseHungerRate>
       <baseHealthScale>0.85</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-      <leatherColor>(153,129,113)</leatherColor>
-      <leatherLabel>Goat hide</leatherLabel>
-      <leatherInsulation>0.9</leatherInsulation>
-	  <leatherMarketValueFactor>3</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.0</MaxHitPoints>
-        <Beauty>1.2</Beauty>
-        <MarketValue>1.5</MarketValue>
-        <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.3</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.2</ArmorRating_Heat>
-        <Insulation_Cold>1.31</Insulation_Cold>
-        <Insulation_Heat>0.71</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>1.15</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.0</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.55</wildness>
       <gestationPeriodDays>22.5</gestationPeriodDays>
       <lifeExpectancy>15</lifeExpectancy>
@@ -325,8 +293,8 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Elk</defName>
-    <label>Elk</label>
-    <description>An Elk is a larger member of the deer family. It is well-adapted to life in cold climates.</description>
+    <label>elk</label>
+    <description>An elk is a larger member of the deer family. It is well-adapted to life in cold climates.</description>
     <statBases>
 	  <Mass>80</Mass>
       <MoveSpeed>4.84</MoveSpeed>
@@ -364,25 +332,8 @@
       <baseHungerRate>0.76</baseHungerRate>
       <baseHealthScale>1.6</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-      <leatherColor>(162,106,57)</leatherColor>
-      <leatherLabel>Elk Hide</leatherLabel>
-      <leatherInsulation>1.3</leatherInsulation>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.9</MaxHitPoints>
-        <Beauty>1.3</Beauty>
-        <MarketValue>1.5</MarketValue>
-        <ArmorRating_Blunt>1.3</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.0</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.38</Insulation_Cold>
-        <Insulation_Heat>0.58</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <meatLabel>Elk Venison</meatLabel>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.7</wildness>
       <manhunterOnDamageChance>0.12</manhunterOnDamageChance>
       <gestationPeriodDays>25</gestationPeriodDays>
@@ -487,7 +438,7 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Caribou</defName>
-    <label>Caribou</label>
+    <label>caribou</label>
     <description>A large member of the deer family, well-adapted to life in cold climates.</description>
     <statBases>
 	  <Mass>60</Mass>
@@ -527,23 +478,8 @@
       <baseHungerRate>0.56</baseHungerRate>
       <baseHealthScale>1.7</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-      <leatherColor>(173,99,77)</leatherColor>
-      <leatherInsulation>1.0</leatherInsulation>
-      <leatherMarketValueFactor>4.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>0.8</MaxHitPoints>
-        <Beauty>1.6</Beauty>
-        <MarketValue>1.5</MarketValue>
-        <ArmorRating_Blunt>1.22</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>1.15</ArmorRating_Heat>
-        <Insulation_Cold>1.31</Insulation_Cold>
-        <Insulation_Heat>0.82</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.28</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Muffalo</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.75</wildness>
       <gestationPeriodDays>25</gestationPeriodDays>
       <lifeExpectancy>18</lifeExpectancy>
@@ -632,7 +568,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>WildBoar</defName>
-    <label>Wild Boar</label>
+    <label>wild boar</label>
     <description>Although considered impure by some cultures, this hairy ancestor of the domesticated pig is prized for the gamey flavor of its meat.</description>
     <statBases>
 	  <Mass>30</Mass>
@@ -657,17 +593,12 @@
       <baseHungerRate>0.45</baseHungerRate>
       <baseHealthScale>1.3</baseHealthScale>
       <foodType>OmnivoreRoughAnimal</foodType>
-      <leatherColor>(117,109,93)</leatherColor>
-      <leatherLabel>Boar Hide</leatherLabel>
-      <leatherInsulation>1.15</leatherInsulation> 
-      <leatherMarketValueFactor>3.5</leatherMarketValueFactor>
-      <useMeatFrom>Pig</useMeatFrom>
-      <useLeatherFrom>Pig</useLeatherFrom>
+      <useMeatFrom>Muffalo</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.40</wildness>
       <manhunterOnDamageChance>0.3</manhunterOnDamageChance>
       <trainableIntelligence>Advanced</trainableIntelligence>
       <manhunterOnTameFailChance>0.005</manhunterOnTameFailChance>
-      <meatLabel>Wild Boar Pork</meatLabel>
       <gestationPeriodDays>13</gestationPeriodDays>
       <litterSizeCurve>
         <points>
@@ -763,7 +694,7 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Tortoise</defName>
-    <label>Tortoise</label>
+    <label>tortoise</label>
     <description>This heavily armored land-dwelling reptile is known for its slow moving speed and surprisingly vicious bite.</description>
     <statBases>
 	  <Mass>20</Mass>
@@ -800,27 +731,11 @@
     <race>
       <body>TurtleLike</body>
       <baseBodySize>0.2</baseBodySize>
-      <baseHungerRate>0.17</baseHungerRate>
+      <baseHungerRate>0.12</baseHungerRate>
       <baseHealthScale>0.5</baseHealthScale>
       <foodType>OmnivoreRoughAnimal</foodType>
-	<meatLabel>Tortoise Meat</meatLabel>
-	<leatherLabel>Tortoise Leather</leatherLabel>
-      <leatherInsulation>0.75</leatherInsulation>
-      <leatherMarketValueFactor>6.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.3</MaxHitPoints>
-        <Beauty>0.9</Beauty>
-        <MarketValue>1.6</MarketValue>
-        <ArmorRating_Blunt>2.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.7</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.4</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>0.74</Insulation_Cold>
-        <Insulation_Heat>1.11</Insulation_Heat>
-		<WorkToMake>1.4</WorkToMake>
-		<BedRestEffectiveness>0.7</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.2</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <wildness>0.65</wildness>
       <gestationPeriodDays>22.5</gestationPeriodDays>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -5,8 +5,8 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Cobra</defName>
-    <label>Cobra</label>
-    <description>A Cobra is a large snake with a venomous bite. Cobras can be highly aggressive if provoked or approached. It is better to stay away from these creatures if possible.</description>
+    <label>cobra</label>
+    <description>A cobra is a large snake with a venomous bite. Cobras can be highly aggressive if provoked or approached. It is better to stay away from these creatures if possible.</description>
     <statBases>
 	  <Mass>2</Mass>
       <MoveSpeed>2.9</MoveSpeed>
@@ -52,25 +52,8 @@
       <baseHungerRate>0.3</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>CarnivoreAnimal, OvivoreAnimal</foodType>
-      <leatherColor>(113,98,87)</leatherColor>
-      <leatherLabel>Cobra Skin</leatherLabel>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-	  	<MaxHitPoints>1.2</MaxHitPoints>
-        <Beauty>1.5</Beauty>
-        <MarketValue>1.6</MarketValue>
-        <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.5</ArmorRating_Electric>
-        <ArmorRating_Heat>1.4</ArmorRating_Heat>
-        <Insulation_Cold>0.45</Insulation_Cold>
-        <Insulation_Heat>1.3</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>0.7</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.26</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <leatherInsulation>1</leatherInsulation>
-      <meatLabel>Cobra Meat</meatLabel>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <wildness>0.65</wildness>
       <manhunterOnTameFailChance>0.01</manhunterOnTameFailChance>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
@@ -157,8 +140,8 @@
 
   <ThingDef ParentName="AnimalThingBase">
     <defName>Monkey</defName>
-    <label>Monkey</label>
-    <description>A Monkey is a type of small primeape. It can use its curly tail to grab onto tree branches, which leaves its hands free to do other things.</description>
+    <label>monkey</label>
+    <description>A monkey is a type of small primeape. It can use its curly tail to grab onto tree branches, which leaves its hands free to do other things.</description>
     <statBases>
 	  <Mass>15</Mass>
       <MoveSpeed>4.84</MoveSpeed>
@@ -190,24 +173,8 @@
       <baseHungerRate>0.4</baseHungerRate>
       <baseHealthScale>0.45</baseHealthScale>
       <foodType>OmnivoreRoughAnimal</foodType>
-	  <meatLabel>Monkey Meat</meatLabel>
-      <leatherLabel>Monkey Hide</leatherLabel>
-      <leatherInsulation>1.0</leatherInsulation>
-      <leatherMarketValueFactor>3.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.0</MaxHitPoints>
-        <Beauty>1.1</Beauty>
-        <MarketValue>1.2</MarketValue>
-        <ArmorRating_Blunt>1.2</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.4</ArmorRating_Electric>
-        <ArmorRating_Heat>1.1</ArmorRating_Heat>
-        <Insulation_Cold>1.18</Insulation_Cold>
-        <Insulation_Heat>0.8</Insulation_Heat>
-		<WorkToMake>1.05</WorkToMake>
-		<BedRestEffectiveness>1.15</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <trainableIntelligence>Advanced</trainableIntelligence>
       <wildness>0.20</wildness>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
@@ -297,8 +264,8 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Boomalope</defName>
-    <label>Boomalope</label>
-    <description>Engineered for chemical production, the Boomalope grows a large sac of volatile chemicals on its back. Though it is weak and fragile for its size, other animals have learned to avoid it because of the huge explosion it produces when it dies.</description>
+    <label>boomalope</label>
+    <description>Engineered for chemical production, the boomalope grows a large sac of volatile chemicals on its back. Though it is weak and fragile for its size, other animals have learned to avoid it because of the huge explosion it produces when it dies.</description>
     <statBases>
 	  <Mass>70</Mass>
       <MoveSpeed>2.15</MoveSpeed>
@@ -332,26 +299,9 @@
       <baseHungerRate>0.35</baseHungerRate>
       <baseHealthScale>0.65</baseHealthScale>
       <foodType>VegetarianRoughAnimal</foodType>
-	  <meatLabel>Boomalope Venison</meatLabel>
-	  <leatherLabel>Boomalope Leather</leatherLabel>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <manhunterOnDamageChance>0</manhunterOnDamageChance>
-      <leatherColor>(219,205,182)</leatherColor>
-      <leatherInsulation>1.2</leatherInsulation>
-      <leatherMarketValueFactor>7.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.2</MaxHitPoints>
-        <Beauty>0.8</Beauty>
-        <MarketValue>1.6</MarketValue>
-        <ArmorRating_Blunt>1.3</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.1</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.8</ArmorRating_Electric>
-        <ArmorRating_Heat>1.1</ArmorRating_Heat>
-        <Insulation_Cold>0.43</Insulation_Cold>
-        <Insulation_Heat>1.45</Insulation_Heat>
-		<WorkToMake>1.15</WorkToMake>
-		<BedRestEffectiveness>0.7</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.22</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <wildness>0.6</wildness>
       <canBePredatorPrey>false</canBePredatorPrey>
       <gestationPeriodDays>30</gestationPeriodDays>
@@ -450,8 +400,8 @@
   
   <ThingDef ParentName="AnimalThingBase">
     <defName>Lacosdile</defName>
-    <label>Lacosdile</label>
-    <description>A Lacosdile is a crossbred and genetically manipulated lizard originally created as part of clever fragrance marketing gig. Being herbivorous and barely dangerous made them very common pets. However as the trends passed Lacosdiles were soon found flooding the sewage systems, and in desperation were carried off across the galaxy to the furthest reaches of space. As a result the species now flourish on desolate rimworlds, where they have adapted to become omnivorous.</description>
+    <label>lacosdile</label>
+    <description>A lacosdile is a crossbred and genetically manipulated lizard originally created as part of clever fragrance marketing gig. Being herbivorous and barely dangerous made them very common pets. However as the trends passed lacosdiles were soon found flooding the sewage systems, and in desperation were carried off across the galaxy to the furthest reaches of space. As a result the species now flourish on desolate rimworlds, where they have adapted to become omnivorous.</description>
     <statBases>
 	  <Mass>180</Mass>
       <MoveSpeed>2.23</MoveSpeed>
@@ -511,25 +461,8 @@
       <baseBodySize>1.55</baseBodySize>
       <baseHealthScale>2.5</baseHealthScale>
       <foodType>CarnivoreAnimal, Corpse, AnimalProduct, OvivoreAnimal</foodType>
-	  <meatLabel>Lacosdile Meat</meatLabel>
-      <leatherColor>(114,152,59)</leatherColor>
-      <leatherLabel>Lacosdile Skin</leatherLabel>
-	  <leatherMarketValueFactor>7</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.3</MaxHitPoints>
-        <Beauty>1.4</Beauty>
-        <MarketValue>1.8</MarketValue>
-        <ArmorRating_Blunt>1.6</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.4</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.1</ArmorRating_Electric>
-        <ArmorRating_Heat>2.1</ArmorRating_Heat>
-        <Insulation_Cold>0.52</Insulation_Cold>
-        <Insulation_Heat>1.45</Insulation_Heat>
-		<WorkToMake>1.4</WorkToMake>
-		<BedRestEffectiveness>0.9</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.15</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <leatherInsulation>1.2</leatherInsulation>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
 	  <wildness>0.75</wildness>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>
       <nuzzleMtbHours>120</nuzzleMtbHours>
@@ -573,7 +506,7 @@
 
   <PawnKindDef ParentName="AnimalKindBase">
     <defName>Lacosdile</defName>
-    <label>Lacosdile</label>
+    <label>lacosdile</label>
     <race>Lacosdile</race>
     <combatPower>190</combatPower>
     <wildSpawn_EcoSystemWeight>0.33</wildSpawn_EcoSystemWeight>
@@ -662,25 +595,8 @@
 	      <baseHungerRate>0.8</baseHungerRate>
 	      <baseHealthScale>1.2</baseHealthScale>
 	      <foodType>VegetarianRoughAnimal</foodType>
-	      <leatherColor>(40,20,10)</leatherColor>
-	      <leatherInsulation>0.75</leatherInsulation>
-		  <leatherLabel>okapi hide</leatherLabel>
-		  <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-		  <leatherStatFactors>
-			<MaxHitPoints>0.9</MaxHitPoints>
-			<Beauty>1.3</Beauty>
-			<MarketValue>1.5</MarketValue>
-			<ArmorRating_Blunt>1.3</ArmorRating_Blunt>
-			<ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-			<ArmorRating_Electric>1.0</ArmorRating_Electric>
-			<ArmorRating_Heat>0.8</ArmorRating_Heat>
-			<Insulation_Cold>1.38</Insulation_Cold>
-			<Insulation_Heat>0.58</Insulation_Heat>
-			<WorkToMake>1.2</WorkToMake>
-			<BedRestEffectiveness>1.25</BedRestEffectiveness>
-			<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
-		  </leatherStatFactors>
-		  <meatLabel>okapi Venison</meatLabel>
+		  <useMeatFrom>Elephant</useMeatFrom>
+		  <useLeatherFrom>Muffalo</useLeatherFrom>
 	      <wildness>0.75</wildness>
 	      <trainableIntelligence>Intermediate</trainableIntelligence>
 	      <gestationPeriodDays>30</gestationPeriodDays>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_WildCanines.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_WildCanines.xml
@@ -6,8 +6,8 @@
   <ThingDef ParentName="AnimalThingBase">
 <thingClass>Core_SK.PersonalShields.Animal.ShieldPawn</thingClass>
     <defName>Warg</defName>
-    <label>Warg</label>
-    <description>Wargs are heavily-muscled wolf-like creatures. Scientists say Wargs are the descendants of weaponized military animals created for population suppression. The superstitious see them as the tools of an angry god.</description>
+    <label>warg</label>
+    <description>Wargs are heavily-muscled wolf-like creatures. Scientists say wargs are the descendants of weaponized military animals created for population suppression. The superstitious see them as the tools of an angry god.</description>
     <statBases>
 	  <Mass>60</Mass>
       <MoveSpeed>5.00</MoveSpeed>
@@ -71,28 +71,11 @@
       <baseHungerRate>0.3</baseHungerRate>
       <baseHealthScale>1.2</baseHealthScale>
       <foodType>CarnivoreAnimal, CarnivoreAnimalStrict</foodType>
-	  <meatLabel>Warg Meat</meatLabel>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <petness>0.4</petness>
       <nameOnTameChance>1</nameOnTameChance>
       <trainableIntelligence>Advanced</trainableIntelligence>
-      <leatherColor>(128,128,128)</leatherColor>
-      <leatherLabel>Warg Hide</leatherLabel>
-      <leatherInsulation>1.5</leatherInsulation>
-      <leatherMarketValueFactor>6.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.1</MaxHitPoints>
-        <Beauty>1.5</Beauty>
-        <MarketValue>1.6</MarketValue>
-        <ArmorRating_Blunt>1.4</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.6</ArmorRating_Electric>
-        <ArmorRating_Heat>1.6</ArmorRating_Heat>
-        <Insulation_Cold>1.37</Insulation_Cold>
-        <Insulation_Heat>0.54</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <gestationPeriodDays>22.5</gestationPeriodDays>
       <wildness>0.65</wildness>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>
@@ -199,7 +182,7 @@
   <ThingDef ParentName="AnimalThingBase">
 <thingClass>Core_SK.PersonalShields.Animal.ShieldPawn</thingClass>
     <defName>Nightling</defName>
-    <label>Nightling</label>
+    <label>nightling</label>
     <description>A large deformed beast with rows of quills on its back.
 The rim is a violent place and the dead are a common sight. But over the years, disturbing reports of ravaged corpses started to increase in surprising numbers, all gut-wrenching and skewered with spikes. Each dawn shedding light to the aftermath of the night before. The locals soon learned to fear the dark, and the nightmares within them.</description>
     <statBases>
@@ -278,29 +261,11 @@ The rim is a violent place and the dead are a common sight. But over the years, 
       <baseBodySize>0.55</baseBodySize>
       <baseHealthScale>1.1</baseHealthScale>
       <foodType>CarnivoreAnimal, CarnivoreAnimalStrict, OmnivoreAnimal, OvivoreAnimal</foodType>
-	  <meatLabel>Rimwolf Meat</meatLabel>
-      <leatherColor>(24,24,31)</leatherColor>
-      <leatherLabel>Nightling fur</leatherLabel>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
       <gestationPeriodDays>24</gestationPeriodDays>
       <nameOnTameChance>1</nameOnTameChance>
-	  <leatherMarketValueFactor>2</leatherMarketValueFactor>
       <trainableIntelligence>Advanced</trainableIntelligence>
-      <leatherMarketValueFactor>7.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.2</MaxHitPoints>
-        <Beauty>1.1</Beauty>
-        <MarketValue>1.8</MarketValue>
-        <ArmorRating_Blunt>1.28</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.22</ArmorRating_Sharp>
-        <ArmorRating_Electric>0.98</ArmorRating_Electric>
-        <ArmorRating_Heat>0.92</ArmorRating_Heat>
-        <Insulation_Cold>1.24</Insulation_Cold>
-        <Insulation_Heat>0.9</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
-      <leatherInsulation>1.5</leatherInsulation>
       <wildness>0.7</wildness>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>
       <manhunterOnTameFailChance>0.05</manhunterOnTameFailChance>
@@ -406,8 +371,8 @@ The rim is a violent place and the dead are a common sight. But over the years, 
 	
   <ThingDef ParentName="AnimalThingBase">
     <defName>FRaptor</defName>
-    <label>Feathered Raptor</label>
-    <description>Quiet, cunning, elegant and ruthless, these reptile species were originally developed to resolve an increasing warg population problem. Someone quickly realized that adding another alpha predator doesn't help an already broken ecosystem, and the project was cancelled. Scientists then started a new development project that was aimed at making raptors the pets of rich people. Because of that, these raptors now have colorful feathers.</description>
+    <label>feathered raptor</label>
+    <description>Quiet, cunning, elegant and ruthless, these protobird species were originally developed to resolve an increasing warg population problem. Someone quickly realized that adding another alpha predator doesn't help an already broken ecosystem, and the project was cancelled. Scientists then started a new development project that was aimed at making raptors the pets of rich people. Because of that, these raptors now have colorful feathers.</description>
     <statBases>
 	  <Mass>160</Mass>
       <MoveSpeed>5.5</MoveSpeed>
@@ -518,9 +483,9 @@ The rim is a violent place and the dead are a common sight. But over the years, 
       <baseHungerRate>1.7</baseHungerRate>
       <baseHealthScale>3.2</baseHealthScale>
       <foodType>CarnivoreAnimal, CarnivoreAnimalStrict</foodType>
-	  <meatLabel>Feathered Raptor Meat</meatLabel>
+	  <useMeatFrom>Muffalo</useMeatFrom>
       <leatherColor>(138,80,154)</leatherColor>
-      <leatherLabel>Feathered Raptor Leather</leatherLabel>
+      <leatherLabel>feathered raptor leather</leatherLabel>
       <leatherMarketValueFactor>15.0</leatherMarketValueFactor>
       <leatherStatFactors>
 		<MaxHitPoints>1.5</MaxHitPoints>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Wolfs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Wolfs.xml
@@ -70,22 +70,6 @@
       <baseHungerRate>0.18</baseHungerRate>
       <baseHealthScale>0.99</baseHealthScale>
       <foodType>CarnivoreAnimal, CarnivoreAnimalStrict</foodType>
-      <leatherInsulation>1.0</leatherInsulation>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.1</MaxHitPoints>
-        <Beauty>1.3</Beauty>
-        <MarketValue>1.4</MarketValue>
-        <ArmorRating_Blunt>1.25</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>0.9</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.31</Insulation_Cold>
-        <Insulation_Heat>0.56</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <gestationPeriodDays>22.5</gestationPeriodDays>
       <nameOnTameChance>1</nameOnTameChance>
       <trainableIntelligence>Advanced</trainableIntelligence>
@@ -142,26 +126,8 @@
     <label>timber wolf</label>
     <description>A rugged predator long feared by many ancient Earth cultures. As pack hunters, wolves have a complex social life and are fiercely intelligent.</description>
     <race>
-      <leatherColor>(115,110,100)</leatherColor>
-      <meatLabel>wolfmeat</meatLabel>
-      <leatherLabel>timber wolfskin</leatherLabel>
-      <leatherInsulation>1.0</leatherInsulation>
-	  <leatherMarketValueFactor>2</leatherMarketValueFactor>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.1</MaxHitPoints>
-        <Beauty>1.3</Beauty>
-        <MarketValue>1.4</MarketValue>
-        <ArmorRating_Blunt>1.25</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>0.9</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.31</Insulation_Cold>
-        <Insulation_Heat>0.56</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
     </race>
   </ThingDef>
 
@@ -216,29 +182,11 @@
 
   <ThingDef ParentName="ThingBaseWolf">
     <defName>WolfArctic</defName>
-    <label>Arctic wolf</label>
+    <label>arctic wolf</label>
     <description>An arctic variant of the old Earth wolf. As pack hunters, wolves have a complex social life and are fiercely intelligent.</description>
     <race>
-      <leatherColor>(200,200,200)</leatherColor>
-      <leatherLabel>arctic wolfskin</leatherLabel>
-      <leatherInsulation>1.25</leatherInsulation>
-      <useMeatFrom>WolfTimber</useMeatFrom>
-	  <leatherMarketValueFactor>2</leatherMarketValueFactor>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.1</MaxHitPoints>
-        <Beauty>1.3</Beauty>
-        <MarketValue>1.4</MarketValue>
-        <ArmorRating_Blunt>1.25</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>0.9</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.31</Insulation_Cold>
-        <Insulation_Heat>0.56</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
     </race>
   </ThingDef>
 
@@ -292,29 +240,11 @@
   
   <ThingDef ParentName="ThingBaseWolf">
     <defName>Rimwolf</defName>
-    <label>Black wolf</label>
+    <label>black wolf</label>
     <description>These intelligent creatures have evolved from the wild wolves of Earth which were released on this backwater planet long ago. They are fearsome predators and can quickly overpower large prey that carelessly lets itself get surrounded by them.</description>
    <race>
-      <leatherColor>(140,85,36)</leatherColor>
-      <leatherLabel>Rimwolf Fur</leatherLabel>
-      <leatherInsulation>1.25</leatherInsulation>
-      <useMeatFrom>WolfTimber</useMeatFrom>
-	  <leatherMarketValueFactor>2</leatherMarketValueFactor>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.1</MaxHitPoints>
-        <Beauty>1.3</Beauty>
-        <MarketValue>1.4</MarketValue>
-        <ArmorRating_Blunt>1.25</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.2</ArmorRating_Sharp>
-        <ArmorRating_Electric>0.9</ArmorRating_Electric>
-        <ArmorRating_Heat>0.8</ArmorRating_Heat>
-        <Insulation_Cold>1.31</Insulation_Cold>
-        <Insulation_Heat>0.56</Insulation_Heat>
-		<WorkToMake>1.2</WorkToMake>
-		<BedRestEffectiveness>1.25</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+      <useMeatFrom>Elephant</useMeatFrom>
+	  <useLeatherFrom>Muffalo</useLeatherFrom>
     </race>
   </ThingDef>
   

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Event.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Event.xml
@@ -39,6 +39,7 @@
 			<manhunterOnDamageChance>0</manhunterOnDamageChance>
 			<hasGenders>true</hasGenders>
 			<foodType>None</foodType>
+			<useMeatFrom>Human</useMeatFrom>
 			<lifeExpectancy>10</lifeExpectancy>
 			<nameGenerator>NamerAnimalGeneric</nameGenerator>
 			<baseBodySize>2</baseBodySize>
@@ -98,6 +99,7 @@
 			<foodType>None</foodType>
 			<baseBodySize>0.3</baseBodySize>
 			<baseHealthScale>10</baseHealthScale>
+			<useMeatFrom>Elephant</useMeatFrom>
       <lifeStageAges>
         <li>
           <def>MechanoidFullyFormed</def>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
@@ -229,7 +229,7 @@
   
   <ThingDef ParentName="BaseHumanlikePawn">
     <defName>Human</defName>
-    <label>Human</label>
+    <label>human</label>
     <description>A baseline human, mostly unmodified by gene engineering and mostly unchanged by evolutionary pressures on non-Earth planets.</description>
     <statBases>
 	  <Mass>70</Mass>
@@ -258,8 +258,8 @@
       </li>
     </verbs>
     <race>
-	  <meatLabel>Human Flesh</meatLabel>
-	  <leatherLabel>Human Skin</leatherLabel>
+	  <meatLabel>humanoid meat</meatLabel>
+	  <leatherLabel>humanoid skin</leatherLabel>
       <leatherColor>(211,194,143)</leatherColor>
       <leatherCommonalityFactor>0.01</leatherCommonalityFactor>
       <leatherInsulation>0.95</leatherInsulation>
@@ -287,7 +287,7 @@
     <ThingDef ParentName="BaseHumanlikePawn" Class="AlienRace.ThingDef_AlienRace">
     <thingClass>AlienRace.AlienPawn</thingClass>
     <defName>Alien_Nova</defName>
-    <label>Nova</label>
+    <label>nova</label>
     <description>Nova are a human-like race from a planet where the temperature is almost always freezing or below. They are well tolerated to cold temperatures because their bodies are unusually warm. They are much quicker than humans.</description>
 
 	<NakedBodyGraphicLocation></NakedBodyGraphicLocation>
@@ -362,31 +362,13 @@
       </li>
     </verbs>
     <race>
+	  <useMeatFrom>Human</useMeatFrom>
+	  <useLeatherFrom>Human</useLeatherFrom>
       <thinkTreeMain>Humanlike</thinkTreeMain>
       <thinkTreeConstant>HumanlikeConstant</thinkTreeConstant>
       <intelligence>Humanlike</intelligence>
       <makesFootprints>true</makesFootprints>
       <lifeExpectancy>120</lifeExpectancy>
-      <leatherColor>(247,247,247)</leatherColor>
-      <leatherCommonalityFactor>0.01</leatherCommonalityFactor>
-      <leatherInsulation>1</leatherInsulation>
-		<leatherLabel>Nova hide</leatherLabel>
-		<meatLabel>Nova flesh</meatLabel>
-			<leatherMarketValueFactor>3.5</leatherMarketValueFactor>
-			  <leatherStatFactors>
-				<MaxHitPoints>1.2</MaxHitPoints>
-				<Beauty>1.8</Beauty>
-				<MarketValue>2.8</MarketValue>
-				<ArmorRating_Blunt>1.25</ArmorRating_Blunt>
-				<ArmorRating_Sharp>1.12</ArmorRating_Sharp>
-				<ArmorRating_Electric>1.7</ArmorRating_Electric>
-				<ArmorRating_Heat>0.8</ArmorRating_Heat>
-				<Insulation_Cold>1.22</Insulation_Cold>
-				<Insulation_Heat>0.70</Insulation_Heat>
-				<WorkToMake>1.3</WorkToMake>
-				<BedRestEffectiveness>0.98</BedRestEffectiveness>
-				<ImmunityGainSpeedFactor>1.32</ImmunityGainSpeedFactor>
-			  </leatherStatFactors>
       <baseBodySize>1</baseBodySize>
       <baseHealthScale>1.2</baseHealthScale>
   </race>
@@ -396,7 +378,7 @@
 
   <ThingDef ParentName="BaseHumanlikePawn">
     <defName>Norbal</defName>
-    <label>Norbal</label>
+    <label>norbal</label>
     <description>Norbals are baseline, tribal humans that have been hardened by colder climates. They are hairy and strong, but are unable to deal with high temperatures. They lack in technology but make up for it by mastering the basic weapons that they can forge.</description>
     <statBases>
 	  <Mass>72</Mass>
@@ -425,10 +407,9 @@
       </li>
     </verbs>
     <race>
+	  <useMeatFrom>Human</useMeatFrom>
+	  <useLeatherFrom>Human</useLeatherFrom>
       <lifeExpectancy>70</lifeExpectancy>
-      <leatherColor>(211,200,155)</leatherColor>
-      <useMeatFrom>Human</useMeatFrom>
-      <useLeatherFrom>Human</useLeatherFrom>
       <baseBodySize>1.1</baseBodySize>
       <baseHealthScale>1.0</baseHealthScale>
       <hediffGiverSets>
@@ -442,7 +423,7 @@
     <ThingDef ParentName="BaseHumanlikePawn" Class="AlienRace.ThingDef_AlienRace">
         <thingClass>AlienRace.AlienPawn</thingClass>
         <defName>Alien_Orassan</defName>
-        <label>Orassan</label>
+        <label>orassan</label>
         <description>A baseline orassan, mostly unmodified by gene engineering and mostly unchanged by evolutionary pressures on non-Orass planets. A humanoid feline race.</description>
 
     <NakedBodyGraphicLocation></NakedBodyGraphicLocation>
@@ -543,28 +524,12 @@
             </li>
         </verbs>
         <race>
+			<useMeatFrom>Human</useMeatFrom>
+			<useLeatherFrom>Human</useLeatherFrom>
             <lifeExpectancy>68</lifeExpectancy>
-            <leatherColor>(235,235,235)</leatherColor>
-			<leatherLabel>Orassan hide</leatherLabel>
-			<meatLabel>Orassan Flesh</meatLabel>
             <body>Orassan</body>
             <baseBodySize>1.0</baseBodySize>
             <baseHealthScale>1.0</baseHealthScale>
-			<leatherMarketValueFactor>4.0</leatherMarketValueFactor>
-			  <leatherStatFactors>
-				<MaxHitPoints>1.2</MaxHitPoints>
-				<Beauty>1.8</Beauty>
-				<MarketValue>2.8</MarketValue>
-				<ArmorRating_Blunt>1.45</ArmorRating_Blunt>
-				<ArmorRating_Sharp>1.12</ArmorRating_Sharp>
-				<ArmorRating_Electric>1.0</ArmorRating_Electric>
-				<ArmorRating_Heat>1.2</ArmorRating_Heat>
-				<Insulation_Cold>1.28</Insulation_Cold>
-				<Insulation_Heat>1.02</Insulation_Heat>
-				<WorkToMake>1.3</WorkToMake>
-				<BedRestEffectiveness>0.95</BedRestEffectiveness>
-				<ImmunityGainSpeedFactor>1.21</ImmunityGainSpeedFactor>
-			  </leatherStatFactors>
         </race>
     <recipes>
       <li>InstallClothTail</li>
@@ -653,29 +618,12 @@
     </verbs>
 	<tickerType>Normal</tickerType>
     <race>
+	  <useMeatFrom>Human</useMeatFrom>
+	  <useLeatherFrom>Human</useLeatherFrom>
       <lifeExpectancy>1200</lifeExpectancy>
       <bloodDef>FilthBloodAsari</bloodDef>
-	  <leatherLabel>Asari Skin</leatherLabel>
-	  <meatLabel>Asari Flesh</meatLabel>
-      <leatherColor>(30,70,210)</leatherColor>
-      <leatherMarketValueFactor>5.0</leatherMarketValueFactor>
-      <leatherStatFactors>
-		<MaxHitPoints>1.2</MaxHitPoints>
-        <Beauty>1.8</Beauty>
-        <MarketValue>2.8</MarketValue>
-        <ArmorRating_Blunt>1.15</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.17</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.9</ArmorRating_Electric>
-        <ArmorRating_Heat>1.4</ArmorRating_Heat>
-        <Insulation_Cold>0.8</Insulation_Cold>
-        <Insulation_Heat>1.25</Insulation_Heat>
-		<WorkToMake>1.4</WorkToMake>
-		<BedRestEffectiveness>0.95</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>1.25</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
       <baseHungerRate>0.75</baseHungerRate>
       <leatherCommonalityFactor>0.01</leatherCommonalityFactor>
-      <leatherInsulation>1.25</leatherInsulation>
       <baseBodySize>1</baseBodySize>
       <baseHealthScale>1</baseHealthScale>
             <ageGenerationCurve>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Insectoid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Insectoid.xml
@@ -13,7 +13,6 @@
       <thinkTreeConstant>AnimalConstant</thinkTreeConstant>
       <fleshType>Insectoid</fleshType>
       <bloodDef>FilthBloodInsect</bloodDef>
-      <meatColor>(160,150,140)</meatColor>
       <foodType>OmnivoreAnimal, AnimalProduct</foodType>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>
       <manhunterOnTameFailChance>0.025</manhunterOnTameFailChance>
@@ -37,7 +36,7 @@
   
   <ThingDef ParentName="InstectoidBase">
     <defName>Antis</defName>
-    <label>Antis</label>
+    <label>antis</label>
     <description>A quiet stalker and merciless killer, the Antis (ant mantis) is a warrior caste of the insectoid hive. This species was created to fight the Mechanoid invasion, but poses a danger to people, too. It is a social creature that cannot reproduce individually.</description>
     <statBases>
 	  <Mass>50</Mass>
@@ -108,7 +107,6 @@
       <baseBodySize>0.9</baseBodySize>
       <baseHungerRate>0.4</baseHungerRate>
       <baseHealthScale>1.1</baseHealthScale>
-      <meatLabel>Antis Meat</meatLabel>
       <maxPreyBodySize>2.2</maxPreyBodySize>
       <herdAnimal>true</herdAnimal>
       <predator>true</predator>
@@ -116,7 +114,7 @@
       <foodType>Corpse, CarnivoreAnimal, CarnivoreAnimalStrict</foodType>
       <gestationPeriodDays>12</gestationPeriodDays>
       <trainableIntelligence>Advanced</trainableIntelligence>
-      <meatColor>(160,150,140)</meatColor>
+      <useMeatFrom>Megaspider</useMeatFrom>
       <fleshType>Insectoid</fleshType>
       <bloodDef>FilthBloodInsect</bloodDef>
       <wildness>0.85</wildness>
@@ -219,7 +217,7 @@
 
   <ThingDef ParentName="InstectoidBase">
     <defName>Gnawler</defName>
-    <label>Gnawler</label>
+    <label>gnawler</label>
     <description>Gnawlers are a "grunt" caste of the insectoid hive. They are much smaller than the "warrior" caste and isn't particular dangerous when alone. Gnawlers can be very dangerous when they form into packs. It is a social creature that cannot reproduce individually.</description>
     <statBases>
 	  <Mass>90</Mass>
@@ -290,7 +288,6 @@
       <baseBodySize>1.3</baseBodySize>
       <baseHungerRate>0.4</baseHungerRate>
       <baseHealthScale>2.2</baseHealthScale>
-      <meatLabel>Gnawler Meat</meatLabel>
       <fleshType>Insectoid</fleshType>
       <bloodDef>FilthBloodInsect</bloodDef>
       <maxPreyBodySize>2.2</maxPreyBodySize>
@@ -300,7 +297,7 @@
       <foodType>Corpse, CarnivoreAnimal, CarnivoreAnimalStrict</foodType>
       <gestationPeriodDays>12</gestationPeriodDays>
       <trainableIntelligence>Advanced</trainableIntelligence>
-      <meatColor>(160,150,140)</meatColor>
+      <useMeatFrom>Megaspider</useMeatFrom>
       <wildness>0.85</wildness>
       <manhunterOnTameFailChance>0.4</manhunterOnTameFailChance>
       <manhunterOnDamageChance>1</manhunterOnDamageChance>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mutant.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mutant.xml
@@ -29,8 +29,8 @@
       <MoveSpeed>3.7</MoveSpeed>
       <ArmorRating_Blunt>0.42</ArmorRating_Blunt>
       <ArmorRating_Sharp>0.38</ArmorRating_Sharp>
-      <MeatAmount>150</MeatAmount>
-      <LeatherAmount>150</LeatherAmount>
+      <MeatAmount>75</MeatAmount>
+      <LeatherAmount>35</LeatherAmount>
       <CarryWeight>170</CarryWeight>
       <CarryBulk>70</CarryBulk>
 	  <ArmorPenetration>0.6</ArmorPenetration>
@@ -77,24 +77,8 @@
       <soundMeleeHitPawn>Pawn_Melee_BigBash_HitPawn</soundMeleeHitPawn>
       <soundMeleeHitBuilding>Pawn_Melee_BigBash_HitBuilding</soundMeleeHitBuilding>
       <soundMeleeMiss>Pawn_Melee_BigBash_Miss</soundMeleeMiss>
-      <leatherColor>(112,252,135)</leatherColor>
-      <leatherInsulation>1.45</leatherInsulation>
-	  <leatherMarketValueFactor>6</leatherMarketValueFactor>
-      <leatherLabel>Ogreskin</leatherLabel>
-      <leatherStatFactors>
-        <Beauty>0</Beauty>
-        <MarketValue>1.9</MarketValue>
-        <ArmorRating_Blunt>1.5</ArmorRating_Blunt>
-        <ArmorRating_Sharp>1.35</ArmorRating_Sharp>
-        <ArmorRating_Electric>1.3</ArmorRating_Electric>
-        <ArmorRating_Heat>1.3</ArmorRating_Heat>
-        <Insulation_Cold>1.35</Insulation_Cold>
-        <Insulation_Heat>0.8</Insulation_Heat>
-        <ArmorRating_Heat>1.0</ArmorRating_Heat>
-		<WorkToMake>1.3</WorkToMake>
-		<BedRestEffectiveness>0.7</BedRestEffectiveness>
-		<ImmunityGainSpeedFactor>0.7</ImmunityGainSpeedFactor>
-      </leatherStatFactors>
+	  <useMeatFrom>Human</useMeatFrom>
+	  <useLeatherFrom>Elephant</useLeatherFrom>
 	  <hediffGiverSets>
         <li>BerserkPassiveSet</li>
       </hediffGiverSets>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Cloth.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Cloth.xml
@@ -374,7 +374,8 @@
     </thingCategories>
   </ThingDef>
   
-  
+<!-- 
+Temporary removal until leather processing is ready
 	<ThingDef ParentName="ResourceBase">
 		<defName>Tannedleather</defName>
 		<label>Tanned</label>
@@ -430,6 +431,7 @@
 			</li>
 		</comps>
 	</ThingDef>
+-->
   
   <ThingDef ParentName="ResourceBase">
     <defName>Velour</defName>


### PR DESCRIPTION
This is the first test run of the new meat and leather overhaul. There
are 4 types of meat:
1 - regular meat
2 - prime meat, which is required to make lavish and luxury meals
3 - insect meat (no change)
4 - humanoid meat

And there are 5 types of leathers:
1 - solf hides, good for beds and furniture, found on small critters
2 - common leather, suitable for ordinary clothing, found on most
mid-sized animals
3 - thick leather, better suited for fighters, found on dangerous
predator animals
4 - chitin, from insects (no change)
5 - unique boss leathers (no change) from fantasy creatures

There was some talk on making raw leather unusable and requiring it to go through a processing stage first, but, that may be a project for later.

There was also a number of misc balance changes made to animals while
the XML was being looked at closely.