### PR TITLE
Fix being unable to tame with berries

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Components.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Components.xml
@@ -1,12 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <RecipeDefs>
 
-  <!-- =========== REALISTIC PRODUCTION SK MOD =========== -->
+	<!-- =========== REALISTIC PRODUCTION SK MOD =========== -->
 
 
 	<RecipeDef>
 		<defName>MakeComponents_Hand</defName>
-		<label>Make Components</label>
+		<label>make components</label>
 		<description>Makes components from metal alloy. Quite slow. Produces 12.</description>
 		<jobString>Making components.</jobString>
 		<workAmount>1600</workAmount>
@@ -24,20 +24,20 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>SLDBar</li>
-				</categories>
+			<categories>
+				<li>SLDBar</li>
+			</categories>
 		</fixedIngredientFilter>
-			<defaultIngredientFilter>
+		<defaultIngredientFilter>
 			<thingDefs>
-			<li>Bronze</li>	
-			<li>SteelBar</li>			
-		</thingDefs>
-		<exceptedthingDefs>
-			<li>FerrosiliconAlloy</li>
-			<li>CupronickelAlloy</li>
-		</exceptedthingDefs>
-	</defaultIngredientFilter>
+				<li>Bronze</li>	
+				<li>SteelBar</li>			
+			</thingDefs>
+			<exceptedthingDefs>
+				<li>FerrosiliconAlloy</li>
+				<li>CupronickelAlloy</li>
+			</exceptedthingDefs>
+		</defaultIngredientFilter>
 		<products>
 			<Component>12</Component>
 		</products>
@@ -48,13 +48,13 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
-	
+
 	<RecipeDef>
 		<defName>MakeComponents_Electric</defName>
-		<label>Make Components</label>
+		<label>make components</label>
 		<description>Makes components from metal alloy. Quite fast. Produces 24.</description>
 		<jobString>Making components.</jobString>
 		<workAmount>1600</workAmount>
@@ -72,20 +72,20 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>SLDBar</li>
-				</categories>
+			<categories>
+				<li>SLDBar</li>
+			</categories>
 		</fixedIngredientFilter>
-					<defaultIngredientFilter>
+		<defaultIngredientFilter>
 			<thingDefs>
-			<li>Bronze</li>	
-			<li>SteelBar</li>			
-		</thingDefs>
-		<exceptedthingDefs>
-			<li>FerrosiliconAlloy</li>
-			<li>CupronickelAlloy</li>
-		</exceptedthingDefs>
-	</defaultIngredientFilter>
+				<li>Bronze</li>	
+				<li>SteelBar</li>			
+			</thingDefs>
+			<exceptedthingDefs>
+				<li>FerrosiliconAlloy</li>
+				<li>CupronickelAlloy</li>
+			</exceptedthingDefs>
+		</defaultIngredientFilter>
 		<products>
 			<Component>24</Component>
 		</products>
@@ -96,17 +96,17 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeWires_Hand</defName>
-		<label>Make Wires</label>
+		<label>make wires</label>
 		<description>Makes wires from high conductivity alloy. Quite slow. Produces 20.</description>
 		<jobString>Making wires.</jobString>
 		<workAmount>800</workAmount>
-    	<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>
 		<soundWorking>Recipe_Machining</soundWorking>
 		<ingredients>
@@ -120,20 +120,20 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-					<categories>
-						<li>HCMBar</li>
-					</categories>
+			<categories>
+				<li>HCMBar</li>
+			</categories>
 		</fixedIngredientFilter>
-					<defaultIngredientFilter>
+		<defaultIngredientFilter>
 			<thingDefs>
-			<li>CopperBar</li>	
-			<li>AluminiumBar</li>			
-		</thingDefs>
-		<exceptedthingDefs>
-			<li>AlnicoAlloy</li>
-			<li>CupronickelAlloy</li>
-		</exceptedthingDefs>
-	</defaultIngredientFilter>
+				<li>CopperBar</li>	
+				<li>AluminiumBar</li>			
+			</thingDefs>
+			<exceptedthingDefs>
+				<li>AlnicoAlloy</li>
+				<li>CupronickelAlloy</li>
+			</exceptedthingDefs>
+		</defaultIngredientFilter>
 		<products>
 			<Wire>20</Wire>
 		</products>
@@ -144,17 +144,17 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeWires_Electric</defName>
-		<label>Make Wires</label>
+		<label>make wires</label>
 		<description>Makes wires from high conductivity alloy. Quite fast. Produces 40.</description>
 		<jobString>Making wires.</jobString>
 		<workAmount>800</workAmount>
-    	<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>
 		<soundWorking>Recipe_Machining</soundWorking>
 		<ingredients>
@@ -168,21 +168,21 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-					<categories>
-						<li>HCMBar</li>
-					</categories>
+			<categories>
+				<li>HCMBar</li>
+			</categories>
 		</fixedIngredientFilter>
-							<defaultIngredientFilter>
+		<defaultIngredientFilter>
 			<thingDefs>
-			<li>CopperBar</li>	
-			<li>TinBar</li>
-			<li>AluminiumBar</li>			
-		</thingDefs>
-		<exceptedthingDefs>
-			<li>AlnicoAlloy</li>
-			<li>CupronickelAlloy</li>
-		</exceptedthingDefs>
-	</defaultIngredientFilter>
+				<li>CopperBar</li>	
+				<li>TinBar</li>
+				<li>AluminiumBar</li>			
+			</thingDefs>
+			<exceptedthingDefs>
+				<li>AlnicoAlloy</li>
+				<li>CupronickelAlloy</li>
+			</exceptedthingDefs>
+		</defaultIngredientFilter>
 		<products>
 			<Wire>40</Wire>
 		</products>
@@ -193,13 +193,13 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeSand_Hand</defName>
-		<label>Make Sand from Rubble</label>
+		<label>make sand from rubble</label>
 		<description>Make sand by crushing rubble. Quite slow. Produces 25.</description>
 		<jobString>Making sand.</jobString>
 		<workAmount>600</workAmount>
@@ -217,21 +217,21 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-					<thingDefs>
-						<li>CrushedStone</li>
-					</thingDefs>
+			<thingDefs>
+				<li>CrushedStone</li>
+			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
 			<Sand>25</Sand>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeSand_Electric</defName>
-		<label>Make Sand from Rubble</label>
+		<label>make sand from rubble</label>
 		<description>Make sand by crushing rubble. Quite fast. Produces 50.</description>
 		<jobString>Making sand.</jobString>
 		<workAmount>600</workAmount>
@@ -249,21 +249,21 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-					<thingDefs>
-						<li>CrushedStone</li>
-					</thingDefs>
+			<thingDefs>
+				<li>CrushedStone</li>
+			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
 			<Sand>50</Sand>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
-	
-	
+
+
 	<RecipeDef>
 		<defName>MakeSand_Hand_Chunk</defName>
-		<label>Make Sand from Chunk</label>
+		<label>make sand from chunk</label>
 		<description>Make sand by pulverizing a chunk of stone. Quite slow. Produces 80.</description>
 		<jobString>Pulverizing chunk into sand.</jobString>
 		<workAmount>3000</workAmount>
@@ -289,13 +289,13 @@
 			<Sand>80</Sand>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
-	
-	
+
+
 	<RecipeDef>
 		<defName>MakeSand_Electric_Chunk</defName>
-		<label>Make Sand from Chunk</label>
+		<label>make sand from chunk</label>
 		<description>Make sand by pulverizing a chunk of stone. Quite fast. Produces 80.</description>
 		<jobString>Pulverizing chunk into sand.</jobString>
 		<workAmount>1500</workAmount>
@@ -321,13 +321,13 @@
 			<Sand>80</Sand>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeCrushedStone_Hand</defName>
-		<label>Make Rubble from Blocks</label>
+		<label>make rubble from blocks</label>
 		<description>Crush stone blocks for rubble. Quite slow. Produces 20.</description>
 		<jobString>Crushing stone into rubble.</jobString>
 		<workAmount>1200</workAmount>
@@ -345,21 +345,21 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>StoneBlocks</li>
-				</categories>
+			<categories>
+				<li>StoneBlocks</li>
+			</categories>
 		</fixedIngredientFilter>
 		<products>
 			<CrushedStone>20</CrushedStone>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeCrushedStone_Electric</defName>
-		<label>Make Rubble from Blocks</label>
+		<label>make rubble from blocks</label>
 		<description>Crush stone blocks for rubble. Quite fast. Produces 40.</description>
 		<jobString>Crushing stone into rubble.</jobString>
 		<workAmount>1200</workAmount>
@@ -377,21 +377,21 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>StoneBlocks</li>
-				</categories>
+			<categories>
+				<li>StoneBlocks</li>
+			</categories>
 		</fixedIngredientFilter>
 		<products>
 			<CrushedStone>40</CrushedStone>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
-	
-	
+
+
 	<RecipeDef>
 		<defName>MakeCrushedStone_Hand_Chunk</defName>
-		<label>Make Rubble from Chunk</label>
+		<label>make rubble from chunk</label>
 		<description>Smash stone chunks for rubble. Quite slow. Produces 32.</description>
 		<jobString>Smashing chunk into rubble.</jobString>
 		<workAmount>2400</workAmount>
@@ -409,21 +409,21 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>StoneChunks</li>
-				</categories>
+			<categories>
+				<li>StoneChunks</li>
+			</categories>
 		</fixedIngredientFilter>
 		<products>
 			<CrushedStone>32</CrushedStone>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
-	
-	
+
+
 	<RecipeDef>
 		<defName>MakeCrushedStone_Electric_Chunk</defName>
-		<label>Make Rubble from Chunk</label>
+		<label>make rubble from chunk</label>
 		<description>Smash stone chunks for rubble. Quite slow. Produces 32.</description>
 		<jobString>Smashing chunk into rubble.</jobString>
 		<workAmount>1200</workAmount>
@@ -441,21 +441,21 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>StoneChunks</li>
-				</categories>
+			<categories>
+				<li>StoneChunks</li>
+			</categories>
 		</fixedIngredientFilter>
 		<products>
 			<CrushedStone>32</CrushedStone>
 		</products>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeReinforcedConcrete_Hand</defName>
-		<label>Make Reinforced Concrete</label>
+		<label>make reinforced concrete</label>
 		<description>Makes reinforced concrete from concrete and metal alloy. Quite slow. Produces 8.</description>
 		<jobString>Making reinforced concrete.</jobString>
 		<workAmount>1600</workAmount>
@@ -481,28 +481,28 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-					<categories>
-						<li>SLDBar</li>
-						<li>USLDBar</li>
-					</categories>
+			<categories>
+				<li>SLDBar</li>
+				<li>USLDBar</li>
+			</categories>
 			<thingDefs>
 				<li>ConcreteResource</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<thingDefs>
-			<li>Bronze</li>	
-			<li>SteelBar</li>
-			<li>ConcreteResource</li>			
-		</thingDefs>
-		<exceptedthingDefs>
-			<li>FerrosiliconAlloy</li>
-			<li>CupronickelAlloy</li>
-		</exceptedthingDefs>
-		<exceptedCategories>
-		<li>USLDBar</li>
-		</exceptedCategories>
-	</defaultIngredientFilter>
+				<li>Bronze</li>	
+				<li>SteelBar</li>
+				<li>ConcreteResource</li>			
+			</thingDefs>
+			<exceptedthingDefs>
+				<li>FerrosiliconAlloy</li>
+				<li>CupronickelAlloy</li>
+			</exceptedthingDefs>
+			<exceptedCategories>
+				<li>USLDBar</li>
+			</exceptedCategories>
+		</defaultIngredientFilter>
 		<products>
 			<ReinforcedConcrete>8</ReinforcedConcrete>
 		</products>
@@ -513,13 +513,13 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
-	
+
 	<RecipeDef>
 		<defName>MakeReinforcedConcrete_Electric</defName>
-		<label>Make Reinforced Concrete</label>
+		<label>make reinforced concrete</label>
 		<description>Makes reinforced concrete from concrete and metal alloy. Quite fast. Produces 16.</description>
 		<jobString>Making reinforced concrete.</jobString>
 		<workAmount>1200</workAmount>
@@ -545,27 +545,27 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-					<categories>
-						<li>SLDBar</li>
-						<li>USLDBar</li>
-					</categories>
-					<thingDefs>
-						<li>ConcreteResource</li>
-					</thingDefs>
-		</fixedIngredientFilter>
-				<defaultIngredientFilter>
+			<categories>
+				<li>SLDBar</li>
+				<li>USLDBar</li>
+			</categories>
 			<thingDefs>
