### PR TITLE
Moved Tinctures and antibiotics from Medicine category to Drugs

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_BodyParts/Items_BodyParts.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_BodyParts/Items_BodyParts.xml
@@ -109,7 +109,7 @@
 			<li Class="CompProperties_Forbiddable"/>
       </comps>
       <thingCategories>
-         <li>Medicine</li>
+         <li>BodyParts</li>
       </thingCategories>
       <pathCost>10</pathCost>
    </ThingDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Medical.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Medical.xml
@@ -102,7 +102,7 @@
     <defName>MedicalDrink</defName>
     <label>Antibiotics</label>
     <description>A concentrated extract of Healroot and some hops. Tastes awful but boosts the immune system.</description>
-    <thingClass>Medicine</thingClass>
+    <thingClass>ThingWithComps</thingClass>
 	<graphicData>
     <texPath>Things/Item/Drug/MedicalDrink</texPath>
     <graphicClass>Graphic_Single</graphicClass>
@@ -115,7 +115,7 @@
       <MarketValue>15</MarketValue>
     </statBases>
     <thingCategories>
-      <li>Medicine</li>
+      <li>Drugs</li>
     </thingCategories>
     <tickerType>Rare</tickerType>  
     <ingestible>
@@ -131,7 +131,6 @@
           <severity>0.25</severity>
         </li>
       </outcomeDoers>
-	  <tasteThought>MedicalDrink</tasteThought>
     </ingestible>
     <comps>
       <li Class="CompProperties_Drug">

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Mushrooms.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Mushrooms.xml
@@ -5,7 +5,7 @@
 		<defName>MushroomTincture</defName>
 		<label>mushroom tincture</label>
 		<description>A concentrated extract from mushrooms. A good, natural medicine source.</description>
-		<thingClass>Medicine</thingClass>
+		<thingClass>ThingWithComps</thingClass>
 		<graphicData>
 			<texPath>Things/Item/Meal/Tincture</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -23,7 +23,7 @@
 		</statBases>
 		<stackLimit>25</stackLimit>
 		<thingCategories>
-			<li>Medicine</li>
+			<li>Drugs</li>
 		</thingCategories>
 		<ingestible>
 			<foodType>Fluid, Processed</foodType>
@@ -56,7 +56,7 @@
 		<defName>HealrootTincture</defName>
 		<label>healroot tincture</label>
 		<description>A concentrated extract from healroot. A good, natural medicine source.</description>
-		<thingClass>Medicine</thingClass>
+		<thingClass>ThingWithComps</thingClass>
 		<graphicData>
 			<texPath>Things/Item/Meal/Tincture</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -74,7 +74,7 @@
 		</statBases>
 		<stackLimit>25</stackLimit>
 		<thingCategories>
-			<li>Medicine</li>
+			<li>Drugs</li>
 		</thingCategories>
 		<ingestible>
 			<foodType>Fluid, Processed</foodType>

--- a/Mods/Core_SK/Defs/ThoughtDefs/Thoughts_Memory_SK.xml
+++ b/Mods/Core_SK/Defs/ThoughtDefs/Thoughts_Memory_SK.xml
@@ -286,18 +286,4 @@
       </li>   	  
     </stages>
   </ThoughtDef>
-  
-    <ThoughtDef>
-    <defName>HadMedicalDrink</defName>
-    <durationDays>1</durationDays>
-    <stackLimit>5</stackLimit>
-    <stages>
-      <li>
-        <label>Feeling better</label>
-        <description>Wow, I feel much better!</description>
-        <baseMoodEffect>10</baseMoodEffect>
-      </li>
-    </stages>
-  </ThoughtDef>
-
 </Defs>


### PR DESCRIPTION
Moved Life support from Medicine category to BodyParts.
Pawns tried to use they in surgeries regardless of care policy. They have no defined MedicalPotency and not supposed to be meds.

Removed taste thought from antibiotics. It alredy added via hediff.

HadMedicalDrink used nowhere.