### PR TITLE
fix missing hopper

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -719,6 +719,7 @@
 				</filter>
 			</defaultStorageSettings>
 		</building>
+		<designationCategory>Production</designationCategory>
 		<designationHotKey>Misc3</designationHotKey>
 		<researchPrerequisites>
 			<li>Electricity</li>


### PR DESCRIPTION
added the missing <designationCategory>Production</designationCategory> to hopper so shows on build menu