-			<li>Bronze</li>	
-			<li>SteelBar</li>
-			<li>ConcreteResource</li>
-		</thingDefs>
-		<exceptedthingDefs>
-			<li>FerrosiliconAlloy</li>
-			<li>CupronickelAlloy</li>
-		</exceptedthingDefs>
-		<exceptedCategories>
-		<li>USLDBar</li>
-		</exceptedCategories>
+				<li>ConcreteResource</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>Bronze</li>	
+				<li>SteelBar</li>
+				<li>ConcreteResource</li>
+			</thingDefs>
+			<exceptedthingDefs>
+				<li>FerrosiliconAlloy</li>
+				<li>CupronickelAlloy</li>
+			</exceptedthingDefs>
+			<exceptedCategories>
+				<li>USLDBar</li>
+			</exceptedCategories>
 		</defaultIngredientFilter>
 		<products>
 			<ReinforcedConcrete>16</ReinforcedConcrete>
@@ -577,13 +577,13 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeSimpleMechanism_Hand</defName>
-		<label>Make Mechanisms</label>
+		<label>make mechanisms</label>
 		<description>Makes mechanisms, simple gear-like parts for use in machines or workbenches. Quite slow. Produces 5.</description>
 		<jobString>Making mechanisms.</jobString>
 		<workAmount>1800</workAmount>
@@ -609,24 +609,24 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>SLDBar</li>
-				</categories>
+			<categories>
+				<li>SLDBar</li>
+			</categories>
 			<thingDefs>
 				<li>Component</li>
 			</thingDefs>
 		</fixedIngredientFilter>			
 		<defaultIngredientFilter>
 			<thingDefs>
-			<li>Component</li>
-			<li>Bronze</li>	
-			<li>SteelBar</li>			
-		</thingDefs>
-		<exceptedthingDefs>
-			<li>FerrosiliconAlloy</li>
-			<li>CupronickelAlloy</li>
-		</exceptedthingDefs>
-	</defaultIngredientFilter>
+				<li>Component</li>
+				<li>Bronze</li>	
+				<li>SteelBar</li>			
+			</thingDefs>
+			<exceptedthingDefs>
+				<li>FerrosiliconAlloy</li>
+				<li>CupronickelAlloy</li>
+			</exceptedthingDefs>
+		</defaultIngredientFilter>
 		<products>
 			<Mechanism>5</Mechanism>
 		</products>
@@ -637,13 +637,13 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
 
 
 	<RecipeDef>
 		<defName>MakeSimpleMechanism_Electric</defName>
-		<label>Make Mechanisms</label>
+		<label>make mechanisms</label>
 		<description>Makes mechanisms, simple gear-like parts for use in machines or workbenches. Quite fast. Produces 10.</description>
 		<jobString>Making mechanisms.</jobString>
 		<workAmount>1800</workAmount>
@@ -669,24 +669,24 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>SLDBar</li>
-				</categories>
+			<categories>
+				<li>SLDBar</li>
+			</categories>
 			<thingDefs>
 				<li>Component</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<thingDefs>
-			<li>Component</li>
-			<li>Bronze</li>	
-			<li>SteelBar</li>			
-		</thingDefs>
-		<exceptedthingDefs>
-			<li>FerrosiliconAlloy</li>
-			<li>CupronickelAlloy</li>
-		</exceptedthingDefs>
-	</defaultIngredientFilter>
+				<li>Component</li>
+				<li>Bronze</li>	
+				<li>SteelBar</li>			
+			</thingDefs>
+			<exceptedthingDefs>
+				<li>FerrosiliconAlloy</li>
+				<li>CupronickelAlloy</li>
+			</exceptedthingDefs>
+		</defaultIngredientFilter>
 		<products>
 			<Mechanism>10</Mechanism>
 		</products>
@@ -697,13 +697,13 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
-	
-	
+
+
 	<RecipeDef>
 		<defName>MakeAdvMechanism_Hand</defName>
-		<label>Make Advanced Mechanisms</label>
+		<label>make advanced mechanisms</label>
 		<description>Makes advanced mechanisms, intricate gear-like parts for use in complex machines or workbenches. Quite slow. Produces 5.</description>
 		<jobString>Making advanced mechanisms.</jobString>
 		<workAmount>3200</workAmount>
@@ -737,36 +737,36 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>USLDBar</li>
-				</categories>
+			<categories>
+				<li>USLDBar</li>
+			</categories>
 			<thingDefs>
 				<li>Component</li>
 				<li>SyntheticFibers</li>
 			</thingDefs>
 		</fixedIngredientFilter>
-				<defaultIngredientFilter>
+		<defaultIngredientFilter>
 			<thingDefs>
-			<li>Component</li>
-			<li>SyntheticFibers</li>	
-			<li>Titanium</li>
-			<li>PobediteAlloy</li>
-			<li>TitaniumBar</li>
-			<li>NitinolAlloy</li>
-			<li>Plasteel</li>
-			<li>AlnicoAlloy</li>
-			<li>NichromeAlloy</li>
-			<li>StelliteAlloy</li>
-		</thingDefs>
-		<categories>
-		<li>RARBar</li>
-		<li>HCMBar</li>
-		</categories>
-		<exceptedthingDefs>
-		<li>AlphaPoly</li>
-		<li>BetaPoly</li>
-		</exceptedthingDefs>
-	</defaultIngredientFilter>
+				<li>Component</li>
+				<li>SyntheticFibers</li>	
+				<li>Titanium</li>
+				<li>PobediteAlloy</li>
+				<li>TitaniumBar</li>
+				<li>NitinolAlloy</li>
+				<li>Plasteel</li>
+				<li>AlnicoAlloy</li>
+				<li>NichromeAlloy</li>
+				<li>StelliteAlloy</li>
+			</thingDefs>
+			<categories>
+				<li>RARBar</li>
+				<li>HCMBar</li>
+			</categories>
+			<exceptedthingDefs>
+				<li>AlphaPoly</li>
+				<li>BetaPoly</li>
+			</exceptedthingDefs>
+		</defaultIngredientFilter>
 		<products>
 			<AdvMechanism>5</AdvMechanism>
 		</products>
@@ -777,14 +777,14 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 		<researchPrerequisite>ComponentAssembly</researchPrerequisite>
 	</RecipeDef>
-	
+
 
 	<RecipeDef>
 		<defName>MakeAdvMechanism_Electric</defName>
-		<label>Make Advanced Mechanisms</label>
+		<label>make advanced mechanisms</label>
 		<description>Makes advanced mechanisms, intricate gear-like parts for use in complex machines or workbenches. Quite fast. Produces 10.</description>
 		<jobString>Making advanced mechanisms.</jobString>
 		<workAmount>3200</workAmount>
@@ -818,9 +818,9 @@
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>USLDBar</li>
-				</categories>
+			<categories>
+				<li>USLDBar</li>
+			</categories>
 			<thingDefs>
 				<li>Component</li>
 				<li>SyntheticFibers</li>
@@ -828,25 +828,25 @@
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<thingDefs>
-			<li>Component</li>
-			<li>SyntheticFibers</li>	
-			<li>Titanium</li>
-			<li>PobediteAlloy</li>
-			<li>TitaniumBar</li>
-			<li>NitinolAlloy</li>
-			<li>Plasteel</li>
-			<li>AlnicoAlloy</li>
-			<li>NichromeAlloy</li>
-			<li>StelliteAlloy</li>
-		</thingDefs>
-		<categories>
-		<li>RARBar</li>
-		<li>HCMBar</li>
-		</categories>
-		<exceptedthingDefs>
-		<li>AlphaPoly</li>
-		<li>BetaPoly</li>
-		</exceptedthingDefs>
+				<li>Component</li>
+				<li>SyntheticFibers</li>	
+				<li>Titanium</li>
+				<li>PobediteAlloy</li>
+				<li>TitaniumBar</li>
+				<li>NitinolAlloy</li>
+				<li>Plasteel</li>
+				<li>AlnicoAlloy</li>
+				<li>NichromeAlloy</li>
+				<li>StelliteAlloy</li>
+			</thingDefs>
+			<categories>
+				<li>RARBar</li>
+				<li>HCMBar</li>
+			</categories>
+			<exceptedthingDefs>
+				<li>AlphaPoly</li>
+				<li>BetaPoly</li>
+			</exceptedthingDefs>
 		</defaultIngredientFilter>
 		<products>
 			<AdvMechanism>10</AdvMechanism>
@@ -858,13 +858,13 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 	</RecipeDef>
-		
-	
+
+
 	<RecipeDef>
 		<defName>MakeMetalCan</defName>
-		<label>Make Metal Cans</label>
+		<label>make metal cans</label>
 		<description>Makes cans from metal alloy. Produces 10.</description>
 		<jobString>Making metal cans.</jobString>
 		<workAmount>800</workAmount>
@@ -874,32 +874,32 @@
 		<ingredients>
 			<li>
 				<filter>
-				<categories>
-					<li>Metallic</li>
-				</categories>
+					<categories>
+						<li>Metallic</li>
+					</categories>
 				</filter>
 				<count>10</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
-				<categories>
-					<li>SLDBar</li>
-					<li>USLDBar</li>
-				</categories>
+			<categories>
+				<li>SLDBar</li>
+				<li>USLDBar</li>
+			</categories>
 		</fixedIngredientFilter>
-	<defaultIngredientFilter>
+		<defaultIngredientFilter>
 			<thingDefs>
-			<li>Bronze</li>	
-			<li>SteelBar</li>			
-		</thingDefs>
-		<exceptedthingDefs>
-			<li>FerrosiliconAlloy</li>
-			<li>CupronickelAlloy</li>
-		</exceptedthingDefs>
-		<exceptedCategories>
-		<li>USLDBar</li>
-		</exceptedCategories>
-	</defaultIngredientFilter>
+				<li>Bronze</li>	
+				<li>SteelBar</li>			
+			</thingDefs>
+			<exceptedthingDefs>
+				<li>FerrosiliconAlloy</li>
+				<li>CupronickelAlloy</li>
+			</exceptedthingDefs>
+			<exceptedCategories>
+				<li>USLDBar</li>
+			</exceptedCategories>
+		</defaultIngredientFilter>
 		<products>
 			<MetalCan>10</MetalCan>
 		</products>
@@ -910,14 +910,14 @@
 			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
-    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 		<researchPrerequisite>ComponentAssembly</researchPrerequisite>
 	</RecipeDef>
-	
+
 	<RecipeDef>
 		<defName>MakeRepairKit</defName>
-		<label>Make Repair kits</label>
-		<description>Craft 5 repair kits.</description>
+		<label>make repair kits</label>
+		<description>Craft 5 repair kits, which can be used to repair items at the mending table.</description>
 		<jobString>Making repair kits.</jobString>
 		<workSpeedStat>SmithingSpeed</workSpeedStat>
 		<effectWorking>Smith</effectWorking>
@@ -936,9 +936,9 @@
 			</li>
 			<li>
 				<filter>
-						<categories>
-							<li>Textiles</li>					
-						</categories>
+					<categories>
+						<li>Textiles</li>					
+					</categories>
 				</filter>
 				<count>10</count>
 			</li>
@@ -952,10 +952,10 @@
 			</categories>
 		</fixedIngredientFilter>
 		<skillRequirements>
-		<li>
-			<skill>Crafting</skill>
-			<minLevel>8</minLevel>
-		</li>
+			<li>
+				<skill>Crafting</skill>
+				<minLevel>8</minLevel>
+			</li>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
 		<workSkillLearnFactor>0.8</workSkillLearnFactor>
@@ -968,5 +968,5 @@
 		</recipeUsers>
 		<researchPrerequisite>Machining</researchPrerequisite>
 	</RecipeDef>
-	
+
 </RecipeDefs>

--- a/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Races_Animal_Fish.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Races_Animal_Fish.xml
@@ -351,7 +351,7 @@
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>OmnivoreAnimal</foodType>
       <leatherInsulation>0.7</leatherInsulation>
-      <useMeatFrom>Elephant</useMeatFrom>
+      <useMeatFrom>Muffalo</useMeatFrom>
 	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.99</wildness>
       <manhunterOnTameFailChance>0.03</manhunterOnTameFailChance>
@@ -478,7 +478,7 @@
       <baseHungerRate>0.07</baseHungerRate>
       <baseHealthScale>0.4</baseHealthScale>
       <foodType>OmnivoreAnimal</foodType>
-      <useMeatFrom>Elephant</useMeatFrom>
+      <useMeatFrom>Muffalo</useMeatFrom>
 	  <useLeatherFrom>Muffalo</useLeatherFrom>
       <wildness>0.99</wildness>
       <manhunterOnTameFailChance>0.015</manhunterOnTameFailChance>

--- a/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Cultivated.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Cultivated.xml
@@ -2,526 +2,528 @@
 <Plants>
 
 
