### PR TITLE
Fix double translated Hauling

### DIFF
--- a/Mods/AllowTool/Languages/Russian-SK/DefInjected/WorkTypeDefs/WorkTypes.xml
+++ b/Mods/AllowTool/Languages/Russian-SK/DefInjected/WorkTypeDefs/WorkTypes.xml
@@ -3,7 +3,6 @@
 	
 	<HaulingUrgent.labelShort>Носильщик+</HaulingUrgent.labelShort>
 	<HaulingUrgent.pawnLabel>срочный носильщик</HaulingUrgent.pawnLabel>
-	<HaulingUrgent.labelShort>Носильщик+</HaulingUrgent.labelShort>
 	<HaulingUrgent.gerundLabel>Срочный перенос</HaulingUrgent.gerundLabel>
 	<HaulingUrgent.description>Перенос высокого приоритета. Применяется к предметам помеченным инструментом "Срочный перенос".\nДобавлено модом Allow Tool.</HaulingUrgent.description>
 	<HaulingUrgent.verb>срочно перенести</HaulingUrgent.verb>


### PR DESCRIPTION
При запуске приложения в протокол фиксируется предупреждение:

    Duplicate def-linked translation key: HaulingUrgent.labelShort
    Verse.Log:Warning(String)
    Verse.DefInjectionPackage:HasError(FileInfo, String)
    Verse.DefInjectionPackage:TryAddInjection(FileInfo, String, String)
    Verse.DefInjectionPackage:AddDataFromFile(FileInfo)
    Verse.LoadedLanguage:LoadFromFile_DefInject(FileInfo, Type)
    Verse.LoadedLanguage:LoadData()
    Verse.LoadedLanguage:TryGetTextFromKey(String, String&)
    Verse.Translator:Translate(String)
    Verse.PlayDataLoader:DoPlayLoad()
    Verse.PlayDataLoader:LoadAllPlayData(Boolean)
    Verse.Root:<Start>m__1()
    Verse.LongEventHandler:RunEventFromAnotherThread(Action)
    Verse.LongEventHandler:<UpdateCurrentAsynchronousEvent>m__1()
