### PR TITLE
Initial insulation and stuff effect material multiplier

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel.xml
@@ -17,6 +17,9 @@
 			<Flammability>1.0</Flammability>
 			<DeteriorationRate>2</DeteriorationRate>
 			<SellPriceFactor>0.3</SellPriceFactor>
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<altitudeLayer>Item</altitudeLayer>
 		<alwaysHaulable>True</alwaysHaulable>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
@@ -26,7 +26,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>0.2</Bulk>
 			<WornBulk>0.1</WornBulk>
-			<EquipDelay>0.4</EquipDelay>
+			<EquipDelay>0.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.1</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<WorkSpeedGlobal>-0.03</WorkSpeedGlobal>
@@ -98,7 +101,10 @@
 			<Mass>0.25</Mass>
 			<Bulk>0.2</Bulk>
 			<WornBulk>0.1</WornBulk>
-			<EquipDelay>0.5</EquipDelay>
+			<EquipDelay>0.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -171,7 +177,10 @@
 			<Mass>0.25</Mass>
 			<Bulk>0.2</Bulk>
 			<WornBulk>0.1</WornBulk>
-			<EquipDelay>0.7</EquipDelay>
+			<EquipDelay>0.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -257,7 +266,10 @@
 			<Mass>0.25</Mass>
 			<Bulk>0.2</Bulk>
 			<WornBulk>0.1</WornBulk>
-			<EquipDelay>0.6</EquipDelay>
+			<EquipDelay>0.6</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -329,7 +341,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>0.2</Bulk>
 			<WornBulk>0.1</WornBulk>
-			<EquipDelay>0.3</EquipDelay>
+			<EquipDelay>0.3</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.006</MoveSpeed>
@@ -404,7 +419,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>0.2</Bulk>
 			<WornBulk>0.1</WornBulk>
-			<EquipDelay>0.3</EquipDelay>
+			<EquipDelay>0.3</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.005</MoveSpeed>
@@ -480,7 +498,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>0.2</Bulk>
 			<WornBulk>0.1</WornBulk>
-			<EquipDelay>0.4</EquipDelay>
+			<EquipDelay>0.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -560,7 +581,10 @@
 			<Mass>0.35</Mass>
 			<Bulk>0.3</Bulk>
 			<WornBulk>0.15</WornBulk>
-			<EquipDelay>0.7</EquipDelay>
+			<EquipDelay>0.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -637,7 +661,10 @@
 			<Mass>0.1</Mass>
 			<Bulk>0.15</Bulk>
 			<WornBulk>0.1</WornBulk>
-			<EquipDelay>0.6</EquipDelay>
+			<EquipDelay>0.6</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.005</MoveSpeed>
@@ -722,7 +749,10 @@
 			<Bulk>0.25</Bulk>
 			<Mass>0.3</Mass>
 			<WornBulk>0.15</WornBulk>
-			<EquipDelay>1.4</EquipDelay>
+			<EquipDelay>1.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.015</MoveSpeed>
@@ -821,7 +851,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>0.8</EquipDelay>
+			<EquipDelay>0.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Industrial.xml
@@ -30,7 +30,10 @@
 			<Mass>1</Mass>
 			<Bulk>15</Bulk>
 			<WornBulk>7</WornBulk>
-			<EquipDelay>3.8</EquipDelay>
+			<EquipDelay>3.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -126,7 +129,10 @@
 			<Mass>1</Mass>
 			<Bulk>14</Bulk>
 			<WornBulk>8</WornBulk>
-			<EquipDelay>2.7</EquipDelay>
+			<EquipDelay>2.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -204,7 +210,10 @@
 			<Mass>0.1</Mass>
 			<Bulk>7</Bulk>
 			<WornBulk>3</WornBulk>
-			<EquipDelay>2.6</EquipDelay>
+			<EquipDelay>2.6</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>8</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Medieval.xml
@@ -25,7 +25,10 @@
 			<Mass>1.5</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>2</EquipDelay>
+			<EquipDelay>2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -90,7 +93,10 @@
 			<Mass>1</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>2</EquipDelay>
+			<EquipDelay>2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -189,7 +195,10 @@
 			<Mass>0.8</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>1.8</EquipDelay>
+			<EquipDelay>1.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -268,7 +277,10 @@
 			<Mass>1.6</Mass>
 			<Bulk>13</Bulk>
 			<WornBulk>11</WornBulk>
-			<EquipDelay>4.7</EquipDelay>
+			<EquipDelay>4.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -345,7 +357,10 @@
 			<Mass>1.6</Mass>
 			<Bulk>13</Bulk>
 			<WornBulk>11</WornBulk>
-			<EquipDelay>1.9</EquipDelay>
+			<EquipDelay>1.9</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -421,7 +436,10 @@
 			<Mass>0.7</Mass>
 			<Bulk>11</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>2.7</EquipDelay>
+			<EquipDelay>2.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -519,7 +537,10 @@
 			<Mass>0.7</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>2.6</EquipDelay>
+			<EquipDelay>2.6</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -619,7 +640,10 @@
 			<Mass>0.6</Mass>
 			<Bulk>11</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>1.5</EquipDelay>
+			<EquipDelay>1.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Neolitic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Neolitic.xml
@@ -27,7 +27,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>0.4</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>1.6</EquipDelay>
+			<EquipDelay>1.6</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>8</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Spacer.xml
@@ -36,7 +36,10 @@
 			<Mass>15</Mass>
 			<Bulk>30</Bulk>
 			<WornBulk>15</WornBulk>
-			<EquipDelay>9</EquipDelay>
+			<EquipDelay>9</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -118,7 +121,10 @@
 			<Mass>2.5</Mass>
 			<Bulk>25</Bulk>
 			<WornBulk>15</WornBulk>
-			<EquipDelay>11</EquipDelay>
+			<EquipDelay>11</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.45</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.45</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.45</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>10</CarryWeight>
@@ -236,7 +242,10 @@
 			<Mass>3.5</Mass>
 			<Bulk>50</Bulk>
 			<WornBulk>20</WornBulk>
-			<EquipDelay>12</EquipDelay>
+			<EquipDelay>12</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.6</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.60</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.60</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>30</CarryWeight>
@@ -324,7 +333,10 @@
 			<Mass>2.5</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>15</WornBulk>
-			<EquipDelay>11</EquipDelay>
+			<EquipDelay>11</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>15</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
@@ -28,7 +28,10 @@
 			<Mass>0.8</Mass>
 			<Bulk>0.6</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>0.7</EquipDelay>
+			<EquipDelay>0.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>0.1</MoveSpeed>
@@ -84,7 +87,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>0.5</EquipDelay>
+			<EquipDelay>0.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>0.03</MoveSpeed>
@@ -144,7 +150,10 @@
 			<Mass>1</Mass>
 			<Bulk>1</Bulk>
 			<WornBulk>1</WornBulk>