-  <ThingDef Name="PlantBase" Abstract="True">
-    <category>Plant</category>
-    <thingClass>Plant</thingClass>
-    <altitudeLayer>LowPlant</altitudeLayer>
-    <useHitPoints>True</useHitPoints>
-    <statBases>
-      <Flammability>0.8</Flammability>
-    </statBases>
-    <tickerType>Long</tickerType>
-    <selectable>False</selectable>
-    <neverMultiSelect>True</neverMultiSelect>
-    <drawerType>MapMeshOnly</drawerType>
-    <pathCostIgnoreRepeat>false</pathCostIgnoreRepeat>
-    <graphicData>
-      <shaderType>CutoutPlant</shaderType>
-    </graphicData>
-    <ingestible>
-      <foodType>Plant</foodType>
-      <preferability>RawBad</preferability>
-    </ingestible>
-    <plant>
+	<ThingDef Name="PlantBase" Abstract="True">
+		<category>Plant</category>
+		<thingClass>Plant</thingClass>
+		<altitudeLayer>LowPlant</altitudeLayer>
+		<useHitPoints>True</useHitPoints>
+		<statBases>
+			<Flammability>0.8</Flammability>
+		</statBases>
+		<tickerType>Long</tickerType>
+		<selectable>False</selectable>
+		<neverMultiSelect>True</neverMultiSelect>
+		<drawerType>MapMeshOnly</drawerType>
+		<pathCostIgnoreRepeat>false</pathCostIgnoreRepeat>
+		<graphicData>
+			<shaderType>CutoutPlant</shaderType>
+		</graphicData>
+		<ingestible>
+			<foodType>Plant</foodType>
+			<preferability>RawBad</preferability>
+		</ingestible>
+		<plant>
 			<fertilityMin>0.5</fertilityMin>
 			<fertilitySensitivity>1.0</fertilitySensitivity>
 			<harvestDestroys>true</harvestDestroys>
-      <soundHarvesting>Harvest_Standard</soundHarvesting>
-      <soundHarvestFinish>Harvest_Standard_Finish</soundHarvestFinish>
-      <harvestWork>190</harvestWork>
-      <sowWork>260</sowWork>
-      <topWindExposure>0.1</topWindExposure>
-      <visualSizeRange>
-        <min>0.3</min>
-        <max>1.00</max>
-      </visualSizeRange>
-    </plant>
-    <damageMultipliers>
-      <li>
-        <damageDef>Bomb</damageDef>
-        <multiplier>7.5</multiplier>
-      </li>
-      <li>
-        <damageDef>Bullet</damageDef>
-        <multiplier>1.0</multiplier>
-      </li>
-      <li>
-        <damageDef>Fragment</damageDef>
-        <multiplier>1.0</multiplier>
-      </li>
-      <li>
-        <damageDef>ArmorPiercing</damageDef>
-        <multiplier>2.5</multiplier>
-      </li>
-      <li>
-        <damageDef>LaserBurn</damageDef>
-        <multiplier>5.0</multiplier>
-      </li>
-      <li>
-        <damageDef>AntiMateriel</damageDef>
-        <multiplier>4.0</multiplier>
-      </li>
-      <li>
-        <damageDef>Optic</damageDef>
-        <multiplier>5.0</multiplier>
-      </li>
-      <li>
-        <damageDef>Plasma</damageDef>
-        <multiplier>5.0</multiplier>
-      </li>
-      <li>
-        <damageDef>Microwave</damageDef>
-        <multiplier>4.0</multiplier>
-      </li>
-    </damageMultipliers>
-  </ThingDef>
+			<soundHarvesting>Harvest_Standard</soundHarvesting>
+			<soundHarvestFinish>Harvest_Standard_Finish</soundHarvestFinish>
+			<harvestWork>190</harvestWork>
+			<sowWork>260</sowWork>
+			<topWindExposure>0.1</topWindExposure>
+			<visualSizeRange>
+				<min>0.3</min>
+				<max>1.00</max>
+			</visualSizeRange>
+		</plant>
+		<damageMultipliers>
+			<li>
+				<damageDef>Bomb</damageDef>
+				<multiplier>7.5</multiplier>
+			</li>
+			<li>
+				<damageDef>Bullet</damageDef>
+				<multiplier>1.0</multiplier>
+			</li>
+			<li>
+				<damageDef>Fragment</damageDef>
+				<multiplier>1.0</multiplier>
+			</li>
+			<li>
+				<damageDef>ArmorPiercing</damageDef>
+				<multiplier>2.5</multiplier>
+			</li>
+			<li>
+				<damageDef>LaserBurn</damageDef>
+				<multiplier>5.0</multiplier>
+			</li>
+			<li>
+				<damageDef>AntiMateriel</damageDef>
+				<multiplier>4.0</multiplier>
+			</li>
+			<li>
+				<damageDef>Optic</damageDef>
+				<multiplier>5.0</multiplier>
+			</li>
+			<li>
+				<damageDef>Plasma</damageDef>
+				<multiplier>5.0</multiplier>
+			</li>
+			<li>
+				<damageDef>Microwave</damageDef>
+				<multiplier>4.0</multiplier>
+			</li>
+		</damageMultipliers>
+	</ThingDef>
 
-  	  <ThingDef ParentName="PlantBase" Name="PlantDef" Abstract="True">
-    <statBases>
-      <MaxHitPoints>85</MaxHitPoints>
-      <Beauty>1</Beauty>
-    </statBases>
-    <selectable>true</selectable>
-    <pathCost>10</pathCost>
-    <ingestible>
-      <nutrition>0.20</nutrition>
-    </ingestible>
-    <plant>
-      <dieIfLeafless>true</dieIfLeafless>
-      <reproduces>false</reproduces>
-      <harvestTag>Standard</harvestTag>
-      <harvestDestroys>true</harvestDestroys>
-    </plant>
-  </ThingDef>
-  
-  	  <ThingDef ParentName="PlantBase" Name="FlowerDef" Abstract="True">
-    <statBases>
-      <MaxHitPoints>70</MaxHitPoints>
-      <Beauty>10</Beauty>
-    </statBases>
-    <hideAtSnowDepth>0.5</hideAtSnowDepth>
-    <fillPercent>0.03</fillPercent>
-    <pathCost>3</pathCost>
-    <ingestible>
-      <nutrition>0.07</nutrition>
-    </ingestible>
-    <plant>
-      <sowTags>
-        <li>Ground</li>
-        <li>Decorative</li>
-      </sowTags>
-      <harvestTag>Standard</harvestTag>
-      <harvestDestroys>True</harvestDestroys>
-      <dieIfLeafless>true</dieIfLeafless>
-      <reproduceMtbDays>5</reproduceMtbDays>
-      <lifespanFraction>5</lifespanFraction>
-      <topWindExposure>0.1</topWindExposure>
-      <sowWork>200</sowWork>
-      <wildClusterSizeRange>
-        <min>2</min>
-        <max>6</max>
-      </wildClusterSizeRange>
-      <wildClusterRadius>4</wildClusterRadius>
-    </plant>
-  </ThingDef>
-  
-  <!--============================ Wild - Trees ============================-->
+	<ThingDef ParentName="PlantBase" Name="PlantDef" Abstract="True">
+		<statBases>
+			<MaxHitPoints>85</MaxHitPoints>
+			<Beauty>1</Beauty>
+		</statBases>
+		<selectable>true</selectable>
+		<pathCost>10</pathCost>
+		<ingestible>
+			<nutrition>0.20</nutrition>
+		</ingestible>
+		<plant>
+			<dieIfLeafless>true</dieIfLeafless>
+			<reproduces>false</reproduces>
+			<harvestTag>Standard</harvestTag>
+			<harvestDestroys>true</harvestDestroys>
+		</plant>
+	</ThingDef>
 
-  <ThingDef ParentName="PlantBase" Name="TreeBase" Abstract="True">
-    <statBases>
-      <MaxHitPoints>300</MaxHitPoints>
-    </statBases>
-    <description>A tree.</description>
-    <altitudeLayer>Building</altitudeLayer>
-    <selectable>true</selectable>
-    <fillPercent>0.43</fillPercent>
-    <graphicData>
-      <shadowData>
-        <volume>(0.3, 0.3, 0.3)</volume>
-      </shadowData>
-    </graphicData>
-    <passability>PassThroughOnly</passability>
-    <pathCost>130</pathCost>
-    <blockWind>true</blockWind>
-    <ingestible>
-      <foodType>Tree</foodType>
-      <preferability>RawBad</preferability>
-      <nutrition>1.50</nutrition>
-    </ingestible>
-    <plant>
+	<ThingDef ParentName="PlantBase" Name="FlowerDef" Abstract="True">
+		<statBases>
+			<MaxHitPoints>70</MaxHitPoints>
+			<Beauty>10</Beauty>
+		</statBases>
+		<hideAtSnowDepth>0.5</hideAtSnowDepth>
+		<fillPercent>0.03</fillPercent>
+		<pathCost>3</pathCost>
+		<ingestible>
+			<nutrition>0.07</nutrition>
+		</ingestible>
+		<plant>
+			<sowTags>
+				<li>Ground</li>
+				<li>Decorative</li>
+			</sowTags>
+			<harvestTag>Standard</harvestTag>
+			<harvestDestroys>True</harvestDestroys>
+			<dieIfLeafless>true</dieIfLeafless>
+			<reproduceMtbDays>5</reproduceMtbDays>
+			<lifespanFraction>5</lifespanFraction>
+			<topWindExposure>0.1</topWindExposure>
+			<sowWork>200</sowWork>
+			<wildClusterSizeRange>
+				<min>2</min>
+				<max>6</max>
+			</wildClusterSizeRange>
+			<wildClusterRadius>4</wildClusterRadius>
+		</plant>
+	</ThingDef>
+
+	<!--============================ Wild - Trees ============================-->
+
+	<ThingDef ParentName="PlantBase" Name="TreeBase" Abstract="True">
+		<statBases>
+			<MaxHitPoints>300</MaxHitPoints>
+		</statBases>
+		<description>A tree.</description>
+		<altitudeLayer>Building</altitudeLayer>
+		<selectable>true</selectable>
+		<fillPercent>0.43</fillPercent>
+		<graphicData>
+			<shadowData>
+				<volume>(0.3, 0.3, 0.3)</volume>
+			</shadowData>
+		</graphicData>
+		<passability>PassThroughOnly</passability>
+		<pathCost>130</pathCost>
+		<blockWind>true</blockWind>
+		<ingestible>
+			<foodType>Tree</foodType>
+			<preferability>RawBad</preferability>
+			<nutrition>1.50</nutrition>
+		</ingestible>
+		<plant>
 			<fertilityMin>0.3</fertilityMin>
 			<fertilitySensitivity>0.5</fertilitySensitivity>
 			<reproduceRadius>30</reproduceRadius>
 			<soundHarvesting>Harvest_Tree</soundHarvesting>
-      <soundHarvestFinish>Harvest_Tree_Finish</soundHarvestFinish>
-      <sowWork>1500</sowWork>
-      <harvestWork>800</harvestWork>
-      <harvestDestroys>true</harvestDestroys>
-      <harvestedThingDef>WoodLog</harvestedThingDef>
-      <harvestYield>50</harvestYield>
-      <harvestTag>Wood</harvestTag>
-      <harvestMinGrowth>0.40</harvestMinGrowth>
-      <harvestFailable>false</harvestFailable>
-      <blockAdjacentSow>true</blockAdjacentSow>
-      <sowTags>
-        <li>Ground</li>
-      </sowTags>
-      <visualSizeRange>
-        <min>1.3</min>
-        <max>2.0</max>
-      </visualSizeRange>
-      <topWindExposure>0.25</topWindExposure>
-      <wildClusterSizeRange>
-        <min>8</min>
-        <max>30</max>
-      </wildClusterSizeRange>
-      <wildClusterRadius>8</wildClusterRadius>
-    </plant>
-  </ThingDef>
-  
-  <ThingDef ParentName="PlantBase" Name="FruitTreeBase" Abstract="True">
-    <statBases>
-      <MaxHitPoints>300</MaxHitPoints>
-    </statBases>
-    <description>A tree.</description>
-    <altitudeLayer>Building</altitudeLayer>
-    <selectable>true</selectable>
-    <fillPercent>0.43</fillPercent>
-    <graphicData>
-      <shadowData>
-        <volume>(0.3, 0.3, 0.3)</volume>
-      </shadowData>
-    </graphicData>
-    <passability>PassThroughOnly</passability>
-    <pathCost>130</pathCost>
-    <blockWind>true</blockWind>
-    <ingestible>
-      <foodType>Tree</foodType>
-      <preferability>RawBad</preferability>
-      <nutrition>1.50</nutrition>
-    </ingestible>
-    <plant>
+			<soundHarvestFinish>Harvest_Tree_Finish</soundHarvestFinish>
+			<sowWork>1500</sowWork>
+			<harvestWork>800</harvestWork>
+			<harvestDestroys>true</harvestDestroys>
+			<harvestedThingDef>WoodLog</harvestedThingDef>
+			<harvestYield>50</harvestYield>
+			<harvestTag>Wood</harvestTag>
+			<harvestMinGrowth>0.40</harvestMinGrowth>
+			<harvestFailable>false</harvestFailable>
+			<blockAdjacentSow>true</blockAdjacentSow>
+			<sowTags>
+				<li>Ground</li>
+			</sowTags>
+			<visualSizeRange>
+				<min>1.3</min>
+				<max>2.0</max>
+			</visualSizeRange>
+			<topWindExposure>0.25</topWindExposure>
+			<wildClusterSizeRange>
+				<min>8</min>
+				<max>30</max>
+			</wildClusterSizeRange>
+			<wildClusterRadius>8</wildClusterRadius>
+		</plant>
+	</ThingDef>
+
+	<ThingDef ParentName="PlantBase" Name="FruitTreeBase" Abstract="True">
+		<statBases>
+			<MaxHitPoints>300</MaxHitPoints>
+		</statBases>
+		<description>A tree.</description>
+		<altitudeLayer>Building</altitudeLayer>
+		<selectable>true</selectable>
+		<fillPercent>0.43</fillPercent>
+		<graphicData>
+			<shadowData>
+				<volume>(0.3, 0.3, 0.3)</volume>
+			</shadowData>
+		</graphicData>
+		<passability>PassThroughOnly</passability>
+		<pathCost>130</pathCost>
+		<blockWind>true</blockWind>
+		<ingestible>
+			<foodType>Tree</foodType>
+			<preferability>RawBad</preferability>
+			<nutrition>1.50</nutrition>
+		</ingestible>
+		<plant>
 			<fertilityMin>0.3</fertilityMin>
 			<fertilitySensitivity>0.5</fertilitySensitivity>
 			<reproduceRadius>30</reproduceRadius>
 			<soundHarvesting>Harvest_Tree</soundHarvesting>
 			<harvestDestroys>false</harvestDestroys>
