### PR TITLE
Update BodyParts_Humanoid.xml

### DIFF
--- a/Mods/Extended Human Body Simulation/Patches/BodyParts_Humanoid.xml
+++ b/Mods/Extended Human Body Simulation/Patches/BodyParts_Humanoid.xml
@@ -1,4 +1,4 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+﻿<?xml version="1.1" encoding="utf-8" ?>
 <Patch>
 
 <Operation Class="PatchOperationSequence">
@@ -226,7 +226,35 @@
 			<spawnThingOnRemoved>Finger</spawnThingOnRemoved>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>*/BodyPartDef[defName="LeftLeg"]</xpath>
+		<value>
+			<spawnThingOnRemoved>Leg</spawnThingOnRemoved>
+		</value>
+	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>*/BodyPartDef[defName="LeftFoot"]</xpath>
+		<value>
+			<spawnThingOnRemoved>Foot</spawnThingOnRemoved>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>*/BodyPartDef[defName="RightLeg"]</xpath>
+		<value>
+			<spawnThingOnRemoved>Leg</spawnThingOnRemoved>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>*/BodyPartDef[defName="RightFoot"]</xpath>
+		<value>
+			<spawnThingOnRemoved>Foot</spawnThingOnRemoved>
+		</value>
+	</Operation>
+	
 	<Operation Class="PatchOperationAdd">
 		<xpath>*/BodyPartDef[defName="LeftFootLittleToe"]</xpath>
 		<value>


### PR DESCRIPTION
Bugfix/patch: Player pawns can now also harvest the legs and feet of humanoid pawns when using the Extended Human Body Simulation mod.