-			<EquipDelay>1.2</EquipDelay>
+			<EquipDelay>1.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.07</MoveSpeed>
@@ -215,7 +224,10 @@
 			<Mass>1</Mass>
 			<Bulk>1</Bulk>
 			<WornBulk>1</WornBulk>
-			<EquipDelay>1.1</EquipDelay>
+			<EquipDelay>1.1</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.06</MoveSpeed>
@@ -274,7 +286,10 @@
 			<Mass>0.5</Mass>
 			<Bulk>1</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>0.8</EquipDelay>
+			<EquipDelay>0.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>0.02</MoveSpeed>
@@ -341,7 +356,10 @@
 			<Mass>0.7</Mass>
 			<Bulk>1</Bulk>
 			<WornBulk>1</WornBulk>
-			<EquipDelay>0.8</EquipDelay>
+			<EquipDelay>0.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -406,7 +424,10 @@
 			<Mass>0.4</Mass>
 			<Bulk>1</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>0.7</EquipDelay>
+			<EquipDelay>0.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>0.12</MoveSpeed>
@@ -467,7 +488,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>1</Bulk>
 			<WornBulk>2</WornBulk>
-			<EquipDelay>0.9</EquipDelay>
+			<EquipDelay>0.9</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>0.05</MoveSpeed>
@@ -529,7 +553,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>1</Bulk>
 			<WornBulk>2</WornBulk>
-			<EquipDelay>0.8</EquipDelay>
+			<EquipDelay>0.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>0.08</MoveSpeed>
@@ -597,7 +624,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>1</Bulk>
 			<WornBulk>2</WornBulk>
-			<EquipDelay>0.8</EquipDelay>
+			<EquipDelay>0.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>0.15</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Feral.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Feral.xml
@@ -26,7 +26,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.1</EquipDelay>
+			<EquipDelay>2.1</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -96,7 +99,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.1</EquipDelay>
+			<EquipDelay>2.1</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<SocialImpact>-0.2</SocialImpact>
@@ -165,7 +171,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>1.9</EquipDelay>
+			<EquipDelay>1.9</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<SocialImpact>-0.2</SocialImpact>
@@ -235,7 +244,10 @@
 			<Mass>1</Mass>
 			<Bulk>4</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.0</EquipDelay>
+			<EquipDelay>2.0</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.09</MoveSpeed>
@@ -284,7 +296,10 @@
 			<Mass>0.8</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.1</EquipDelay>
+			<EquipDelay>2.1</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>
@@ -350,7 +365,10 @@
 			<Mass>7</Mass>
 			<Bulk>13</Bulk>
 			<WornBulk>7</WornBulk>
-			<EquipDelay>5</EquipDelay>
+			<EquipDelay>5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>20</CarryBulk>
@@ -424,7 +442,10 @@
 			<Mass>7</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>10</WornBulk>
-			<EquipDelay>10</EquipDelay>
+			<EquipDelay>10</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -489,7 +510,10 @@
 			<Mass>7</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>10</WornBulk>
-			<EquipDelay>13</EquipDelay>
+			<EquipDelay>13</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Industrial.xml
@@ -32,7 +32,10 @@
 			<Mass>3.5</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>15</WornBulk>
-			<EquipDelay>12</EquipDelay>
+			<EquipDelay>12</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.6</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.6</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.6</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>15</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Medieval.xml
@@ -24,7 +24,10 @@
 			<Mass>4</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>10</EquipDelay>
+			<EquipDelay>10</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.25</MoveSpeed>
@@ -98,7 +101,10 @@
 			<Mass>5</Mass>
 			<Bulk>12</Bulk>
 			<WornBulk>7</WornBulk>
-			<EquipDelay>11</EquipDelay>
+			<EquipDelay>11</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.4</MoveSpeed>
@@ -174,7 +180,10 @@
 			<Mass>3</Mass>
 			<Bulk>5</Bulk>
 			<WornBulk>2</WornBulk>
-			<EquipDelay>11</EquipDelay>
+			<EquipDelay>11</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.1</MoveSpeed>
@@ -268,7 +277,10 @@
 			<Mass>6</Mass>
 			<Bulk>15</Bulk>
 			<WornBulk>7</WornBulk>
-			<EquipDelay>12</EquipDelay>
+			<EquipDelay>12</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.45</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.45</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.45</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>8</CarryBulk>
@@ -348,7 +360,10 @@
 			<Mass>9</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>11</WornBulk>
-			<EquipDelay>12</EquipDelay>
+			<EquipDelay>12</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.45</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.45</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.45</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -429,7 +444,10 @@
 			<Mass>12</Mass>
 			<Bulk>33</Bulk>
 			<WornBulk>17</WornBulk>
-			<EquipDelay>16</EquipDelay>
+			<EquipDelay>16</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.6</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.6</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.6</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -511,7 +529,10 @@
 			<Mass>12</Mass>
 			<Bulk>33</Bulk>
 			<WornBulk>17</WornBulk>
-			<EquipDelay>18</EquipDelay>
+			<EquipDelay>18</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.6</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.6</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.6</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>12</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Spacer.xml
@@ -36,7 +36,10 @@
 			<Mass>3.5</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>15</WornBulk>
-			<EquipDelay>14</EquipDelay>
+			<EquipDelay>14</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.6</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.6</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.6</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>40</CarryWeight>
@@ -133,7 +136,10 @@
 			<Mass>5</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>15</WornBulk>
-			<EquipDelay>13</EquipDelay>
+			<EquipDelay>13</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.9</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.9</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.9</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>40</CarryWeight>
@@ -220,7 +226,10 @@
 			<Mass>12</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>15</WornBulk>
-			<EquipDelay>14</EquipDelay>
+			<EquipDelay>14</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.9</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.9</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.9</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>50</CarryWeight>
@@ -311,7 +320,10 @@
 			<Mass>7</Mass>
 			<Bulk>60</Bulk>
 			<WornBulk>20</WornBulk>
-			<EquipDelay>15</EquipDelay>
+			<EquipDelay>15</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.9</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.9</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.9</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>40</CarryWeight>
@@ -415,7 +427,10 @@
 			<Mass>0.6</Mass>
 			<Bulk>30</Bulk>
 			<WornBulk>10</WornBulk>
-			<EquipDelay>10</EquipDelay>
+			<EquipDelay>10</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.5</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.5</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -505,7 +520,10 @@
 			<Mass>12</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>15</WornBulk>
