### PR TITLE
Update Weapons_Melee_Midworld.xml

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Midworld.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Midworld.xml
@@ -200,7 +200,7 @@
   
   <Verse.ThingDef ParentName="WeaponIndustrialBase">
     <defName>MeleeWeapon_Cleaver</defName>
-    <label>Сleaver</label>
+    <label>cleaver</label>
     <description>Tool designed to separate meat from bones and casting menacing shadows through shower curtains.</description>
     <graphicData>
       <texPath>Things/Weapons/Melee/Cleaver</texPath>


### PR DESCRIPTION
cleaver label changed to <label>cleaver</label> due to <label>Cleaver</label> causing it to not show ingame. reason unknown but astorgerp shows the C in Cleaver as ??