### PR TITLE
Fixes and stuff

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
@@ -918,7 +918,7 @@
 						<li>Rawbean</li>
 					</thingDefs>
 				</filter>
-				<count>5.0</count>
+				<count>1.6</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
@@ -137,7 +137,6 @@
 		</stuffCategories>
 		<costStuffCount>120</costStuffCount>
 		<comps>
-			<li Class="CompProperties_Flickable"/>
 			<li Class="SK.CompProperties_HeatPusherExt">
 				<compClass>SK.CompHeatPusherExt</compClass>
 				<heatPerSecond>40</heatPerSecond>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
@@ -15,6 +15,9 @@
 		<comps>
 			<li Class="CompProperties_Forbiddable"/>
 		</comps>
+		<ingestible>
+			<chairSearchRadius>60</chairSearchRadius>
+    </ingestible>
 		<alwaysHaulable>true</alwaysHaulable>
 		<drawGUIOverlay>true</drawGUIOverlay>
 		<rotatable>false</rotatable>
@@ -65,6 +68,7 @@
       <foodType>Meal</foodType>
       <maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
       <optimalityOffset>16</optimalityOffset>
+			<chairSearchRadius>60</chairSearchRadius>
     </ingestible>
 		<thingCategories>
 			<li>FoodMeals</li>
@@ -109,6 +113,7 @@
       <foodType>Meal</foodType>
       <maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
       <optimalityOffset>16</optimalityOffset>
+			<chairSearchRadius>60</chairSearchRadius>
     </ingestible>
 		<thingCategories>
 			<li>SweetMeals</li>
@@ -144,6 +149,7 @@
       <foodType>Meal</foodType>
       <maxNumToIngestAtOnce>1</maxNumToIngestAtOnce>
       <optimalityOffset>16</optimalityOffset>
+			<chairSearchRadius>60</chairSearchRadius>
     </ingestible>
     </ThingDef>
 

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Canned.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Canned.xml
@@ -27,6 +27,7 @@
     <ingestible>
       <foodType>Meal</foodType>
       <optimalityOffset>16</optimalityOffset>
+			<chairSearchRadius>60</chairSearchRadius>
     </ingestible>
     <stackLimit>75</stackLimit>
   </ThingDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Synthetic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Synthetic.xml
@@ -69,6 +69,7 @@
 			<ingestEffect>EatMeat</ingestEffect>
 			<ingestSound>Meal_Eat</ingestSound>
 			<maxNumToIngestAtOnce>7</maxNumToIngestAtOnce>
+			<chairSearchRadius>60</chairSearchRadius>
 		</ingestible>
 		<stackLimit>75</stackLimit>
 	<thingCategories>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
@@ -338,7 +338,7 @@
     <description>Crawlers are small spider-like Mechanoids. While not particularly sturdy, their speed, size and numbers more than make up for it. A tiny plasma cutter at their front allows them to cut through metal like butter. Their favorite passtime is open surgery.</description>
     <statBases>
       <Mass>20</Mass>
-      <MoveSpeed>7.4</MoveSpeed>
+      <MoveSpeed>6.8</MoveSpeed>
       <ArmorRating_Blunt>0.08</ArmorRating_Blunt>
       <ArmorRating_Sharp>0.12</ArmorRating_Sharp>
       <ArmorRating_Electric>5</ArmorRating_Electric>
@@ -349,7 +349,7 @@
     <verbs>
       <li Class="CombatExtended.VerbPropertiesCE">
         <verbClass>CombatExtended.Verb_MeleeAttackCE</verbClass>
-        <defaultCooldownTime>1.2</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>LeftBlade</linkedBodyPartsGroup>
@@ -365,7 +365,7 @@
       </li>
       <li Class="CombatExtended.VerbPropertiesCE">
         <verbClass>CombatExtended.Verb_MeleeAttackCE</verbClass>
