### PR TITLE
Add weapon smelt to fueled smithy

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -2422,6 +2422,9 @@
 		<placeWorkers>
 			<li>PlaceWorker_ShowFacilitiesConnections</li>
 		</placeWorkers>
+		<recipes>
+			<li>SmeltWeapon</li>
+		</recipes>
 		<researchPrerequisites>
 			<li>Smithing</li>
 		</researchPrerequisites>


### PR DESCRIPTION
Fueled smithy is a more advanced version of the craftsman table, but is missing the ability to smelt weapons that the less advanced version has. -Szara