-			<EquipDelay>18</EquipDelay>
+			<EquipDelay>18</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.9</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.9</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.9</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>60</CarryWeight>
@@ -603,7 +621,10 @@
 			<Mass>9</Mass>
 			<Bulk>20</Bulk>
 			<WornBulk>15</WornBulk>
-			<EquipDelay>18</EquipDelay>
+			<EquipDelay>18</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.9</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.9</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.9</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>50</CarryWeight>
@@ -699,7 +720,10 @@
 			<Mass>0.6</Mass>
 			<Bulk>30</Bulk>
 			<WornBulk>10</WornBulk>
-			<EquipDelay>14</EquipDelay>
+			<EquipDelay>14</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.6</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.6</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.6</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Gloves.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Gloves.xml
@@ -32,6 +32,9 @@
 			<Bulk>0.7</Bulk>
 			<WornBulk>0.2</WornBulk>
 			<EquipDelay>0.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<WorkSpeedGlobal>0.05</WorkSpeedGlobal>
@@ -96,6 +99,9 @@
 			<Bulk>1</Bulk>
 			<WornBulk>0.4</WornBulk>
 			<EquipDelay>0.5</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<WorkSpeedGlobal>0.12</WorkSpeedGlobal>
@@ -159,6 +165,9 @@
 			<Bulk>0.5</Bulk>
 			<WornBulk>0.5</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>
@@ -219,6 +228,9 @@
 			<Bulk>0.5</Bulk>
 			<WornBulk>0.5</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.05</MoveSpeed>
@@ -298,6 +310,9 @@
 			<Bulk>0.5</Bulk>
 			<WornBulk>0.5</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -365,6 +380,9 @@
 			<Bulk>0.2</Bulk>
 			<WornBulk>0.2</WornBulk>
 			<EquipDelay>0.5</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<WorkSpeedGlobal>0.07</WorkSpeedGlobal>
@@ -431,6 +449,9 @@
 			<Bulk>0.25</Bulk>
 			<WornBulk>0.1</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -492,6 +513,9 @@
 			<Bulk>0.3</Bulk>
 			<WornBulk>0.1</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -561,6 +585,9 @@
 			<Bulk>0.5</Bulk>
 			<WornBulk>0.5</WornBulk>
 			<EquipDelay>0.5</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -633,6 +660,9 @@
 			<Bulk>1</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -701,6 +731,9 @@
 			<Bulk>0.7</Bulk>
 			<WornBulk>0.7</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -768,6 +801,9 @@
 			<Bulk>0.5</Bulk>
 			<WornBulk>0.5</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -838,6 +874,9 @@
 			<Bulk>1</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -907,6 +946,9 @@
 			<Bulk>1</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -987,6 +1029,9 @@
 			<Bulk>0.7</Bulk>
 			<WornBulk>0.7</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_HellEffect.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_HellEffect.xml
@@ -35,6 +35,9 @@
 			<Bulk>23</Bulk>
 			<WornBulk>17</WornBulk>
 			<EquipDelay>14</EquipDelay>
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>40</CarryWeight>
@@ -131,6 +134,9 @@
 			<Bulk>50</Bulk>
 			<WornBulk>18</WornBulk>
 			<EquipDelay>14</EquipDelay>
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryWeight>40</CarryWeight>
@@ -212,6 +218,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.2</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.2</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.2</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.18</MoveSpeed>
@@ -285,6 +294,9 @@
 			<Bulk>35</Bulk>
 			<WornBulk>15</WornBulk>
 			<EquipDelay>14</EquipDelay>
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>15</CarryBulk>
@@ -354,6 +366,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -417,6 +432,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.1</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -495,6 +513,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -577,6 +598,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Industrial.xml
@@ -32,6 +32,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.05</MoveSpeed>
@@ -104,6 +107,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -178,6 +184,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>
@@ -251,6 +260,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -323,6 +335,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>
@@ -395,6 +410,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.1</MoveSpeed>
@@ -467,6 +485,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Medieval.xml
@@ -29,6 +29,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.1</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -94,6 +97,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.3</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.05</MoveSpeed>
@@ -157,6 +163,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.10</MoveSpeed>
@@ -219,6 +228,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.5</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.12</MoveSpeed>
@@ -277,6 +289,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.14</MoveSpeed>
@@ -349,6 +364,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>3.0</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.14</MoveSpeed>
@@ -407,6 +425,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>3.0</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.14</MoveSpeed>
@@ -465,6 +486,9 @@
 			<Bulk>5</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.1</MoveSpeed>
@@ -532,6 +556,9 @@
 			<Bulk>5</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.1</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Neolitic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Neolitic.xml
@@ -27,6 +27,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -100,6 +103,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>
@@ -173,6 +179,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Outlander.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Outlander.xml
@@ -33,6 +33,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Spacer.xml
@@ -34,6 +34,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.22</MoveSpeed>
@@ -124,6 +127,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.18</MoveSpeed>
@@ -211,6 +217,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.05</MoveSpeed>
@@ -290,6 +299,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.1</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.1</MoveSpeed>
@@ -369,6 +381,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.14</MoveSpeed>
@@ -453,6 +468,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.15</MoveSpeed>
@@ -527,6 +545,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.5</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.2</MoveSpeed>
@@ -607,6 +628,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.21</MoveSpeed>
@@ -690,6 +714,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>1.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.07</MoveSpeed>
@@ -794,6 +821,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.3</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.2</MoveSpeed>
@@ -872,6 +902,9 @@
 			<Bulk>4</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>2.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.18</MoveSpeed>
@@ -951,6 +984,9 @@
 			<Bulk>4</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>2.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.15</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Industrial.xml
@@ -33,6 +33,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.14</MoveSpeed>
@@ -93,6 +96,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.1</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<WorkSpeedGlobal>-0.04</WorkSpeedGlobal>
@@ -151,6 +157,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.12</MoveSpeed>
@@ -209,6 +218,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.3</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.07</MoveSpeed>
@@ -278,6 +290,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.1</MoveSpeed>
@@ -339,6 +354,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.4</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.11</MoveSpeed>
@@ -404,6 +422,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.3</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.11</MoveSpeed>
@@ -466,6 +487,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.07</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Industrial_Two.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Industrial_Two.xml
@@ -32,6 +32,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.5</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -97,6 +100,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.08</MoveSpeed>
@@ -170,6 +176,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -243,6 +252,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<SocialImpact>0.08</SocialImpact>
@@ -317,6 +329,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -390,6 +405,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.4</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -453,6 +471,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.14</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Medieval.xml
@@ -30,6 +30,9 @@
 			<Bulk>5</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.15</MoveSpeed>
@@ -110,6 +113,9 @@
 			<Bulk>5</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.4</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.16</MoveSpeed>
@@ -183,6 +189,9 @@
 			<Bulk>5</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.07</MoveSpeed>
