### PR TITLE
Dining room furniture II techlevel update

### DIFF
--- a/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Furniture.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Furniture.xml
@@ -39,7 +39,7 @@
 			<label>Dining room furniture II</label>
 			<description>It opens the possibility of building dining chairs in the dining room for the comfort of your colonists.</description>
 			<baseCost>200</baseCost>
-			<techLevel>Neolithic</techLevel>
+			<techLevel>Medieval</techLevel>
 				<prerequisites>
 					<li>SK_DiningRoomI</li>
 				</prerequisites>


### PR DESCRIPTION
Dining room furniture I's tech level was at medieval. Changed DRF II from neolithic to medieval, as it's more logical that way.