### PR TITLE
Changes to baked potatos for more realism.

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
@@ -907,7 +907,7 @@
 	<RecipeDef Name="BakePotato">
 		<defName>BakePotato</defName>
 		<label>bake potato</label>
-		<description>Prepares baked potatoes from raw potatoes. Produces 1.</description>
+		<description>Prepares baked potatoes from raw potatoes. Produces 4.</description>
 		<jobString>Baking potato.</jobString>
 		<workAmount>350</workAmount>
 		<workSpeedStat>CookSpeed</workSpeedStat>
@@ -926,7 +926,7 @@
 			</li>
 		</ingredients>
 		<products>
-			<BakedPotato>1</BakedPotato>
+			<BakedPotato>4</BakedPotato>
 		</products>
 		<fixedIngredientFilter>
 			<thingDefs>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
@@ -359,23 +359,24 @@
 	<ThingDef ParentName="MealBase">
 		<defName>BakedPotato</defName>
 		<label>Baked Potato</label>
-		<description>Baked Potato.</description>
+		<description>A baked Potato. At least it's not raw.</description>
 		<graphicData>
 			<texPath>Things/Item/Meal/Baked_Potato</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>5</MarketValue>
+			<MarketValue>1.5</MarketValue>
 			<WorkToMake>300</WorkToMake>
-			<Bulk>1.50</Bulk>
+			<Bulk>1.0</Bulk>
 			<Mass>0.3</Mass>
 		</statBases>
 		<stackLimit>75</stackLimit>
 		<ingestible>
 			<foodType>Meal, Processed</foodType>
 			<preferability>MealSimple</preferability>
-			<nutrition>0.30</nutrition>
+			<nutrition>0.07</nutrition>
+			<maxNumToIngestAtOnce>10</maxNumToIngestAtOnce>
 			<ingestEffect>EatVegetarian</ingestEffect>
 			<ingestSound>Meal_Eat</ingestSound>
 		</ingestible>


### PR DESCRIPTION
Makes it so that baking 4 potatos doesn't magically produce one big potato that's way less heavy/bulky than those 4 potatos combined with more nutrinional value than those 4 potatos combined. Nutritional value and bulk/mass changed accordingly. The 75 stack limit now makes sense. Fixes issue where pawns without loadouts would hoard baked potatos in large quantities (10 or more). Deals with an issue of pawns returning to base up to 9 times per day to eat one baked potato due to the poor nutrinional value of this meal.