### PR TITLE
Update Buildings_Accessories.xml

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -1482,7 +1482,6 @@
 				<fuelFilter>
 					<thingDefs>
 						<li>Kindling</li>
-						<li>Charcoal</li>
 					</thingDefs>
 					<categories>
 						<li>Wooden</li>
@@ -1552,7 +1551,6 @@
 				<fuelFilter>
 					<thingDefs>
 						<li>Kindling</li>
-						<li>Charcoal</li>
 					</thingDefs>
 					<categories>
 						<li>Wooden</li>
@@ -1619,7 +1617,6 @@
 				<fuelFilter>
 					<thingDefs>
 						<li>Kindling</li>
-						<li>Charcoal</li>
 					</thingDefs>
 					<categories>
 						<li>Wooden</li>


### PR DESCRIPTION
removed <li>Charcoal</li> from neo lights as was allowing them to be filed with coal and charcoal wasting materal as they get no added bonus from them