@@ -251,6 +260,9 @@
 			<Bulk>5</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -321,6 +333,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.5</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Neolitic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Neolitic.xml
@@ -29,6 +29,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -102,6 +105,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -171,6 +177,9 @@
 			<Bulk>4</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.1</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -242,6 +251,9 @@
 			<Bulk>4</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.1</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.05</MoveSpeed>
@@ -314,6 +326,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.005</MoveSpeed>
@@ -387,6 +402,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -452,6 +470,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Outlander.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Outlander.xml
@@ -29,6 +29,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -96,6 +99,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -162,6 +168,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -234,6 +243,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -308,6 +320,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<SocialImpact>0.07</SocialImpact>
@@ -381,6 +396,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -455,6 +473,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.1</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -527,6 +548,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -596,6 +620,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -663,6 +690,9 @@
 			<Bulk>2</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.032</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Outlander_Two.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Outlander_Two.xml
@@ -31,6 +31,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -97,6 +100,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.3</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -168,6 +174,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -238,6 +247,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>
@@ -308,6 +320,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -370,6 +385,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -441,6 +459,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -513,6 +534,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.01</MoveSpeed>
@@ -586,6 +610,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -657,6 +684,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -727,6 +757,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -795,6 +828,9 @@
 			<Bulk>2</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Spacer.xml
@@ -38,6 +38,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.3</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.12</MoveSpeed>
@@ -119,6 +122,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.3</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.15</MoveSpeed>
@@ -199,6 +205,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.4</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.05</MoveSpeed>
@@ -271,6 +280,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.5</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>
@@ -358,6 +370,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>1.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>
@@ -435,6 +450,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.08</MoveSpeed>
@@ -504,6 +522,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>0.9</EquipDelay>
+			<StuffEffectMultiplierArmor>0.10</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.03</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Kits.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Kits.xml
@@ -16,7 +16,10 @@
 			<Mass>12</Mass>
 			<Bulk>8</Bulk>
 			<WornBulk>12</WornBulk>
-			<EquipDelay>16</EquipDelay>
+			<EquipDelay>16</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.1</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>0.50</MoveSpeed>
@@ -72,7 +75,10 @@
 			<Mass>2</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>8</WornBulk>
-			<EquipDelay>4.8</EquipDelay>
+			<EquipDelay>4.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.1</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>30</CarryBulk>
@@ -153,7 +159,10 @@
 			<WorkToMake>5000</WorkToMake>
 			<Mass>1</Mass>
 			<Bulk>3</Bulk>
-			<EquipDelay>1.5</EquipDelay>
+			<EquipDelay>1.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.1</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>30</CarryBulk>
@@ -233,7 +242,10 @@
 			<WorkToMake>3000</WorkToMake>
 			<Mass>1</Mass>
 			<Bulk>3</Bulk>
-			<EquipDelay>1.3</EquipDelay>
+			<EquipDelay>1.3</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.1</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>15</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
@@ -28,7 +28,10 @@
 			<Mass>0.5</Mass>
 			<Bulk>0.7</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.5</EquipDelay>
+			<EquipDelay>2.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -89,7 +92,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.2</EquipDelay>
+			<EquipDelay>2.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.2</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.2</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.2</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -147,7 +153,10 @@
 			<Mass>0.35</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.3</EquipDelay>
+			<EquipDelay>2.3</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -206,7 +215,10 @@
 			<Mass>0.35</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.4</EquipDelay>
+			<EquipDelay>2.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -269,7 +281,10 @@
 			<Mass>0.4</Mass>
 			<Bulk>0.6</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.8</EquipDelay>
+			<EquipDelay>2.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -331,7 +346,10 @@
 			<Mass>0.6</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.5</EquipDelay>
+			<EquipDelay>2.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -416,7 +434,10 @@
 			<Mass>0.6</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.7</EquipDelay>
+			<EquipDelay>2.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -479,7 +500,10 @@
 			<Mass>0.9</Mass>
 			<Bulk>1</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>3.5</EquipDelay>
+			<EquipDelay>3.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -544,7 +568,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>0.3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.2</EquipDelay>
+			<EquipDelay>2.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -615,7 +642,10 @@
 			<Mass>0.2</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.9</EquipDelay>
+			<EquipDelay>2.9</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -678,7 +708,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>0.3</Bulk>
 			<WornBulk>0.3</WornBulk>
-			<EquipDelay>2.4</EquipDelay>
+			<EquipDelay>2.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs_Hightech.xml
@@ -31,7 +31,10 @@
 			<Mass>0.4</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.5</EquipDelay>
+			<EquipDelay>2.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -97,7 +100,10 @@
 			<Mass>0.7</Mass>
 			<Bulk>0.8</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.7</EquipDelay>
+			<EquipDelay>2.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>5</CarryBulk>
@@ -166,7 +172,10 @@
 			<Mass>0.8</Mass>
 			<Bulk>0.7</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.8</EquipDelay>
+			<EquipDelay>2.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>7</CarryBulk>
@@ -246,7 +255,10 @@
 			<Mass>1</Mass>
 			<Bulk>0.9</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.7</EquipDelay>
+			<EquipDelay>2.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.4</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.4</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>8</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_NaniteShieldModulator.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_NaniteShieldModulator.xml
@@ -49,7 +49,10 @@
 			<Mass>1</Mass>
 			<Bulk>2</Bulk>
 			<WornBulk>1</WornBulk>
-			<EquipDelay>0</EquipDelay>
+			<EquipDelay>0</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.1</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<generateCommonality>1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_New.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_New.xml
@@ -31,7 +31,10 @@
 			<Mass>2</Mass>
 			<Bulk>15</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>5</EquipDelay>
+			<EquipDelay>5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>13</CarryBulk>
@@ -110,7 +113,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>1</WornBulk>
-			<EquipDelay>6</EquipDelay>			
+			<EquipDelay>6</EquipDelay>		
+			<StuffEffectMultiplierArmor>0.2</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.20</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.20</StuffEffectMultiplierInsulation_Heat>			
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -183,7 +189,10 @@
 			<Mass>1.6</Mass>
 			<Bulk>13</Bulk>
 			<WornBulk>11</WornBulk>
-			<EquipDelay>9</EquipDelay>
+			<EquipDelay>9</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>12</CarryBulk>
@@ -262,7 +271,10 @@
 			<Mass>1</Mass>
 			<Bulk>7</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>1.8</EquipDelay>
+			<EquipDelay>1.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>25</CarryBulk>
@@ -337,7 +349,10 @@
 			<ArmorRating_Blunt>0.02</ArmorRating_Blunt>
 			<Mass>0.3</Mass>
 			<Bulk>0.5</Bulk>