-      <soundHarvestFinish>Harvest_Tree_Finish</soundHarvestFinish>
-      <sowWork>1200</sowWork>
-      <harvestWork>600</harvestWork>
-      <harvestTag>Standard</harvestTag>
-      <harvestMinGrowth>0.60</harvestMinGrowth>
-      <harvestFailable>false</harvestFailable>
-	 <harvestYield>50</harvestYield>
-      <blockAdjacentSow>true</blockAdjacentSow>
-      <sowTags>
-        <li>Ground</li>
-      </sowTags>
-      <visualSizeRange>
-        <min>1.5</min>
-        <max>2.0</max>
-      </visualSizeRange>
-      <topWindExposure>0.25</topWindExposure>
-      <wildClusterSizeRange>
-        <min>8</min>
-        <max>30</max>
-      </wildClusterSizeRange>
-      <wildClusterRadius>8</wildClusterRadius>
-    </plant>
-  </ThingDef>
-  
-    <ThingDef ParentName="TreeBase" Name="TreewoodBase" Abstract="True">
-    <plant>
-      <soundHarvesting>Harvest_Tree</soundHarvesting>
-      <soundHarvestFinish>Harvest_Tree_Finish</soundHarvestFinish>
-      <sowWork>1500</sowWork>
-      <harvestWork>800</harvestWork>
-      <harvestDestroys>true</harvestDestroys>
-      <harvestedThingDef>WoodLog</harvestedThingDef>
-      <harvestYield>50</harvestYield>
-      <harvestTag>Wood</harvestTag>
-      <harvestMinGrowth>0.40</harvestMinGrowth>
-      <harvestFailable>false</harvestFailable>
-      <blockAdjacentSow>true</blockAdjacentSow>
-    </plant>
-  </ThingDef>
-  
+			<soundHarvestFinish>Harvest_Tree_Finish</soundHarvestFinish>
+			<sowWork>1200</sowWork>
+			<harvestWork>600</harvestWork>
+			<harvestTag>Standard</harvestTag>
+			<harvestMinGrowth>0.60</harvestMinGrowth>
+			<harvestFailable>false</harvestFailable>
+			<harvestYield>50</harvestYield>
+			<blockAdjacentSow>true</blockAdjacentSow>
+			<sowTags>
+				<li>Ground</li>
+			</sowTags>
+			<visualSizeRange>
+				<min>1.5</min>
+				<max>2.0</max>
+			</visualSizeRange>
+			<topWindExposure>0.25</topWindExposure>
+			<wildClusterSizeRange>
+				<min>8</min>
+				<max>30</max>
+			</wildClusterSizeRange>
+			<wildClusterRadius>8</wildClusterRadius>
+		</plant>
+	</ThingDef>
 
-  <!--=========================== Grass ==============================-->
+	<ThingDef ParentName="TreeBase" Name="TreewoodBase" Abstract="True">
+		<plant>
+			<soundHarvesting>Harvest_Tree</soundHarvesting>
+			<soundHarvestFinish>Harvest_Tree_Finish</soundHarvestFinish>
+			<sowWork>1500</sowWork>
+			<harvestWork>800</harvestWork>
+			<harvestDestroys>true</harvestDestroys>
+			<harvestedThingDef>WoodLog</harvestedThingDef>
+			<harvestYield>50</harvestYield>
+			<harvestTag>Wood</harvestTag>
+			<harvestMinGrowth>0.40</harvestMinGrowth>
+			<harvestFailable>false</harvestFailable>
+			<blockAdjacentSow>true</blockAdjacentSow>
+		</plant>
+	</ThingDef>
 
-  <ThingDef ParentName="PlantBase">
-    <defName>PlantGrass</defName>
-    <label>Grass</label>
-    <description>Wild grass. It grows anywhere that there is a little light and minimally fertile ground.</description>
-    <statBases>
-      <MaxHitPoints>85</MaxHitPoints>
-      <Beauty>2</Beauty>
-    </statBases>
-    <graphicData>
-      <texPath>Things/Plant/PlantGrass</texPath>
-      <graphicClass>Graphic_Random</graphicClass>
-    </graphicData>
-    <hideAtSnowDepth>0.5</hideAtSnowDepth>
-    <ingestible>
-      <foodType>Plant</foodType>
-      <preferability>NeverForNutrition</preferability>
-      <nutrition>0.15</nutrition>
-    </ingestible>
-    <fillPercent>0</fillPercent>
-    <plant>
-      <leaflessGraphicPath>Things/Plant/PlantGrass_Leafless</leaflessGraphicPath>
-      <harvestWork>40</harvestWork>
-      <fertilityMin>0.05</fertilityMin>
-      <maxMeshCount>4</maxMeshCount>
-      <harvestTag>Standard</harvestTag>
-      <harvestedThingDef>Hay</harvestedThingDef>
-      <harvestDestroys>true</harvestDestroys>
-      <harvestYield>3</harvestYield>
-      <visualSizeRange>
-        <min>0.2</min>
-        <max>0.85</max>
-      </visualSizeRange>
-      <growDays>2.5</growDays>
-      <topWindExposure>0.4</topWindExposure>
-      <reproduceMtbDays>3</reproduceMtbDays>
-      <fertilitySensitivity>0.90</fertilitySensitivity>
-    </plant>
-  </ThingDef>
 
-  <ThingDef ParentName="PlantBase">
-    <defName>PlantTallGrass</defName>
-    <label>Tall Grass</label>
-    <description>Wild Tall Grass is grass that grew exceedingly high. It significantly slows down anyone moving over it.</description>
-    <statBases>
-      <MaxHitPoints>90</MaxHitPoints>
-      <Beauty>0</Beauty>
-    </statBases>
-    <pathCost>18</pathCost>
-    <graphicData>
-      <texPath>Things/Plant/PlantGrass</texPath>
-      <graphicClass>Graphic_Random</graphicClass>
-    </graphicData>
-    <hideAtSnowDepth>0.5</hideAtSnowDepth>
-    <ingestible>
-      <nutrition>0.18</nutrition>
-    </ingestible>
-    <fillPercent>0</fillPercent>
-    <plant>
-      <leaflessGraphicPath>Things/Plant/PlantGrass_Leafless</leaflessGraphicPath>
-      <harvestWork>60</harvestWork>
-      <fertilityMin>0.05</fertilityMin>
-      <maxMeshCount>4</maxMeshCount>
-      <harvestTag>Standard</harvestTag>
-      <harvestedThingDef>Hay</harvestedThingDef>
-      <harvestDestroys>true</harvestDestroys>
-      <harvestYield>6</harvestYield>
-      <visualSizeRange>
-        <min>0.5</min>
-        <max>1.4</max>
-      </visualSizeRange>
-      <growDays>3</growDays>
-      <topWindExposure>0.4</topWindExposure>
-      <reproduceMtbDays>3</reproduceMtbDays>
-      <fertilitySensitivity>0.90</fertilitySensitivity>
-    </plant>
-  </ThingDef>
-  
+	<!--=========================== Grass ==============================-->
 
