### PR TITLE
Russian work type allignment for WorkTab

### DIFF
--- a/Mods/Core/Languages/Russian-SK/DefInjected/WorkTypeDef/WorkTypes.xml
+++ b/Mods/Core/Languages/Russian-SK/DefInjected/WorkTypeDef/WorkTypes.xml
@@ -13,7 +13,7 @@
 	<Cleaning.verb>Убрать</Cleaning.verb>
 	<Cleaning.description>Уборщики наводят порядок в домашней зоне и чистят снег.</Cleaning.description>
 
-	<Hauling.labelShort>Носильщик</Hauling.labelShort>
+	<Hauling.labelShort>Носить</Hauling.labelShort>
 	<Hauling.pawnLabel>Носильщик</Hauling.pawnLabel>
 	<Hauling.gerundLabel>Перенос</Hauling.gerundLabel>
 	<Hauling.verb>Перенести</Hauling.verb>
@@ -25,7 +25,7 @@
 	<Art.verb>Заниматься искусством</Art.verb>
 	<Art.description>Художники создают прекрасные произведения искусства.</Art.description>
 
-	<Crafting.labelShort>Ремесленник</Crafting.labelShort>
+	<Crafting.labelShort>Ремесло</Crafting.labelShort>
 	<Crafting.pawnLabel>Ремесленник</Crafting.pawnLabel>
 	<Crafting.gerundLabel>Ремесло</Crafting.gerundLabel>
 	<Crafting.verb>Изготовлять</Crafting.verb>
@@ -67,19 +67,19 @@
 	<Cooking.verb>Готовить</Cooking.verb>
 	<Cooking.description>Повара заполняют дозаторы паст и готовят пищу.</Cooking.description>
 
-	<Warden.labelShort>Надзиратель</Warden.labelShort>
+	<Warden.labelShort>Надзир</Warden.labelShort>
 	<Warden.pawnLabel>Надзиратель</Warden.pawnLabel>
 	<Warden.gerundLabel>Надсмотр</Warden.gerundLabel>
 	<Warden.verb>Смотрит</Warden.verb>
 	<Warden.description>В зависимости от вашего выбора, надзиратели навещают заключённых, общаются с ними, применяют силу или вербуют. Также они кормят заключённых и раненых гостей.</Warden.description>
 
-	<Handling.labelShort>Животновод</Handling.labelShort>
+	<Handling.labelShort>Животн</Handling.labelShort>
 	<Handling.pawnLabel>Животновод</Handling.pawnLabel>
 	<Handling.gerundLabel>Животноводство</Handling.gerundLabel>
 	<Handling.verb>Ухаживает</Handling.verb>
 	<Handling.description>Ухаживают за прирученными животными, приручают их, собирают приносимые животными ресурсы и расправляются с животными на убой.</Handling.description>
 
-	<Flicker.labelShort>Оператор</Flicker.labelShort>
+	<Flicker.labelShort>Опер</Flicker.labelShort>
 	<Flicker.pawnLabel>Оператор</Flicker.pawnLabel>
 	<Flicker.gerundLabel>Контроль</Flicker.gerundLabel>
 	<Flicker.verb>Оперировать</Flicker.verb>
@@ -115,7 +115,7 @@
 	<Tailoring.verb>Шить</Tailoring.verb>
 	<Tailoring.description>Шьёт различные виды одежды.</Tailoring.description>
 
-	<PatientBedRest.labelShort>Постельный режим</PatientBedRest.labelShort>
+	<PatientBedRest.labelShort>Отдых</PatientBedRest.labelShort>
 	<PatientBedRest.pawnLabel>Пациент</PatientBedRest.pawnLabel>
 	<PatientBedRest.gerundLabel>Отдыхает в постели</PatientBedRest.gerundLabel>
 	<PatientBedRest.verb>Лечиться</PatientBedRest.verb>


### PR DESCRIPTION
Just to make sure that they don't cross each other.

Для ская: В вокр табе названия друг на друга залезают, я их укоротил немного. 