-			<EquipDelay>4.8</EquipDelay>
+			<EquipDelay>4.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.2</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.20</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.20</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -402,7 +417,10 @@
 			<ArmorRating_Blunt>0.02</ArmorRating_Blunt>
 			<Mass>0.3</Mass>
 			<Bulk>0.5</Bulk>
-			<EquipDelay>4.9</EquipDelay>
+			<EquipDelay>4.9</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.2</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.20</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.20</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -469,7 +487,10 @@
 			<Mass>6</Mass>
 			<Bulk>12</Bulk>
 			<WornBulk>6</WornBulk> 
-			<EquipDelay>4.4</EquipDelay>
+			<EquipDelay>4.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>50</CarryBulk>
@@ -535,7 +556,10 @@
 			<Mass>1.6</Mass>
 			<Bulk>8</Bulk>
 			<WornBulk>6</WornBulk>
-			<EquipDelay>2.2</EquipDelay>
+			<EquipDelay>2.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>12</CarryBulk>
@@ -606,7 +630,10 @@
 			<Mass>1</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.2</EquipDelay>
+			<EquipDelay>2.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.2</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.20</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.20</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.15</MoveSpeed>
@@ -676,7 +703,10 @@
 			<Mass>0.7</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>1.2</EquipDelay>
+			<EquipDelay>1.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.003</MoveSpeed>
@@ -750,7 +780,10 @@
 			<Mass>0.4</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>0.8</EquipDelay>
+			<EquipDelay>0.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>
@@ -820,7 +853,10 @@
 			<Mass>0.4</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>0.8</EquipDelay>
+			<EquipDelay>0.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.02</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_PersonalShieldw.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_PersonalShieldw.xml
@@ -52,7 +52,10 @@
 			<Mass>3</Mass>
 			<Bulk>4</Bulk>
 			<WornBulk>2</WornBulk>
-			<EquipDelay>1.7</EquipDelay>
+			<EquipDelay>1.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<stuffCategories>
 			<li>Metallic</li>
@@ -130,7 +133,10 @@
 			<Bulk>3</Bulk>
 			<WornBulk>1</WornBulk>
 			<SmokepopBeltRadius>4</SmokepopBeltRadius>
-			<EquipDelay>1.8</EquipDelay>
+			<EquipDelay>1.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<generateAllowChance>0.15</generateAllowChance>
 		<stuffCategories>
@@ -214,7 +220,10 @@
 			<Mass>3</Mass>
 			<Bulk>4</Bulk>
 			<WornBulk>2</WornBulk>
-			<EquipDelay>1.7</EquipDelay>
+			<EquipDelay>1.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<generateCommonality>1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Industrial.xml
@@ -31,7 +31,10 @@
 			<Mass>2</Mass>
 			<Bulk>5</Bulk>
 			<WornBulk>2</WornBulk>
-			<EquipDelay>4.8</EquipDelay>
+			<EquipDelay>4.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>7</CarryBulk>
@@ -89,7 +92,10 @@
 			<Mass>5</Mass>
 			<Bulk>13</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>4.9</EquipDelay>
+			<EquipDelay>4.9</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Medieval.xml
@@ -28,7 +28,10 @@
 			<Mass>0.7</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>2.3</EquipDelay>
+			<EquipDelay>2.3</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -90,7 +93,10 @@
 			<Mass>3</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>4.7</EquipDelay>
+			<EquipDelay>4.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -148,7 +154,10 @@
 			<Mass>2</Mass>
 			<Bulk>7</Bulk>
 			<WornBulk>3</WornBulk>
-			<EquipDelay>4.3</EquipDelay>
+			<EquipDelay>4.3</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>8</CarryBulk>
@@ -206,7 +215,10 @@
 			<Mass>2</Mass>
 			<Bulk>7</Bulk>
 			<WornBulk>3</WornBulk>
-			<EquipDelay>4.6</EquipDelay>
+			<EquipDelay>4.6</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>6</CarryBulk>
@@ -267,7 +279,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>2.6</EquipDelay>
+			<EquipDelay>2.6</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -343,7 +358,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>2.7</EquipDelay>
+			<EquipDelay>2.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -418,7 +436,10 @@
 			<Mass>0.5</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>2.5</EquipDelay>
+			<EquipDelay>2.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -531,7 +552,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>2.5</EquipDelay>
+			<EquipDelay>2.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -596,7 +620,10 @@
 			<Mass>0.1</Mass>
 			<Bulk>13</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>3.5</EquipDelay>
+			<EquipDelay>3.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -666,7 +693,10 @@
 			<Mass>0.5</Mass>
 			<Bulk>7</Bulk>
 			<WornBulk>3</WornBulk>
-			<EquipDelay>4.2</EquipDelay>
+			<EquipDelay>4.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>8</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
@@ -31,7 +31,10 @@
 			<Mass>2</Mass>
 			<Bulk>15</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>4.3</EquipDelay>
+			<EquipDelay>4.3</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>13</CarryBulk>
@@ -115,7 +118,10 @@
 			<Mass>1</Mass>
 			<Bulk>11</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>4.2</EquipDelay>
+			<EquipDelay>4.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>13</CarryBulk>
@@ -194,7 +200,10 @@
 			<Mass>2</Mass>
 			<Bulk>12</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>4.5</EquipDelay>
+			<EquipDelay>4.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -290,7 +299,10 @@
 			<Mass>5</Mass>
 			<Bulk>13</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>4.6</EquipDelay>
+			<EquipDelay>4.6</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -367,7 +379,10 @@
 			<Mass>2</Mass>
 			<Bulk>13</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>4.4</EquipDelay>
+			<EquipDelay>4.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Shields.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Shields.xml
@@ -60,7 +60,10 @@
 			<WornBulk>1</WornBulk>
 			<ArmorRating_Blunt>0.13</ArmorRating_Blunt>
 			<ArmorRating_Sharp>0.17</ArmorRating_Sharp>
-			<EquipDelay>1.2</EquipDelay>
+			<EquipDelay>1.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<stuffCategories>
 			<li>Leathery</li>
@@ -124,7 +127,10 @@
 			<WornBulk>2</WornBulk>
 			<ArmorRating_Blunt>0.15</ArmorRating_Blunt>
 			<ArmorRating_Sharp>0.25</ArmorRating_Sharp>
-			<EquipDelay>1.1</EquipDelay>
+			<EquipDelay>1.1</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<tradeability>Sellable</tradeability>
 		<equippedStatOffsets>
@@ -181,7 +187,10 @@
 			<WornBulk>2</WornBulk>
 			<ArmorRating_Blunt>0.2</ArmorRating_Blunt>
 			<ArmorRating_Sharp>0.24</ArmorRating_Sharp>