-        <defaultCooldownTime>1.2</defaultCooldownTime>
+        <defaultCooldownTime>1.3</defaultCooldownTime>
         <meleeDamageBaseAmount>14</meleeDamageBaseAmount>
         <meleeDamageDef>Cut</meleeDamageDef>
         <linkedBodyPartsGroup>RightBlade</linkedBodyPartsGroup>
@@ -421,7 +421,7 @@
     </butcherProducts>
     <modExtensions>
       <li Class="CombatExtended.RacePropertiesExtensionCE">
-        <bodyShape>Serpentine</bodyShape>
+        <bodyShape>QuadrupedLow</bodyShape>
       </li>
     </modExtensions>
   </Verse.ThingDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops.xml
@@ -28,6 +28,7 @@
     <ingestible>
       <preferability>DesperateOnly</preferability>
       <nutrition>0.05</nutrition>
+			<chairSearchRadius>60</chairSearchRadius>
     </ingestible>
     <socialPropernessMatters>true</socialPropernessMatters>
     <statBases>
@@ -44,6 +45,7 @@
       <nutrition>0.05</nutrition>
       <ingestEffect>EatVegetarian</ingestEffect>
       <ingestSound>RawVegetable_Eat</ingestSound>
+			<chairSearchRadius>60</chairSearchRadius>
     </ingestible>
 	<socialPropernessMatters>true</socialPropernessMatters>
 	<stuffProps>
@@ -73,6 +75,7 @@
       <foodType>Plant</foodType>
       <preferability>NeverForNutrition</preferability>
       <joyKind>Gluttonous</joyKind>
+			<chairSearchRadius>60</chairSearchRadius>
     </ingestible>
     <tickerType>Rare</tickerType>
   </ThingDef>
@@ -92,6 +95,7 @@
       <foodType>Plant</foodType>
       <preferability>NeverForNutrition</preferability>
       <joyKind>Gluttonous</joyKind>
+			<chairSearchRadius>60</chairSearchRadius>
     </ingestible>
     <tickerType>Rare</tickerType>
   </ThingDef>

--- a/Mods/Dubs Bad Hygiene/Defs/ThingDefs_Buildings/Buildings_Hygiene.xml
+++ b/Mods/Dubs Bad Hygiene/Defs/ThingDefs_Buildings/Buildings_Hygiene.xml
@@ -912,7 +912,6 @@
         <glowRadius>6</glowRadius>
         <glowColor>(217,112,33,0)</glowColor>
       </li>
-	        <li Class="CompProperties_Flickable"/>
 			<li Class="SK.CompProperties_HeatPusherExt">
 				<compClass>SK.CompHeatPusherExt</compClass>
 				<heatPerSecond>30</heatPerSecond>

--- a/Mods/RedistHeat/Defs/ThingDefs/Buildings_TempController.xml
+++ b/Mods/RedistHeat/Defs/ThingDefs/Buildings_TempController.xml
@@ -13,7 +13,7 @@
     </ThingDef>
 	<!-- Heater -->
 	<ThingDef ParentName="BuildingBase">
-        <defName>MPHeater</defName>
+        <defName>Heater</defName>
         <label>multi-purpose heater</label>
         <thingClass>RedistHeat.Building_Heater</thingClass>
         <graphicData>
@@ -46,7 +46,7 @@
 		<stuffCategories>
 			<li>Metallic</li>
 		</stuffCategories>
-		<costStuffCount>60</costStuffCount>
+		<costStuffCount>70</costStuffCount>
 		<costList>
 			<Component>6</Component>
 			<ElectronicComponents>2</ElectronicComponents>


### PR DESCRIPTION
update:
-reverted cropsbase change
-nerfed mechanoid crawlers speed/cd/body (serpentine body too low, unhitable).

-removed flickable from both non power grid stoves.
-fixed tofu recipe.
-renamed RH heater so it overrides the vanilla one.
-added chairsearchradius to cover all ingestible defs, removing the need for table diner patch.