### PR TITLE
Remove apparrel default from pallet and skip

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -459,7 +459,6 @@
 				<priority>Important</priority>
 				<filter>
 					<categories>
-						<li>Apparel</li>
 					</categories>
 				</filter>
 			</defaultStorageSettings>
@@ -539,7 +538,6 @@
 				<priority>Important</priority>
 				<filter>
 					<categories>
-						<li>Apparel</li>
 					</categories>
 				</filter>
 			</defaultStorageSettings>


### PR DESCRIPTION
Паллеты не позволяют хранить одежду, но она почему-то отмечена по умолчанию.
Из-за этого пропадали фильтры гнилое/свежее.