-			<EquipDelay>1.0</EquipDelay>
+			<EquipDelay>1.0</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.18</MoveSpeed>
@@ -247,7 +256,10 @@
 			<WornBulk>4</WornBulk>
 			<ArmorRating_Blunt>0.29</ArmorRating_Blunt>
 			<ArmorRating_Sharp>0.32</ArmorRating_Sharp>
-			<EquipDelay>1.4</EquipDelay>
+			<EquipDelay>1.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.35</MoveSpeed>
@@ -320,7 +332,10 @@
 			<Mass>8</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>6</WornBulk>
-			<EquipDelay>2.2</EquipDelay>
+			<EquipDelay>2.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.2</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_SlaveOutfit.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_SlaveOutfit.xml
@@ -28,7 +28,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>2</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>0.9</EquipDelay>
+			<EquipDelay>0.9</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.1</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.10</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.10</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.012</MoveSpeed>
@@ -94,7 +97,10 @@
 			<Mass>0.3</Mass>
 			<Bulk>0.4</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>2.4</EquipDelay>
+			<EquipDelay>2.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>6</CarryBulk>
@@ -156,7 +162,10 @@
 			<Mass>0.4</Mass>
 			<Bulk>0.5</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>4.4</EquipDelay>
+			<EquipDelay>4.4</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>8</CarryBulk>
@@ -217,7 +226,10 @@
 			<Mass>1.5</Mass>
 			<Bulk>5</Bulk>
 			<WornBulk>1</WornBulk>
-			<EquipDelay>8.2</EquipDelay>
+			<EquipDelay>8.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
@@ -301,7 +313,10 @@
 			<Mass>0.6</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>7.2</EquipDelay>
+			<EquipDelay>7.2</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>12</CarryBulk>
@@ -370,7 +385,10 @@
 			<Mass>1</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>6.8</EquipDelay>
+			<EquipDelay>6.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>12</CarryBulk>
@@ -444,7 +462,10 @@
 			<Mass>1</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>6.5</EquipDelay>
+			<EquipDelay>6.5</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>13</CarryBulk>
@@ -505,7 +526,10 @@
 			<Mass>1</Mass>
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
-			<EquipDelay>8.8</EquipDelay>
+			<EquipDelay>8.8</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.4</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.40</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.40</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>13</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Special.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Special.xml
@@ -29,7 +29,10 @@
 			<Mass>1</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
-			<EquipDelay>1.7</EquipDelay>
+			<EquipDelay>1.7</EquipDelay>			
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.08</MoveSpeed>
@@ -90,6 +93,9 @@
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.15</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.15</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.15</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<MoveSpeed>-0.12</MoveSpeed>
@@ -154,6 +160,9 @@
 			<Bulk>1.5</Bulk>
 			<WornBulk>1.5</WornBulk>
 			<EquipDelay>16</EquipDelay>
+			<StuffEffectMultiplierArmor>0.5</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.5</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.5</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>15</CarryBulk>
@@ -223,6 +232,9 @@
 			<Bulk>7</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>10</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>15</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
@@ -28,6 +28,9 @@
 			<Bulk>10</Bulk>
 			<WornBulk>5</WornBulk>
 			<EquipDelay>4</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>12</CarryBulk>
@@ -105,6 +108,9 @@
 			<Bulk>10</Bulk>
 			<WornBulk>6</WornBulk>
 			<EquipDelay>4.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>14</CarryBulk>
@@ -171,6 +177,9 @@
 			<Bulk>12</Bulk>
 			<WornBulk>6</WornBulk>
 			<EquipDelay>5.6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>15</CarryBulk>
@@ -228,6 +237,9 @@
 			<Bulk>8</Bulk>
 			<WornBulk>3</WornBulk>
 			<EquipDelay>5.5</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>12</CarryBulk>
@@ -289,6 +301,9 @@
 			<Bulk>8</Bulk>
 			<WornBulk>3</WornBulk>
 			<EquipDelay>4.7</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>12</CarryBulk>
@@ -349,6 +364,9 @@
 			<Bulk>12</Bulk>
 			<WornBulk>4</WornBulk>
 			<EquipDelay>6.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>6</CarryBulk>
@@ -426,6 +444,9 @@
 			<Bulk>10</Bulk>
 			<WornBulk>3</WornBulk>
 			<EquipDelay>5.2</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>25</CarryBulk>
@@ -496,6 +517,9 @@
 			<Bulk>12</Bulk>
 			<WornBulk>4</WornBulk>
 			<EquipDelay>5.8</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>28</CarryBulk>
@@ -588,6 +612,9 @@
 			<Bulk>12</Bulk>
 			<WornBulk>4</WornBulk>
 			<EquipDelay>6</EquipDelay>
+			<StuffEffectMultiplierArmor>0.25</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
+			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>16</CarryBulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Cloth.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Cloth.xml
@@ -20,8 +20,8 @@
 			<StuffPower_Armor_Blunt>1.3</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.1</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.04</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.95</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>9</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>7</StuffPower_Insulation_Heat>
 			<Mass>0.01</Mass>
 			<Bulk>0.01</Bulk>
 		</statBases>
@@ -89,8 +89,8 @@
 			<StuffPower_Armor_Blunt>1.1</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.15</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.4</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.6</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>14</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>6</StuffPower_Insulation_Heat>
 			<Mass>0.02</Mass>
 			<Bulk>0.02</Bulk>
 		</statBases>
@@ -136,8 +136,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.0</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.38</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.62</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>13.8</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>6.2</StuffPower_Insulation_Heat>
 			<Mass>0.02</Mass>
 			<Bulk>0.02</Bulk>
 		</statBases>
@@ -183,8 +183,8 @@
 			<StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.0</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.3</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.08</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.9</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>10.8</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>9</StuffPower_Insulation_Heat>
 			<Mass>0.02</Mass>
 			<Bulk>0.02</Bulk>
 		</statBases>
@@ -230,8 +230,8 @@
 			<StuffPower_Armor_Blunt>1.3</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.3</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.3</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.21</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.55</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>12.1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>5.5</StuffPower_Insulation_Heat>
 			<Mass>0.02</Mass>
 			<Bulk>0.02</Bulk>
 		</statBases>
@@ -277,8 +277,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.1</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.4</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.25</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-4</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>7.5</StuffPower_Insulation_Heat>
 			<Mass>0.015</Mass>
 			<Bulk>0.015</Bulk>
 		</statBases>
@@ -331,8 +331,8 @@
 			<StuffPower_Armor_Blunt>1.45</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.0</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.8</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.3</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.5</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>13</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<Mass>0.02</Mass>
 			<Bulk>0.02</Bulk>
 		</statBases>