-  <ThingDef ParentName="PlantBase">
-    <defName>PlantHaygrass</defName>
-    <label>Haygrass</label>
-    <description>A mixture of nutrient-rich grasses that yield large amounts of Hay. Hay is edible for animals, but not humans.</description>
-    <statBases>
-      <MaxHitPoints>85</MaxHitPoints>
-      <Beauty>1</Beauty>
-    </statBases>
-    <graphicData>
-      <texPath>Things/Plant/Haygrass</texPath>
-      <graphicClass>Graphic_Random</graphicClass>
-    </graphicData>
-    <selectable>true</selectable>
-    <pathCost>5</pathCost>
-    <ingestible>
-      <nutrition>0.20</nutrition>
-    </ingestible>
-    <fillPercent>0</fillPercent>
-    <plant>
-	  <leaflessGraphicPath>Things/Plant/Haygrass_Leafless</leaflessGraphicPath>
-      <dieIfLeafless>false</dieIfLeafless>
-      <maxMeshCount>4</maxMeshCount>
-      <harvestedThingDef>Hay</harvestedThingDef>
-      <harvestYield>18</harvestYield>
-      <sowTags>
-        <li>Ground</li>
-        <li>Hydroponic</li>
-      </sowTags>
-      <sowMinSkill>1</sowMinSkill>
-      <sowResearchPrerequisites>
-        <li>SK_LivestockI</li>
-      </sowResearchPrerequisites>
-      <topWindExposure>0.1</topWindExposure>
-      <growDays>10.0</growDays>
-      <fertilityMin>0.15</fertilityMin>
-      <fertilitySensitivity>0.80</fertilitySensitivity>
-      <visualSizeRange>
-        <min>0.3</min>
-        <max>0.8</max>
-      </visualSizeRange>
-    </plant>
-  </ThingDef>
+	<ThingDef ParentName="PlantBase">
+		<defName>PlantGrass</defName>
+		<label>grass</label>
+		<description>Wild grass. It grows anywhere that there is a little light and minimally fertile ground.</description>
+		<statBases>
+			<MaxHitPoints>85</MaxHitPoints>
+			<Beauty>1</Beauty>
+		</statBases>
+		<graphicData>
+			<texPath>Things/Plant/PlantGrass</texPath>
+			<graphicClass>Graphic_Random</graphicClass>
+		</graphicData>
+		<hideAtSnowDepth>0.5</hideAtSnowDepth>
+		<ingestible>
+			<foodType>Plant</foodType>
+			<preferability>NeverForNutrition</preferability>
+			<nutrition>0.15</nutrition>
+		</ingestible>
+		<fillPercent>0</fillPercent>
+		<plant>
+			<leaflessGraphicPath>Things/Plant/PlantGrass_Leafless</leaflessGraphicPath>
+			<harvestWork>40</harvestWork>
+			<fertilityMin>0.05</fertilityMin>
+			<maxMeshCount>4</maxMeshCount>
+			<harvestTag>Standard</harvestTag>
+			<harvestedThingDef>Hay</harvestedThingDef>
+			<harvestDestroys>true</harvestDestroys>
+			<harvestYield>3</harvestYield>
+			<visualSizeRange>
+				<min>0.2</min>
+				<max>0.85</max>
+			</visualSizeRange>
+			<growDays>2.5</growDays>
+			<topWindExposure>0.4</topWindExposure>
+			<reproduceMtbDays>3</reproduceMtbDays>
+			<fertilitySensitivity>0.90</fertilitySensitivity>
+		</plant>
+	</ThingDef>
+
+	<ThingDef ParentName="PlantBase">
+		<defName>PlantTallGrass</defName>
+		<label>tall grass</label>
+		<description>Wild tall grass is grass that grew exceedingly high. It significantly slows down anyone moving over it.</description>
+		<statBases>
+			<MaxHitPoints>90</MaxHitPoints>
+			<Beauty>0</Beauty>
+		</statBases>
+		<pathCost>18</pathCost>
+		<graphicData>
+			<texPath>Things/Plant/PlantGrass</texPath>
+			<graphicClass>Graphic_Random</graphicClass>
+		</graphicData>
+		<hideAtSnowDepth>0.5</hideAtSnowDepth>
+		<ingestible>
+			<nutrition>0.18</nutrition>
+		</ingestible>
+		<fillPercent>0</fillPercent>
+		<plant>
+			<leaflessGraphicPath>Things/Plant/PlantGrass_Leafless</leaflessGraphicPath>
+			<harvestWork>60</harvestWork>
+			<fertilityMin>0.05</fertilityMin>
+			<maxMeshCount>4</maxMeshCount>
+			<harvestTag>Standard</harvestTag>
+			<harvestedThingDef>Hay</harvestedThingDef>
+			<harvestDestroys>true</harvestDestroys>
+			<harvestYield>6</harvestYield>
+			<visualSizeRange>
+				<min>0.5</min>
+				<max>1.4</max>
+			</visualSizeRange>
+			<growDays>3</growDays>
+			<topWindExposure>0.4</topWindExposure>
+			<reproduceMtbDays>3</reproduceMtbDays>
+			<fertilitySensitivity>0.90</fertilitySensitivity>
+		</plant>
+	</ThingDef>
+
+
+	<ThingDef ParentName="PlantBase">
+		<defName>PlantHaygrass</defName>
+		<label>haygrass</label>
+		<description>A mixture of nutrient-rich grasses that yield large amounts of Hay. Hay is edible for animals, but not humans. Haygrass is not destroyed when an animal eats it, so it can be used to make an improved, more compact grazing area for ranching animals.</description>
+		<statBases>
+			<MaxHitPoints>85</MaxHitPoints>
+			<Beauty>1</Beauty>
+		</statBases>
+		<graphicData>
+			<texPath>Things/Plant/Haygrass</texPath>
+			<graphicClass>Graphic_Random</graphicClass>
+		</graphicData>
+		<selectable>true</selectable>
+		<pathCost>5</pathCost>
+		<ingestible>
+			<!-- when an animal eats a plant that is not destroyed upon harvest, they eat 30% of it (and won't eat if less than 65% grown). They get the below nutrition per 30% of plant growth, down to 50% (if they eat at 65%, then only the first 15% of the 30% will count) -->
+			<nutrition>0.15</nutrition>
+		</ingestible>
+		<fillPercent>0</fillPercent>
+		<plant>
+			<leaflessGraphicPath>Things/Plant/Haygrass_Leafless</leaflessGraphicPath>
+			<dieIfLeafless>false</dieIfLeafless>
+			<maxMeshCount>4</maxMeshCount>
+			<harvestedThingDef>Hay</harvestedThingDef>
+			<harvestYield>18</harvestYield>
+			<harvestDestroys>false</harvestDestroys>
+			<sowTags>
+				<li>Ground</li>
+				<li>Hydroponic</li>
+			</sowTags>
+			<sowMinSkill>1</sowMinSkill>
+			<sowResearchPrerequisites>
+				<li>SK_LivestockI</li>
+			</sowResearchPrerequisites>
+			<topWindExposure>0.25</topWindExposure>
+			<growDays>5.0</growDays>
+			<fertilityMin>0.15</fertilityMin>
+			<fertilitySensitivity>1.1</fertilitySensitivity>
+			<visualSizeRange>
+				<min>0.3</min>
+				<max>0.8</max>
+			</visualSizeRange>
+		</plant>
+	</ThingDef>
 
 	<ThingDef ParentName="PlantDef">
 		<defName>PlantWildRose</defName>
-		<label>Wild Rose Flowers</label>
-		<description>Wild Rose Flowers are from Wild Rose Seeds and produce red flowers called Wild Roses. The plant is also known as the Prickly Rose, Bristly Rose and Arctic Rose. They are used in Herb Collections made from the Tobacco Rolling Bench, Advanced Medicine kits made from the Medical Table, and lastly, into Luxury Meals from the Cook Stove.</description>
-    <statBases>
-      <Beauty>6</Beauty>
-    </statBases>
-	<graphicData>
-    <texPath>Things/Plant/mediflowerplant</texPath>
-    <graphicClass>Graphic_Single</graphicClass>
-	<shaderType>CutoutPlant</shaderType>
-	</graphicData>
-    <ingestible>
-      <nutrition>0.12</nutrition>
-    </ingestible>
-    <plant>
-      <sowMinSkill>12</sowMinSkill>
-      <sowResearchPrerequisites>
-        <li>SK_MedicalCropsI</li>
-      </sowResearchPrerequisites>
-      <sowTags>
-        <li>Hydroponic</li>
-      </sowTags>
-      <harvestedThingDef>WildRose</harvestedThingDef>
-	<sowWork>150</sowWork>
-	<harvestYield>6</harvestYield>
-      <topWindExposure>0.1</topWindExposure>
-	<growMinGlow>0.3</growMinGlow>
-      <growDays>10</growDays>
-	<fertilityMin>1.4</fertilityMin>
-	<fertilitySensitivity>1.3</fertilitySensitivity>
-      <visualSizeRange>
-        <min>0.3</min>
-        <max>1.05</max>
-      </visualSizeRange>
-    </plant>
-  </ThingDef>
+		<label>wild rose flowers</label>
+		<description>Wild rose flowers are from wild rose seeds and produce red flowers called wild roses. The plant is also known as the prickly rose, bristly rose and arctic rose. They are used in berb collections made from the tobacco rolling bench, Advanced medicine kits made from the medical table, and lastly, into luxury meals from the cook stove.</description>
+		<statBases>
+			<Beauty>6</Beauty>
+		</statBases>
+		<graphicData>
+			<texPath>Things/Plant/mediflowerplant</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>CutoutPlant</shaderType>
+		</graphicData>
+		<ingestible>
+			<nutrition>0.12</nutrition>
+		</ingestible>
+		<plant>
+			<sowMinSkill>12</sowMinSkill>
+			<sowResearchPrerequisites>
+				<li>SK_MedicalCropsI</li>
+			</sowResearchPrerequisites>
+			<sowTags>
+				<li>Hydroponic</li>
+			</sowTags>
+			<harvestedThingDef>WildRose</harvestedThingDef>
+			<sowWork>150</sowWork>
+			<harvestYield>6</harvestYield>
+			<topWindExposure>0.1</topWindExposure>
+			<growMinGlow>0.3</growMinGlow>
+			<growDays>10</growDays>
+			<fertilityMin>1.4</fertilityMin>
+			<fertilitySensitivity>1.3</fertilitySensitivity>
+			<visualSizeRange>
+				<min>0.3</min>
+				<max>1.05</max>
+			</visualSizeRange>
+		</plant>
+	</ThingDef>
 
 
 	<ThingDef ParentName="PlantDef">
 		<defName>PlantHypericum</defName>
-		<label>Hypericum Plant</label>
-		<description>Hypericum Plants produce a type of medicinal flower called Hypericum. They are used in Herb Collections made from the Tobacco Rolling Bench, Advanced Medicine kits made from the Medical Table, and lastly, into Luxury Meals from the Cook Stove</description>
-    <statBases>
-      <Beauty>6</Beauty>
-    </statBases>
-	<graphicData>
-    <texPath>Things/Plant/mediflowerplanty</texPath>
-    <graphicClass>Graphic_Single</graphicClass>
-	<shaderType>CutoutPlant</shaderType>
-	</graphicData>
-    <ingestible>
-      <nutrition>0.12</nutrition>
-    </ingestible>
-    <plant>
-      <sowMinSkill>12</sowMinSkill>
-      <sowResearchPrerequisites>
-        <li>SK_MedicalCropsI</li>
-      </sowResearchPrerequisites>
-      <sowTags>
-        <li>Hydroponic</li>
-      </sowTags>
-      <harvestedThingDef>Hypericum</harvestedThingDef>
-	<sowWork>150</sowWork>
-      <harvestYield>4</harvestYield>
-      <topWindExposure>0.1</topWindExposure>
-	<growMinGlow>0.3</growMinGlow>
-      <growDays>7</growDays>
-	<fertilityMin>1.3</fertilityMin>
-	<fertilitySensitivity>1.4</fertilitySensitivity>
-      <visualSizeRange>
-        <min>0.3</min>
-        <max>1.05</max>
-      </visualSizeRange>
-    </plant>
-  </ThingDef>
+		<label>hypericum plant</label>
+		<description>Hypericum plants produce a type of medicinal flower called hypericum. They are used in herb collections made from the tobacco rolling bench, advanced medicine kits made from the medical table, and lastly, into luxury meals from the cook stove.</description>
+		<statBases>
+			<Beauty>6</Beauty>
+		</statBases>
+		<graphicData>
+			<texPath>Things/Plant/mediflowerplanty</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>CutoutPlant</shaderType>
+		</graphicData>
+		<ingestible>
+			<nutrition>0.12</nutrition>
+		</ingestible>
+		<plant>
+			<sowMinSkill>12</sowMinSkill>
+			<sowResearchPrerequisites>
+				<li>SK_MedicalCropsI</li>
+			</sowResearchPrerequisites>
+			<sowTags>
+				<li>Hydroponic</li>
+			</sowTags>
+			<harvestedThingDef>Hypericum</harvestedThingDef>
+			<sowWork>150</sowWork>
+			<harvestYield>4</harvestYield>
+			<topWindExposure>0.1</topWindExposure>
+			<growMinGlow>0.3</growMinGlow>
+			<growDays>7</growDays>
+			<fertilityMin>1.3</fertilityMin>
+			<fertilitySensitivity>1.4</fertilitySensitivity>
+			<visualSizeRange>
+				<min>0.3</min>
+				<max>1.05</max>
+			</visualSizeRange>
+		</plant>
+	</ThingDef>
 
 
 	<ThingDef ParentName="PlantDef">
 		<defName>PlantMint</defName>
-		<label>Mint Plant</label>
-		<description>Mint Plants are herbs that grow aromatic leaves called Mint Leaves. They are used in Herb Collections made from the Tobacco Rolling Bench, Advanced Medicine kits made from the Medical Table, and into Luxury Meals from the Cook Stove.</description>
-    <statBases>
-      <Beauty>6</Beauty>
-    </statBases>
-	<graphicData>
-    <texPath>Things/Plant/mediflowerplantg</texPath>
-    <graphicClass>Graphic_Single</graphicClass>
-	<shaderType>CutoutPlant</shaderType>
-	</graphicData>
-    <pathCost>10</pathCost>
-    <ingestible>
-      <nutrition>0.12</nutrition>
-    </ingestible>
-    <plant>
-      <sowMinSkill>12</sowMinSkill>
-      <sowResearchPrerequisites>
-        <li>SK_MedicalCropsI</li>
-      </sowResearchPrerequisites>
-      <sowTags>
-        <li>Hydroponic</li>
-      </sowTags>
-      <harvestedThingDef>MintLeaves</harvestedThingDef>
-	<sowWork>150</sowWork>
-      <harvestYield>5</harvestYield>
-      <topWindExposure>0.1</topWindExposure>
-	<growMinGlow>0.3</growMinGlow>
-      <growDays>8</growDays>
-	<fertilityMin>1.35</fertilityMin>
-	<fertilitySensitivity>1.45</fertilitySensitivity>
-      <visualSizeRange>
-        <min>0.3</min>
-        <max>1.05</max>
-      </visualSizeRange>
-    </plant>
-  </ThingDef>
-  
-  
-<ThingDef ParentName="PlantDef">
+		<label>mint plant</label>
+		<description>Mint plants are herbs that grow aromatic leaves called mint leaves. They are used in herb collections made from the tobacco rolling bench, advanced medicine kits made from the medical table, and into luxury meals from the cook stove.</description>
+		<statBases>
+			<Beauty>6</Beauty>
+		</statBases>
+		<graphicData>
+			<texPath>Things/Plant/mediflowerplantg</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shaderType>CutoutPlant</shaderType>
+		</graphicData>
+		<pathCost>10</pathCost>
+		<ingestible>
+			<nutrition>0.12</nutrition>
+		</ingestible>
+		<plant>
+			<sowMinSkill>12</sowMinSkill>
+			<sowResearchPrerequisites>
+				<li>SK_MedicalCropsI</li>
+			</sowResearchPrerequisites>
+			<sowTags>
+				<li>Hydroponic</li>
+			</sowTags>
+			<harvestedThingDef>MintLeaves</harvestedThingDef>
+			<sowWork>150</sowWork>
+			<harvestYield>5</harvestYield>
+			<topWindExposure>0.1</topWindExposure>
+			<growMinGlow>0.3</growMinGlow>
+			<growDays>8</growDays>
+			<fertilityMin>1.35</fertilityMin>
+			<fertilitySensitivity>1.45</fertilitySensitivity>
+			<visualSizeRange>
+				<min>0.3</min>
+				<max>1.05</max>
+			</visualSizeRange>
+		</plant>
+	</ThingDef>
+
+
+	<ThingDef ParentName="PlantDef">
 		<defName>Plantonion</defName>
-		<label>Onion Plant</label>
-		<description>Onions Plants produce vegetable bulbs called Onions. They are considered to be a luxury crop and are used in Luxury Meals from the Cook Stove. A pungeant chemcial is released when Onions are chopped that can make you cry!</description>
-    <statBases>
-      <Beauty>4</Beauty>
-    </statBases>
-	<graphicData>
-    <texPath>Things/Plant/onionPlant</texPath>
-    <graphicClass>Graphic_Single</graphicClass>
-	</graphicData>
-    <ingestible>
-      <nutrition>0.12</nutrition>
-    </ingestible>
-    <plant>
-      <sowMinSkill>3</sowMinSkill>
-      <sowResearchPrerequisites>
-        <li>SK_VegetablesI</li>
-      </sowResearchPrerequisites>
-      <sowTags>
-        <li>Ground</li>
-        <li>Hydroponic</li>
-      </sowTags>
-      <harvestedThingDef>Rawonion</harvestedThingDef>
-      <harvestYield>3</harvestYield>
-      <topWindExposure>0.1</topWindExposure>
-      <growDays>5.00</growDays>
-	  <fertilityMin>1.2</fertilityMin>
-      <fertilitySensitivity>1.5</fertilitySensitivity>
-      <visualSizeRange>
-        <min>0.25</min>
-        <max>1.00</max>
-      </visualSizeRange>
-    </plant>
-  </ThingDef>
+		<label>onion plant</label>
+		<description>Onions plants produce vegetable bulbs called onions. They are considered to be a luxury crop and are used in Luxury Meals from the Cook Stove. A pungent chemical is released when onions are chopped that can make you cry!</description>
+		<statBases>
+			<Beauty>4</Beauty>
+		</statBases>
+		<graphicData>
+			<texPath>Things/Plant/onionPlant</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<ingestible>
+			<nutrition>0.12</nutrition>
+		</ingestible>
+		<plant>
+			<sowMinSkill>3</sowMinSkill>
+			<sowResearchPrerequisites>
+				<li>SK_VegetablesI</li>
+			</sowResearchPrerequisites>
+			<sowTags>
+				<li>Ground</li>
+				<li>Hydroponic</li>
+			</sowTags>
+			<harvestedThingDef>Rawonion</harvestedThingDef>
+			<harvestYield>3</harvestYield>
+			<topWindExposure>0.1</topWindExposure>
+			<growDays>5.00</growDays>
+			<fertilityMin>1.2</fertilityMin>
+			<fertilitySensitivity>1.5</fertilitySensitivity>
+			<visualSizeRange>
+				<min>0.25</min>
+				<max>1.00</max>
+			</visualSizeRange>
+		</plant>
+	</ThingDef>
 
 </Plants>

--- a/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Tree_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Tree_SK.xml
@@ -79,7 +79,7 @@
       <harvestTag>Standard</harvestTag>
       <harvestedThingDef>Kindling</harvestedThingDef>
       <harvestDestroys>true</harvestDestroys>
-      <harvestYield>4</harvestYield>
+      <harvestYield>2</harvestYield>
       <wildClusterSizeRange>
         <min>2</min>
         <max>5</max>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource.xml
@@ -1,10 +1,10 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Resources>
-  <!-- =========== REALISTIC PRODUCTION SK MOD =========== -->
-  
+	<!-- =========== REALISTIC PRODUCTION SK MOD =========== -->
+
 	<ThingDef ParentName="ResourceBase">
 		<defName>Silicon</defName>
-		<label>Silicon</label>
+		<label>silicon</label>
 		<description>Silicon is the one of the most common elements in the universe by mass, but very rarely occurs as the pure free element in nature. It can be produced by smelting Sand.</description>
 		<graphicData>
 			<texPath>Things/Item/Resource/Silicon</texPath>
@@ -18,22 +18,22 @@
 		<statBases>
 			<MarketValue>4</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
-    		<Flammability>0</Flammability>
+			<Flammability>0</Flammability>
 		</statBases>
 		<thingCategories>
 			<li>ResourcesRaw</li>
 		</thingCategories>
 		<stackLimit>300</stackLimit>
 	</ThingDef>
-	
+
 	<ThingDef ParentName="ResourceBase">
 		<defName>Biomatter</defName>
-		<label>BioMatter</label>
+		<label>biomatter</label>
 		<description>BioMatter can be extracted from a humanlike corpse. It can be used to grow natural organs in an Organ Vat.</description>
-    <graphicData>
-		<texPath>Things/Item/Resource/Biomatter</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
+		<graphicData>
+			<texPath>Things/Item/Resource/Biomatter</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<soundInteract>Standard_Drop</soundInteract>
 		<soundDrop>Standard_Drop</soundDrop>
 		<stackLimit>75</stackLimit>
@@ -41,7 +41,7 @@
 		<statBases>
 			<MarketValue>22</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
-    		<Flammability>3</Flammability>
+			<Flammability>3</Flammability>
 		</statBases>
 		<thingCategories>
 			<li>SuperMaterialCat</li>
@@ -50,15 +50,15 @@
 			<li>Exotic</li>
 		</tradeTags>
 	</ThingDef>
-	
+
 	<ThingDef ParentName="ResourceBase">
 		<defName>ArtificialBone</defName>
-		<label>Artificial Bone</label>
+		<label>artificial bone</label>
 		<description>A carefully crafted synthetic bone piece. It is useful for repairing damaged bones.</description>
-    <graphicData>
-		<texPath>Things/Item/BodyPart/ArtificialBone</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
+		<graphicData>
+			<texPath>Things/Item/BodyPart/ArtificialBone</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<soundInteract>Standard_Drop</soundInteract>
 		<soundDrop>Standard_Drop</soundDrop>
 		<stackLimit>25</stackLimit>
@@ -66,7 +66,7 @@
 		<statBases>
 			<MarketValue>380</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
-    		<Flammability>1</Flammability>
+			<Flammability>1</Flammability>
 		</statBases>
 		<thingCategories>
 			<li>BodyParts</li>
@@ -75,22 +75,22 @@
 			<li>Exotic</li>
 		</tradeTags>
 	</ThingDef>
-	
+
 	<ThingDef ParentName="ResourceBase">
 		<defName>CrushedStone</defName>
-		<label>Rubble</label>
+		<label>rubble</label>
 		<description>Rough Rubble stones are created by smashing stone chunks or blocks. It can be gathered from gravel on the ground. It is a useful ingredient for concrete. It can also be smashed further to produce Sand.</description>
-    <graphicData>
-		<texPath>Things/Item/CrushedStone</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
+		<graphicData>
+			<texPath>Things/Item/CrushedStone</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
 		<stackLimit>900</stackLimit>
 		<statBases>
 			<MarketValue>0.3</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
-    		<Flammability>0</Flammability>
+			<Flammability>0</Flammability>
 		</statBases>
 		<tickerType>Rare</tickerType>
 		<thingCategories>
@@ -98,105 +98,105 @@
 		</thingCategories>
 	</ThingDef>
 
-	
+
 	<ThingDef ParentName="ResourceBase">
 		<defName>Ash</defName>
-		<label>Ash</label>
-		<description>Ash is obtained by burning Corpses or other materials in a Crematorium or Fire Pit.</description>
-    <graphicData>
-		<texPath>Things/Item/Ash</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
+		<label>ash</label>
+		<description>Ash is obtained by burning corpses or other materials in a crematorium or fire pit.</description>
+		<graphicData>
+			<texPath>Things/Item/Ash</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
 		<stackLimit>150</stackLimit>
 		<statBases>
 			<MarketValue>10</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
-    		<Flammability>0</Flammability>
+			<Flammability>0</Flammability>
 		</statBases>
 		<thingCategories>
 			<li>ResourcesRaw</li>
 		</thingCategories>
 	</ThingDef>
 
-  <ThingDef ParentName="ResourceBase">
-    <defName>ConcreteResource</defName>
-    <label>Concrete</label>
-    <description>Concrete is a composite material composed of Sand and Rubble. It is a fluid material that bonds into a solid material over time. It can have metals added to create Reinforced Concrete, a durable and solid building material.</description>
-    <graphicData>
-    <texPath>Things/Item/Resource/Concrete</texPath>
-    <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <stackLimit>150</stackLimit>
-    <statBases>
-      <MaxHitPoints>50</MaxHitPoints>
-      <MarketValue>6.0</MarketValue>
-		<DeteriorationRate>0</DeteriorationRate>
-    	<Flammability>1</Flammability>
-    </statBases>
-    <thingCategories>
-      <li>ConstructionParts</li>
-    </thingCategories>
+	<ThingDef ParentName="ResourceBase">
+		<defName>ConcreteResource</defName>
+		<label>concrete</label>
+		<description>Concrete is a composite material composed of sand and rubble. It is a fluid material that bonds into a solid material over time. It can have metals added to create reinforced concrete, a durable and solid building material.</description>
+		<graphicData>
+			<texPath>Things/Item/Resource/Concrete</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<stackLimit>150</stackLimit>
+		<statBases>
+			<MaxHitPoints>50</MaxHitPoints>
+			<MarketValue>6.0</MarketValue>
+			<DeteriorationRate>0</DeteriorationRate>
+			<Flammability>1</Flammability>
+		</statBases>
+		<thingCategories>
+			<li>ConstructionParts</li>
+		</thingCategories>
 		<tickerType>Rare</tickerType>
-    <stuffProps>
-      <appearance>Planks</appearance>
-      <color>(122,122,120)</color>
-      <soundImpactStuff>BulletImpactGround</soundImpactStuff>
-      <stuffAdjective>concrete</stuffAdjective>
-    </stuffProps>
-  </ThingDef>
-  
+		<stuffProps>
+			<appearance>Planks</appearance>
+			<color>(122,122,120)</color>
+			<soundImpactStuff>BulletImpactGround</soundImpactStuff>
+			<stuffAdjective>concrete</stuffAdjective>
+		</stuffProps>
+	</ThingDef>
 
-  <ThingDef ParentName="ResourceBase">
-    <defName>ClayBrick</defName>
-    <label>Clay Bricks</label>
-    <description>A brick of hardened clay baked at a Smelting Furnace. It can be used for construction purposes.</description>
-    <graphicData>
-      <texPath>Things/Item/Resource/ClayBricks</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <soundInteract>Stone_Drop</soundInteract>
-    <soundDrop>Stone_Drop</soundDrop>
-    <statBases>
-		<MarketValue>3</MarketValue>
-		<DeteriorationRate>0</DeteriorationRate>
-    	<Flammability>0</Flammability>
-    </statBases>
-    <thingCategories>
-	<li>ConstructionParts</li>
-    </thingCategories>
-    <stackLimit>300</stackLimit>
-    <stuffProps>
-      <stuffAdjective>Clay Bricks</stuffAdjective>
-      <categories>
-	<li>Stony</li>
-      </categories>
-      <color>(163,109,64)</color>
-      <statOffsets>
-        <WorkToMake>70</WorkToMake>
-        <WorkToBuild>70</WorkToBuild>
-        <Beauty>1.5</Beauty>
-      </statOffsets>
-      <statFactors>
-		<MaxHitPoints>1.4</MaxHitPoints>
-		<Beauty>1.35</Beauty>
-		<Flammability>0</Flammability>
-		<WorkToMake>1.3</WorkToMake>
-        <WorkToBuild>1.3</WorkToBuild>
-		<WorkTableWorkSpeedFactor>1.0</WorkTableWorkSpeedFactor>
-      </statFactors>
-    </stuffProps>
-  </ThingDef>
 
-  <!-- ============================================================== -->
-  <!-- Matter -->
+	<ThingDef ParentName="ResourceBase">
+		<defName>ClayBrick</defName>
+		<label>clay bricks</label>
+		<description>A brick of hardened clay baked at a kiln. It can be used for construction purposes.</description>
+		<graphicData>
+			<texPath>Things/Item/Resource/ClayBricks</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<soundInteract>Stone_Drop</soundInteract>
+		<soundDrop>Stone_Drop</soundDrop>
+		<statBases>
+			<MarketValue>3</MarketValue>
+			<DeteriorationRate>0</DeteriorationRate>
+			<Flammability>0</Flammability>
+		</statBases>
+		<thingCategories>
+			<li>ConstructionParts</li>
+		</thingCategories>
+		<stackLimit>300</stackLimit>
+		<stuffProps>
+			<stuffAdjective>Clay Bricks</stuffAdjective>
+			<categories>
+				<li>Stony</li>
+			</categories>
+			<color>(163,109,64)</color>
+			<statOffsets>
+				<WorkToMake>70</WorkToMake>
+				<WorkToBuild>70</WorkToBuild>
+				<Beauty>1.5</Beauty>
+			</statOffsets>
+			<statFactors>
+				<MaxHitPoints>1.4</MaxHitPoints>
+				<Beauty>1.35</Beauty>
+				<Flammability>0</Flammability>
+				<WorkToMake>1.3</WorkToMake>
+				<WorkToBuild>1.3</WorkToBuild>
+				<WorkTableWorkSpeedFactor>1.0</WorkTableWorkSpeedFactor>
+			</statFactors>
+		</stuffProps>
+	</ThingDef>
 
-  
+	<!-- ============================================================== -->
+	<!-- Matter -->
+
+
 	<ThingDef ParentName="ResourceBase">
 		<defName>Matter</defName>
-		<label>Inorganic Matter</label>
-		<description>A container of Inorganic Matter. It can be made at an Inorganic Matter Converter from various types of raw resources or refined into specific resources. It can be used to feed a Hadron Collider for AntiMatter production.</description>
+		<label>inorganic matter</label>
+		<description>A container of inorganic matter. It can be made at an inorganic matter converter from various types of raw resources or refined into specific resources. It can be used to feed a hadron collider for antimatter production.</description>
 		<graphicData>
 			<texPath>Things/Item/RMatter</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -221,35 +221,35 @@
 	</ThingDef>
 
 
-<!--=============== Drill head SK ====================-->
+	<!--=============== Drill head SK ====================-->
 
 
-  <ThingDef ParentName="ResourceBase">
-    <defName>DrillHead</defName>
-    <label>Drill Head</label>
-    <description>A Drill Head for the Drilling Rig. Drilling Rigs are placed on Deposits of Crude Oil to drill Oil Fissures. These are openings in the ground that can produce Crude Oil through the use of an Oil Extractor.</description>
-    <graphicData>
-    <texPath>Things/Item/Resource/DrillHead</texPath>
-    <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <stackLimit>25</stackLimit>
-    <soundInteract>Metal_Drop</soundInteract>
-    <soundDrop>Metal_Drop</soundDrop>
-    <statBases>
-		<MaxHitPoints>300</MaxHitPoints>
-		<MarketValue>200</MarketValue>
-		<Flammability>0</Flammability>
-		<DeteriorationRate>0</DeteriorationRate>
-    </statBases>
-    <thingCategories>
-      <li>Manufactured</li>
-    </thingCategories>
-  </ThingDef>
-  
-  
-  	<ThingDef ParentName="ResourceBase">
+	<ThingDef ParentName="ResourceBase">
+		<defName>DrillHead</defName>
+		<label>drill head</label>
+		<description>A drill head for the drilling rig. Drilling rigs are placed on deposits of crude oil to create oil fissures. These are openings in the ground that can produce crude oil through the use of an oil extractor.</description>
+		<graphicData>
+			<texPath>Things/Item/Resource/DrillHead</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<stackLimit>25</stackLimit>
+		<soundInteract>Metal_Drop</soundInteract>
+		<soundDrop>Metal_Drop</soundDrop>
+		<statBases>
+			<MaxHitPoints>300</MaxHitPoints>
+			<MarketValue>200</MarketValue>
+			<Flammability>0</Flammability>
+			<DeteriorationRate>0</DeteriorationRate>
+		</statBases>
+		<thingCategories>
+			<li>Manufactured</li>
+		</thingCategories>
+	</ThingDef>
+
+
+	<ThingDef ParentName="ResourceBase">
 		<defName>PileOfBooks</defName>
-		<label>Pile of Books</label>
+		<label>pile of books</label>
 		<description>A random assortment of books. Most are old and discarded classics, but occasionally a good quality book can be found.</description>
 		<graphicData>
 			<texPath>Things/Item/Resource/PileOfBooks</texPath>
@@ -275,11 +275,11 @@
 		<techLevel>Spacer</techLevel>
 		<canBeSpawningInventory>true</canBeSpawningInventory>		
 	</ThingDef>
-	
-	
+
+
 	<ThingDef ParentName="ResourceBase">
 		<defName>PaintingSupplies</defName>
-		<label>Painting Supplies</label>
+		<label>painting supplies</label>
 		<description>A large assortment of brushes and paints. Perfect for any aspiring artist.</description>
 		<graphicData>
 			<texPath>Things/Item/Resource/PaintingSupplies</texPath>
@@ -310,77 +310,77 @@
 			</categories>
 		</stuffProps>
 	</ThingDef>
-	
-	
-  <ThingDef ParentName="ResourceBase">
-    <defName>MineralSonarModule</defName>
-    <label>Mineral Sonar Module</label>
-    <description>This is a Mineral Sonar Module. When deployed on the field with some energy packs, it can scan the surrounding area for metallic objects or Hidden Deposits of Ores.</description>
-    <graphicData>
-      <graphicClass>Graphic_Single</graphicClass>
-      <texPath>Things/Item/Resource/MineralSonarModule</texPath>
-    </graphicData>
-    <soundInteract>Metal_Drop</soundInteract>
-    <soundDrop>Metal_Drop</soundDrop>
-	<tickerType>Rare</tickerType>
-    <statBases>
-      <DeteriorationRate>0</DeteriorationRate>
-      <MaxHitPoints>100</MaxHitPoints>
-      <Flammability>0.1</Flammability>
-      <MarketValue>300</MarketValue>
-    </statBases>
-    <thingCategories>
-      <li>ElectronicsCat</li>
-    </thingCategories>
-    <stackLimit>4</stackLimit>
-  </ThingDef>
-  
-  <ThingDef ParentName="ResourceVerbBase">
-    <defName>ThrumboHorn</defName>
-    <label>Thrumbo Horn</label>
-    <description>The horn from a previously living Thrumbo. It's razor-sharp, very hard and priceless in most markets. This is a true trophy.</description>
-    <graphicData>
-      <texPath>Things/Item/Special/ThrumboHorn</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <equippedAngleOffset>-20</equippedAngleOffset>
-    <statBases>
-      <MarketValue>900</MarketValue>
-      <MaxHitPoints>150</MaxHitPoints>
-      <Flammability>1.0</Flammability>
-      <DeteriorationRate>0.2</DeteriorationRate>
-      <MeleeWeapon_DamageAmount>15</MeleeWeapon_DamageAmount>
-      <MeleeWeapon_Cooldown>1.75</MeleeWeapon_Cooldown>
-    </statBases>
-    <techLevel>Neolithic</techLevel>
-    <resourceReadoutPriority>Middle</resourceReadoutPriority>
-    <stackLimit>10</stackLimit>
-    <verbs>
-      <li>
-        <verbClass>Verb_MeleeAttack</verbClass>
-        <hasStandardCommand>true</hasStandardCommand>
-        <meleeDamageDef>Scratch</meleeDamageDef>
-      </li>
-    </verbs>
-    <thingCategories>
-      <li>Items</li>
-    </thingCategories>
-    <tradeTags>
-      <li>Exotic</li>
-    </tradeTags>
-  </ThingDef>
 
-  
-  	<!-- mai items -->
-	
-  	<ThingDef ParentName="ResourceBase">
+
+	<ThingDef ParentName="ResourceBase">
+		<defName>MineralSonarModule</defName>
+		<label>mineral sonar module</label>
+		<description>This is a mineral sonar module. When deployed on the field with some energy packs, it can scan the surrounding area for metallic objects or hidden deposits of ores.</description>
+		<graphicData>
+			<graphicClass>Graphic_Single</graphicClass>
+			<texPath>Things/Item/Resource/MineralSonarModule</texPath>
+		</graphicData>
+		<soundInteract>Metal_Drop</soundInteract>
+		<soundDrop>Metal_Drop</soundDrop>
+		<tickerType>Rare</tickerType>
+		<statBases>
+			<DeteriorationRate>0</DeteriorationRate>
+			<MaxHitPoints>100</MaxHitPoints>
+			<Flammability>0.1</Flammability>
+			<MarketValue>300</MarketValue>
+		</statBases>
+		<thingCategories>
+			<li>ElectronicsCat</li>
+		</thingCategories>
+		<stackLimit>4</stackLimit>
+	</ThingDef>
+
+	<ThingDef ParentName="ResourceVerbBase">
+		<defName>ThrumboHorn</defName>
+		<label>thrumbo horn</label>
+		<description>The horn from a previously living thrumbo. It's razor-sharp, very hard and priceless in most markets. This is a true trophy.</description>
+		<graphicData>
+			<texPath>Things/Item/Special/ThrumboHorn</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<equippedAngleOffset>-20</equippedAngleOffset>
+		<statBases>
+			<MarketValue>900</MarketValue>
+			<MaxHitPoints>150</MaxHitPoints>
+			<Flammability>1.0</Flammability>
+			<DeteriorationRate>0.2</DeteriorationRate>
+			<MeleeWeapon_DamageAmount>15</MeleeWeapon_DamageAmount>
+			<MeleeWeapon_Cooldown>1.75</MeleeWeapon_Cooldown>
+		</statBases>
+		<techLevel>Neolithic</techLevel>
+		<resourceReadoutPriority>Middle</resourceReadoutPriority>
+		<stackLimit>10</stackLimit>
+		<verbs>
+			<li>
+				<verbClass>Verb_MeleeAttack</verbClass>
+				<hasStandardCommand>true</hasStandardCommand>
+				<meleeDamageDef>Scratch</meleeDamageDef>
+			</li>
+		</verbs>
+		<thingCategories>
+			<li>Items</li>
+		</thingCategories>
+		<tradeTags>
+			<li>Exotic</li>
+		</tradeTags>
+	</ThingDef>
+
+
+	<!-- mai items -->
+
+	<ThingDef ParentName="ResourceBase">
 		<defName>RobotParts</defName>
-		<label>Robot Parts</label>
-		<description>Robot Parts.</description>
-    <graphicData>
-		<texPath>Things/Item/Resource/RobotParts</texPath>
-		<graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
+		<label>robot parts</label>
+		<description>These parts could be used to create a robot.</description>
+		<graphicData>
+			<texPath>Things/Item/Resource/RobotParts</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
 		<stackLimit>25</stackLimit>
@@ -388,7 +388,7 @@
 		<statBases>
 			<MarketValue>354</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
-    		<Flammability>1</Flammability>
+			<Flammability>1</Flammability>
 		</statBases>
 		<thingCategories>
 			<li>ElectronicsCat</li>
@@ -399,27 +399,27 @@
 		</tradeTags>
 	</ThingDef>
 
-	
-  <ThingDef ParentName="ResourceBase">
-    <defName>RepairKit</defName>
-    <label>Repair kit</label>
-    <description>A kit of resources to repair an item.</description>
-    <graphicData>
-      <texPath>Things/Item/Resource/RepairKit</texPath>
-      <graphicClass>Graphic_Single</graphicClass>
-    </graphicData>
-    <soundInteract>Standard_Drop</soundInteract>
-    <soundDrop>Standard_Drop</soundDrop>
-    <stackLimit>75</stackLimit>
-    <thingCategories>
-      <li>Manufactured</li>
-    </thingCategories>
-    <statBases>
-      <MaxHitPoints>100</MaxHitPoints>
-      <MarketValue>30</MarketValue>
-      <Flammability>1.0</Flammability>
-      <DeteriorationRate>1</DeteriorationRate>
-    </statBases>
-  </ThingDef>
+
+	<ThingDef ParentName="ResourceBase">
+		<defName>RepairKit</defName>
+		<label>repair kit</label>
+		<description>A kit of resources to repair an item. Each kit can restore 5 hit points, and must be taken to a mending station in order to use them. An item can only be repaired fully, not partially, so be sure to stock enough kits.</description>
+		<graphicData>
+			<texPath>Things/Item/Resource/RepairKit</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<soundInteract>Standard_Drop</soundInteract>
+		<soundDrop>Standard_Drop</soundDrop>
+		<stackLimit>75</stackLimit>
+		<thingCategories>
+			<li>Manufactured</li>
+		</thingCategories>
+		<statBases>
+			<MaxHitPoints>100</MaxHitPoints>
+			<MarketValue>30</MarketValue>
+			<Flammability>1.0</Flammability>
+			<DeteriorationRate>1</DeteriorationRate>
+		</statBases>
+	</ThingDef>
 
 </Resources>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Fruits.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Fruits.xml
@@ -1,311 +1,318 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <ThingDefs>
 
-  <ThingDef Abstract="True" Name="FruitFoodRawBase" ParentName="OrganicProductBase" >
-    <ingestible>
-      <preferability>RawTasty</preferability>
-      <ingestEffect>EatVegetarian</ingestEffect>
-      <ingestSound>RawVegetable_Eat</ingestSound>
-       <foodType>VegetableOrFruit</foodType>
-	  <joyKind>Gluttonous</joyKind>
-    </ingestible>
-    <comps>
-      <li Class="CompProperties_FoodPoisoningChance" />
-    </comps>
-   </ThingDef>
+	<ThingDef Abstract="True" Name="FruitFoodRawBase" ParentName="OrganicProductBase" >
+		<ingestible>
+			<preferability>RawTasty</preferability>
+			<ingestEffect>EatVegetarian</ingestEffect>
+			<ingestSound>RawVegetable_Eat</ingestSound>
+			<foodType>VegetableOrFruit</foodType>
+			<joyKind>Gluttonous</joyKind>
+		</ingestible>
+		<comps>
+			<li Class="CompProperties_FoodPoisoningChance" />
+		</comps>
+	</ThingDef>
 
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>RawBerries</defName>
-    <label>Strawberries</label>
-    <description>Strawberries are small, red, soft fruits of a Strawberry Plant. They are good when eaten raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/Berries</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>2.1</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>14</daysToRotStart>
-      </li>
-    </comps>
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <joy>0.005</joy>
-      <nutrition>0.015</nutrition>
-    </ingestible>
-  </ThingDef>
+	<ThingDef Abstract="True" Name="SmallFruitFoodRawBase" ParentName="FruitFoodRawBase" >  
+		<statBases>
+			<Mass>0.3</Mass>
+			<Bulk>0.3</Bulk>
+		</statBases>
+	</ThingDef>
 
- 
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>RawAgave</defName>
-    <label>Agave Fruit</label>
-    <description>The Agave Fruit is edible stalks and flowers of a wild Agave Plant. Agave Plants are native to deserts. The fruits are foul when eaten raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/AgaveFruit</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>2.1</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <nutrition>0.015</nutrition>
-      <joy>0.002</joy>
-    </ingestible>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>25</daysToRotStart>
-      </li>
-    </comps>
-  </ThingDef>
-  
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>Rawapple</defName>
-    <label>Apples</label>
-    <description>Apples are a round, red fruit that grows on Apple Trees. Commonly used in cooking for deserts due to its sweet taste, it can also be brewed into Apple Cider. Delectable to eat even when raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/apple</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>6</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <nutrition>0.02</nutrition>
-      <joy>0.006</joy>
-    </ingestible>
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>4</daysToRotStart>
-      </li>
-    </comps>    
-  </ThingDef> 
+	<ThingDef ParentName="SmallFruitFoodRawBase">
+		<defName>RawBerries</defName>
+		<label>Strawberries</label>
+		<description>Strawberries are small, red, soft fruits of a Strawberry Plant. They are good when eaten raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/Berries</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.1</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>14</daysToRotStart>
+			</li>
+		</comps>
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<joy>0.005</joy>
+			<nutrition>0.015</nutrition>
+		</ingestible>
+	</ThingDef>
 
-  
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>Rawbanana</defName>
-    <label>Banana</label>
-    <description>A Banana is a long, soft, yellow, sweet fruit that grows on Banana Trees. Yummy to eat when raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/banana</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>8</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <nutrition>0.04</nutrition>
-      <joy>0.006</joy>
-    </ingestible>
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>4</daysToRotStart>
-      </li>
-    </comps>    
-  </ThingDef>
-  
-  
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>Rawgrape</defName>
-    <label>Grapes</label>
-    <description>Grapes are small, sweet, berry fruits that grow in clusters on Grape Vines. Tantalizing to eat even when raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/grape</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>6</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <nutrition>0.02</nutrition>
-      <joy>0.006</joy>
-    </ingestible>
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>4</daysToRotStart>
-      </li>
-    </comps>    
-  </ThingDef>
 
-  
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>Raworange</defName>
-    <label>Orange</label>
-    <description>Oranges are a sweet, citric fruit that grows on Orange Trees. A tough outer rind protects the soft pulpy flesh inside. Pleasant to eat when raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/orange</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>7</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <nutrition>0.02</nutrition>
-      <joy>0.006</joy>
-    </ingestible>
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>4</daysToRotStart>
-      </li>
-    </comps>    
-  </ThingDef>
-  
-  
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>Rawpeach</defName>
-    <label>Peach</label>
-    <description>Peaches are a soft, fuzzy, sweet fruit that grows on Peach Trees. They have a large, hard pit at the core of the fruit. Splendid to eat when raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/peach</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>7</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <nutrition>0.04</nutrition>
-      <joy>0.006</joy>
-    </ingestible>
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>4</daysToRotStart>
-      </li>
-    </comps>    
-  </ThingDef>
+	<ThingDef ParentName="SmallFruitFoodRawBase">
+		<defName>RawAgave</defName>
+		<label>Agave Fruit</label>
+		<description>The Agave Fruit is edible stalks and flowers of a wild Agave Plant. Agave Plants are native to deserts. The fruits are foul when eaten raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/AgaveFruit</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>2.1</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<nutrition>0.015</nutrition>
+			<joy>0.002</joy>
+		</ingestible>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>25</daysToRotStart>
+			</li>
+		</comps>
+	</ThingDef>
 
-  
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>Rawblueberry</defName>
-    <label>Blueberry</label>
-    <description>Blueberries are blue, tiny, round, berry fruits that grow on Blueberry Bushes. Often used in desserts, like Blueberry Pie. Lovely to eat when raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/blueberry</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>1.4</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <joy>0.004</joy>
-      <nutrition>0.015</nutrition>
-    </ingestible>
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>4</daysToRotStart>
-      </li>
-    </comps>    
-  </ThingDef>
-  
+	<ThingDef ParentName="FruitFoodRawBase">
+		<defName>Rawapple</defName>
+		<label>Apples</label>
+		<description>Apples are a round, red fruit that grows on Apple Trees. Commonly used in cooking for deserts due to its sweet taste, it can also be brewed into Apple Cider. Delectable to eat even when raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/apple</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>6</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<nutrition>0.02</nutrition>
+			<joy>0.006</joy>
+		</ingestible>
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+			</li>
+		</comps>    
+	</ThingDef> 
 
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>Rawgooseberry</defName>
-    <label>Gooseberry</label>
-    <description>Gooseberries are small, sweet, somewhat hairy fruits that grow on Gooseberry Vines. Okay to eat when raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/gooseberries</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>6</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <nutrition>0.02</nutrition>
-      <joy>0.006</joy>
-    </ingestible>
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>4</daysToRotStart>
-      </li>
-    </comps>    
-  </ThingDef> 
-  
 
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>Rawcloudberry</defName>
-    <label>Cloudberry</label>
-    <description>Cloudberries are small, amber colored, sweet, raspberry-like fruits that grow on Cloudberry Plants. Marevlous to eat when raw.</description>
-    <graphicData>
-      <texPath>Things/Fruits/cloudberries</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>6</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <nutrition>0.015</nutrition>
-      <joy>0.006</joy>
-    </ingestible>
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>4</daysToRotStart>
-      </li>
-    </comps>    
-  </ThingDef>
-  
-  <ThingDef ParentName="FruitFoodRawBase">
-    <defName>RawCoconut</defName>
-    <label>Coconut</label>
-    <description>Coconut.</description>
-    <graphicData>
-      <texPath>Things/Fruits/Coconut</texPath>
-    </graphicData>
-    <statBases>
-      <MarketValue>6.5</MarketValue>
-    </statBases>
-    <tickerType>Rare</tickerType>   
-    <comps>
-      <li Class="CompProperties_Rottable">
-        <daysToRotStart>14</daysToRotStart>
-      </li>
-    </comps>
-    <ingestible>
-      <foodType>VegetableOrFruit</foodType>
-      <joy>0.008</joy>
-      <nutrition>0.05</nutrition>
-    </ingestible>
-    <thingCategories>
-      <li>FruitFoodRaw</li>
-    </thingCategories>
-  </ThingDef>
+	<ThingDef ParentName="FruitFoodRawBase">
+		<defName>Rawbanana</defName>
+		<label>Banana</label>
+		<description>A Banana is a long, soft, yellow, sweet fruit that grows on Banana Trees. Yummy to eat when raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/banana</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>8</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<nutrition>0.04</nutrition>
+			<joy>0.006</joy>
+		</ingestible>
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+			</li>
+		</comps>    
+	</ThingDef>
+
+
+	<ThingDef ParentName="FruitFoodRawBase">
+		<defName>Rawgrape</defName>
+		<label>Grapes</label>
+		<description>Grapes are small, sweet, berry fruits that grow in clusters on Grape Vines. Tantalizing to eat even when raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/grape</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>6</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<nutrition>0.02</nutrition>
+			<joy>0.006</joy>
+		</ingestible>
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+			</li>
+		</comps>    
+	</ThingDef>
+
+
+	<ThingDef ParentName="FruitFoodRawBase">
+		<defName>Raworange</defName>
+		<label>Orange</label>
+		<description>Oranges are a sweet, citric fruit that grows on Orange Trees. A tough outer rind protects the soft pulpy flesh inside. Pleasant to eat when raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/orange</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>7</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<nutrition>0.02</nutrition>
+			<joy>0.006</joy>
+		</ingestible>
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+			</li>
+		</comps>    
+	</ThingDef>
+
+
+	<ThingDef ParentName="FruitFoodRawBase">
+		<defName>Rawpeach</defName>
+		<label>Peach</label>
+		<description>Peaches are a soft, fuzzy, sweet fruit that grows on Peach Trees. They have a large, hard pit at the core of the fruit. Splendid to eat when raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/peach</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>7</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<nutrition>0.04</nutrition>
+			<joy>0.006</joy>
+		</ingestible>
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+			</li>
+		</comps>    
+	</ThingDef>
+
+
+	<ThingDef ParentName="SmallFruitFoodRawBase">
+		<defName>Rawblueberry</defName>
+		<label>Blueberry</label>
+		<description>Blueberries are blue, tiny, round, berry fruits that grow on Blueberry Bushes. Often used in desserts, like Blueberry Pie. Lovely to eat when raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/blueberry</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>1.4</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<joy>0.004</joy>
+			<nutrition>0.015</nutrition>
+		</ingestible>
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+			</li>
+		</comps>    
+	</ThingDef>
+
+
+	<ThingDef ParentName="SmallFruitFoodRawBase">
+		<defName>Rawgooseberry</defName>
+		<label>Gooseberry</label>
+		<description>Gooseberries are small, sweet, somewhat hairy fruits that grow on Gooseberry Vines. Okay to eat when raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/gooseberries</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>6</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<nutrition>0.02</nutrition>
+			<joy>0.006</joy>
+		</ingestible>
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+			</li>
+		</comps>    
+	</ThingDef> 
+
+
+	<ThingDef ParentName="SmallFruitFoodRawBase">
+		<defName>Rawcloudberry</defName>
+		<label>Cloudberry</label>
+		<description>Cloudberries are small, amber colored, sweet, raspberry-like fruits that grow on Cloudberry Plants. Marevlous to eat when raw.</description>
+		<graphicData>
+			<texPath>Things/Fruits/cloudberries</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>6</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<nutrition>0.015</nutrition>
+			<joy>0.006</joy>
+		</ingestible>
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+			</li>
+		</comps>    
+	</ThingDef>
+
+	<ThingDef ParentName="FruitFoodRawBase">
+		<defName>RawCoconut</defName>
+		<label>Coconut</label>
+		<description>Coconut.</description>
+		<graphicData>
+			<texPath>Things/Fruits/Coconut</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>6.5</MarketValue>
+		</statBases>
+		<tickerType>Rare</tickerType>   
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>14</daysToRotStart>
+			</li>
+		</comps>
+		<ingestible>
+			<foodType>VegetableOrFruit</foodType>
+			<joy>0.008</joy>
+			<nutrition>0.05</nutrition>
+		</ingestible>
+		<thingCategories>
+			<li>FruitFoodRaw</li>
+		</thingCategories>
+	</ThingDef>
 
 </ThingDefs>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Wood.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Wood.xml
@@ -260,8 +260,8 @@
 
 	<ThingDef ParentName="ResourceBase">
 		<defName>Kindling</defName>
-		<label>kindling</label>
-		<description>Kindling is made from Wood Logs or Bamboo Logs. It can be used as fuel in the Steam Generator.</description>
+		<label>firewood</label>
+		<description>Firewood is either created by cutting logs, or salvaged from breaking down bushes. It can act as a fuel for various low-tech buildings, including the steam generator. It burns twice as long compared to unprocessed wood.</description>
 		<graphicData>
 			<texPath>Things/Item/Resource/Kindling</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -275,13 +275,13 @@
 			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>5</Flammability>
 			<MaxBurningTempCelsius>600</MaxBurningTempCelsius>
-			<BurnDurationHours>1</BurnDurationHours>
+			<BurnDurationHours>2</BurnDurationHours>
 		</statBases>
 		<thingCategories>
 			<li>FuelCat</li>
 		</thingCategories>
 		<stuffProps>
-			<stuffAdjective>kindling</stuffAdjective>
+			<stuffAdjective>wooden</stuffAdjective>
 			<categories>
 				<li>Kindlingstuff</li>
 			</categories>


### PR DESCRIPTION
Berries didn't have a bulk value set, and were much too high, so pawns couldn't grab enough. It was set to 0.3 because they have about 1/3rd the nutrition as other foods which are a bulk of 1.

This was through a new mini-abstract called SmallFruitFoodRawBase.