@@ -435,8 +435,8 @@ Temporary removal until leather processing is ready
 			<StuffPower_Armor_Blunt>1.3</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.0</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.8</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.28</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.5</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>12.8</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<Mass>0.03</Mass>
 			<Bulk>0.03</Bulk>
 		</statBases>
@@ -483,8 +483,8 @@ Temporary removal until leather processing is ready
 			<StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.3</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.0</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.9</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.2</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-2</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>12</StuffPower_Insulation_Heat>
 			<Mass>0.02</Mass>
 			<Bulk>0.02</Bulk>
 		</statBases>
@@ -534,8 +534,8 @@ Temporary removal until leather processing is ready
 			<StuffPower_Armor_Blunt>1.6</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.7</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.18</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-3</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>11.8</StuffPower_Insulation_Heat>
 			<Mass>0.02</Mass>
 			<Bulk>0.02</Bulk>
 		</statBases>
@@ -585,8 +585,8 @@ Temporary removal until leather processing is ready
 			<StuffPower_Armor_Blunt>1.6</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.4</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.95</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.04</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>5.1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>10.4</StuffPower_Insulation_Heat>
 			<Mass>0.04</Mass>
 			<Bulk>0.04</Bulk>
 		</statBases>
@@ -630,8 +630,8 @@ Temporary removal until leather processing is ready
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.7</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.97</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.24</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>5.2</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>12.4</StuffPower_Insulation_Heat>
 			<Mass>0.03</Mass>
 			<Bulk>0.03</Bulk>
 		</statBases>
@@ -680,8 +680,8 @@ Temporary removal until leather processing is ready
 			<StuffPower_Armor_Blunt>1.7</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.9</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.8</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.05</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-2.5</StuffPower_Insulation_Heat>
 			<Mass>0.1</Mass>
 			<Bulk>0.1</Bulk>
 		</statBases>
@@ -737,8 +737,8 @@ Temporary removal until leather processing is ready
 			<StuffPower_Armor_Blunt>0.75</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.85</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.45</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-2.85</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5.45</StuffPower_Insulation_Heat>
 			<Mass>0.05</Mass>
 			<Bulk>0.05</Bulk>
 		</statBases>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Stuff_Leather.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Stuff_Leather.xml
@@ -52,8 +52,8 @@
 			<StuffPower_Armor_Blunt>1.1</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.35</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.9</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>11</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>9</StuffPower_Insulation_Heat>
 		</statBases>
 		<stuffProps>
 			<color>(162,106,57)</color>
@@ -68,12 +68,13 @@
 			<color>(209,168,39)</color>
 		</graphicData>
 		<statBases>
+
 			<MarketValue>2</MarketValue>
 			<StuffPower_Armor_Blunt>1</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.2</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>14</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>1</StuffPower_Insulation_Heat>
 			<BedRestEffectiveness>0.8</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
 			<WorkToMake>0.9</WorkToMake>
@@ -101,8 +102,8 @@
         <StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
         <StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
         <StuffPower_Armor_Heat>1.6</StuffPower_Armor_Heat>
-        <StuffPower_Insulation_Cold>1.37</StuffPower_Insulation_Cold>
-        <StuffPower_Insulation_Heat>0.54</StuffPower_Insulation_Heat>
+        <StuffPower_Insulation_Cold>18.7</StuffPower_Insulation_Cold>
+        <StuffPower_Insulation_Heat>5.4</StuffPower_Insulation_Heat>
         <WorkToMake>1.2</WorkToMake>
         <BedRestEffectiveness>1.25</BedRestEffectiveness>
         <ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
@@ -127,8 +128,8 @@
         <StuffPower_Armor_Blunt>1.28</StuffPower_Armor_Blunt>
         <StuffPower_Armor_Sharp>1.22</StuffPower_Armor_Sharp>
         <StuffPower_Armor_Heat>0.92</StuffPower_Armor_Heat>
-        <StuffPower_Insulation_Cold>1.24</StuffPower_Insulation_Cold>
-        <StuffPower_Insulation_Heat>0.9</StuffPower_Insulation_Heat>
+        <StuffPower_Insulation_Cold>12.4</StuffPower_Insulation_Cold>
+        <StuffPower_Insulation_Heat>9.</StuffPower_Insulation_Heat>
         <WorkToMake>1.2</WorkToMake>
         <BedRestEffectiveness>1.25</BedRestEffectiveness>
         <ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
@@ -151,8 +152,8 @@
 			<StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.3</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.8</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.2</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.9</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>12</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>20</StuffPower_Insulation_Heat>
 			<BedRestEffectiveness>1.1</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
 			<WorkToMake>1.1</WorkToMake>
@@ -195,8 +196,8 @@
 			<StuffPower_Armor_Blunt>1.3</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.2</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>16</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>10</StuffPower_Insulation_Heat>
 			<BedRestEffectiveness>1.2</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>0.95</ImmunityGainSpeedFactor>
 			<WorkToMake>1</WorkToMake>
@@ -222,8 +223,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.4</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.3</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.35</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>14</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>14.5</StuffPower_Insulation_Heat>
 			<BedRestEffectiveness>1</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>1.1</ImmunityGainSpeedFactor>
 			<WorkToMake>1.15</WorkToMake>
@@ -252,8 +253,8 @@
 				<StuffPower_Armor_Blunt>1.15</StuffPower_Armor_Blunt>
 				<StuffPower_Armor_Sharp>1.1</StuffPower_Armor_Sharp>
 				<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-				<StuffPower_Insulation_Cold>1.1</StuffPower_Insulation_Cold>
-				<StuffPower_Insulation_Heat>0.77</StuffPower_Insulation_Heat>
+				<StuffPower_Insulation_Cold>9</StuffPower_Insulation_Cold>
+				<StuffPower_Insulation_Heat>7.7</StuffPower_Insulation_Heat>
 				<WorkToMake>1</WorkToMake>
 				<BedRestEffectiveness>1.0</BedRestEffectiveness>
 				<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
@@ -276,8 +277,8 @@
 			<StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.25</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>10.5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>8</StuffPower_Insulation_Heat>
 			<BedRestEffectiveness>1</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
 			<WorkToMake>1</WorkToMake>
@@ -305,8 +306,8 @@
 			<StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.9</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.2</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.2</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>12</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>12</StuffPower_Insulation_Heat>
 			<BedRestEffectiveness>1.2</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>1.2</ImmunityGainSpeedFactor>
 			<WorkToMake>0.9</WorkToMake>
@@ -334,8 +335,8 @@
 			<MarketValue>1.8</MarketValue>
 			<StuffPower_Armor_Sharp>0.67</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Blunt>0.14</StuffPower_Armor_Blunt>
-			<StuffPower_Insulation_Cold>10</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>10</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>8</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>8</StuffPower_Insulation_Heat>
 		</statBases>
 		<stuffProps>
 			<color>(76,83,99)</color>
@@ -381,8 +382,8 @@
         <StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
         <StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
         <StuffPower_Armor_Heat>0.8</StuffPower_Armor_Heat>
-        <StuffPower_Insulation_Cold>1.3</StuffPower_Insulation_Cold>
-        <StuffPower_Insulation_Heat>0.6</StuffPower_Insulation_Heat>
+        <StuffPower_Insulation_Cold>17</StuffPower_Insulation_Cold>
+        <StuffPower_Insulation_Heat>6</StuffPower_Insulation_Heat>
         <BedRestEffectiveness>1.4</BedRestEffectiveness>
         <ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
         <WorkToMake>1.2</WorkToMake>
@@ -408,8 +409,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.4</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.45</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.3</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>4.5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>11</StuffPower_Insulation_Heat>
 			<BedRestEffectiveness>0.9</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>1.35</ImmunityGainSpeedFactor>
 			<WorkToMake>1.1</WorkToMake>
@@ -445,8 +446,8 @@
 			<StuffPower_Armor_Blunt>2.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>2.3</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.4</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.65</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.25</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>6.5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>11.5</StuffPower_Insulation_Heat>
 			<WorkToMake>1.8</WorkToMake>
 			<BedRestEffectiveness>0.7</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>0.9</ImmunityGainSpeedFactor>
@@ -474,8 +475,8 @@
 			<StuffPower_Armor_Blunt>1.8</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.8</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.4</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.2</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.2</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>30</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>12</StuffPower_Insulation_Heat>
 			<WorkToMake>1.8</WorkToMake>
 			<BedRestEffectiveness>0.85</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>1.2</ImmunityGainSpeedFactor>
@@ -497,14 +498,15 @@
 			<color>(150,150,150)</color>
 		</graphicData>
 		<statBases>
+
 			<MaxHitPoints>1.5</MaxHitPoints>
 			<Beauty>1.2</Beauty>
 			<MarketValue>2.0</MarketValue>
 			<StuffPower_Armor_Blunt>2.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>2.1</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.4</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.6</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.15</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>6</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>11.5</StuffPower_Insulation_Heat>
 			<WorkToMake>1.7</WorkToMake>
 			<BedRestEffectiveness>0.8</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
@@ -534,8 +536,8 @@
 			<StuffPower_Armor_Blunt>2.4</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>2.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.3</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.41</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.12</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>14.1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>11.2</StuffPower_Insulation_Heat>
 			<WorkToMake>1.9</WorkToMake>
 			<BedRestEffectiveness>0.8</BedRestEffectiveness>
 			<ImmunityGainSpeedFactor>1.28</ImmunityGainSpeedFactor>
@@ -563,8 +565,8 @@
 				<StuffPower_Armor_Blunt>2.65</StuffPower_Armor_Blunt>
 				<StuffPower_Armor_Sharp>2.45</StuffPower_Armor_Sharp>
 				<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-				<StuffPower_Insulation_Cold>0.9</StuffPower_Insulation_Cold>
-				<StuffPower_Insulation_Heat>1.38</StuffPower_Insulation_Heat>
+				<StuffPower_Insulation_Cold>9</StuffPower_Insulation_Cold>
+				<StuffPower_Insulation_Heat>13.8</StuffPower_Insulation_Heat>
 				<WorkToMake>2.4</WorkToMake>
 				<BedRestEffectiveness>0.7</BedRestEffectiveness>
 				<ImmunityGainSpeedFactor>1.37</ImmunityGainSpeedFactor>
@@ -592,8 +594,8 @@
 				<StuffPower_Armor_Blunt>2.17</StuffPower_Armor_Blunt>
 				<StuffPower_Armor_Sharp>2.05</StuffPower_Armor_Sharp>
 				<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
-				<StuffPower_Insulation_Cold>1.46</StuffPower_Insulation_Cold>
-				<StuffPower_Insulation_Heat>0.82</StuffPower_Insulation_Heat>
+				<StuffPower_Insulation_Cold>14.6</StuffPower_Insulation_Cold>
+				<StuffPower_Insulation_Heat>8.2</StuffPower_Insulation_Heat>
 				<WorkToMake>2.2</WorkToMake>
 				<BedRestEffectiveness>1.15</BedRestEffectiveness>
 				<ImmunityGainSpeedFactor>1.39</ImmunityGainSpeedFactor>
@@ -621,8 +623,8 @@
 				<StuffPower_Armor_Blunt>2.35</StuffPower_Armor_Blunt>
 				<StuffPower_Armor_Sharp>2.22</StuffPower_Armor_Sharp>
 				<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-				<StuffPower_Insulation_Cold>1.31</StuffPower_Insulation_Cold>
-				<StuffPower_Insulation_Heat>1.07</StuffPower_Insulation_Heat>
+				<StuffPower_Insulation_Cold>13.1</StuffPower_Insulation_Cold>
+				<StuffPower_Insulation_Heat>10.7</StuffPower_Insulation_Heat>
 				<WorkToMake>1.8</WorkToMake>
 				<BedRestEffectiveness>1.05</BedRestEffectiveness>
 				<ImmunityGainSpeedFactor>1.2</ImmunityGainSpeedFactor>
@@ -650,8 +652,8 @@
 				<StuffPower_Armor_Blunt>1.6</StuffPower_Armor_Blunt>
 				<StuffPower_Armor_Sharp>1.7</StuffPower_Armor_Sharp>
 				<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
-				<StuffPower_Insulation_Cold>1.39</StuffPower_Insulation_Cold>
-				<StuffPower_Insulation_Heat>0.7</StuffPower_Insulation_Heat>
+				<StuffPower_Insulation_Cold>13.9</StuffPower_Insulation_Cold>
+				<StuffPower_Insulation_Heat>7</StuffPower_Insulation_Heat>
 				<WorkToMake>1.7</WorkToMake>
 				<BedRestEffectiveness>1.2</BedRestEffectiveness>
 				<ImmunityGainSpeedFactor>1.14</ImmunityGainSpeedFactor>


### PR DESCRIPTION
Adds 
<StuffEffectMultiplierArmor>, <StuffEffectMultiplierInsulation_Cold>, <StuffEffectMultiplierInsulation_Heat>
to every piece of apparel, so that stuff has an effect. The value range is 0 - 1.0 (other values not tested), being 0-100%. Without these values set, stuff material has no effect whatsoever on the armor/insulation of a piece of apparel.
There will be quite a bit of tweaking to do, and decisions to be made about how to progress.
Also changes insulation values of cloths and leathers. These will also take a lot more tweaking. Those values are flat degrees C modifiers.