### PR TITLE
Metal insulation initial update

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Hightech.xml
@@ -18,8 +18,8 @@
 			<StuffPower_Armor_Blunt>1.45</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.25</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.6</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.4</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -51,8 +51,8 @@
 			<StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.25</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.05</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.3</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.1</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -114,8 +114,8 @@
 			<StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.35</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.15</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.35</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.25</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -176,8 +176,8 @@
 			<StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.45</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.35</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.4</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.1</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -240,8 +240,8 @@
 			<StuffPower_Armor_Blunt>1.45</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.35</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.4</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.3</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.9</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -305,8 +305,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.5</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.35</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.4</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -368,8 +368,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.4</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.45</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.2</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Hightech.xml
@@ -15,6 +15,13 @@
 		<stackLimit>75</stackLimit>
 		<statBases>
 			<MarketValue>50</MarketValue>
+			<StuffPower_Armor_Blunt>1.45</StuffPower_Armor_Blunt>
+			<StuffPower_Armor_Sharp>1.6</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Heat>1.25</StuffPower_Armor_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<SharpDamageMultiplier>1.6</SharpDamageMultiplier>
+			<BluntDamageMultiplier>1.4</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>0</Flammability>
 			<Mass>0.35</Mass>
@@ -44,8 +51,8 @@
 			<StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.25</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.05</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.15</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.3</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.1</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -107,8 +114,8 @@
 			<StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.35</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.15</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.15</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.15</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.35</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.25</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -169,8 +176,8 @@
 			<StuffPower_Armor_Blunt>1.4</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.45</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.35</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.25</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.2</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.4</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.1</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -233,8 +240,8 @@
 			<StuffPower_Armor_Blunt>1.45</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.35</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.4</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.25</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.2</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.3</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.9</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -298,8 +305,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.5</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.25</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.25</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.35</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.4</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -361,8 +368,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.4</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.3</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.3</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.45</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.2</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -425,8 +432,8 @@
 			<StuffPower_Armor_Blunt>0.7</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.35</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.3</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>30</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>30</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.5</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.5</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -489,8 +496,8 @@
 			<StuffPower_Armor_Blunt>1.65</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.4</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.65</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.4</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.35</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>40</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>40</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.55</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.55</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
@@ -116,7 +116,7 @@
 			<StuffPower_Armor_Blunt>0.8</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.8</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.85</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
 			<StuffPower_Insulation_Heat>0.9</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.85</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.4</BluntDamageMultiplier>
@@ -180,7 +180,7 @@
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.4</StuffPower_Armor_Heat>
 			<StuffPower_Insulation_Cold>0.8</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.85</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.3</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.3</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -245,8 +245,8 @@
 			<StuffPower_Armor_Blunt>0.9</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.8</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.85</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.85</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.0</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.0</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -309,7 +309,7 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.9</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.8</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.95</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
 			<StuffPower_Insulation_Heat>0.9</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.1</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.2</BluntDamageMultiplier>
@@ -371,8 +371,8 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.9</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.8</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.95</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.95</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.15</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.3</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -434,8 +434,8 @@
 			<StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.8</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.0</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.0</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.2</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.2</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -496,8 +496,8 @@
 			<StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.15</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.0</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.05</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.0</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.3</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.15</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -557,8 +557,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.55</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.3</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>1.05</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>1.1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.35</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.25</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -609,6 +609,11 @@
 		<stackLimit>75</stackLimit>
 		<statBases>
 			<MarketValue>135</MarketValue>
+			<StuffPower_Armor_Blunt>1.3</StuffPower_Armor_Blunt>
+			<StuffPower_Armor_Sharp>1.35</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.4</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.7</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
@@ -116,7 +116,7 @@
 			<StuffPower_Armor_Blunt>0.8</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.8</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
 			<StuffPower_Insulation_Heat>0.9</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.85</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.4</BluntDamageMultiplier>
@@ -180,7 +180,7 @@
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.4</StuffPower_Armor_Heat>
 			<StuffPower_Insulation_Cold>0.8</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.3</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.3</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -245,8 +245,8 @@
 			<StuffPower_Armor_Blunt>0.9</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.8</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.0</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.0</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -309,7 +309,7 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.9</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.8</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
 			<StuffPower_Insulation_Heat>0.9</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.1</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.2</BluntDamageMultiplier>
@@ -371,8 +371,8 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.9</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.8</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.15</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.3</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -434,8 +434,8 @@
 			<StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.8</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.2</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.2</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -496,8 +496,8 @@
 			<StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.15</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.0</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.3</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.15</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -557,8 +557,8 @@
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.55</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.3</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.35</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.25</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -612,8 +612,8 @@
 			<StuffPower_Armor_Blunt>1.3</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.35</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>1.2</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>1.4</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.7</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
@@ -17,8 +17,8 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.8</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.85</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-4</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-3</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.5</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.7</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
@@ -17,8 +17,8 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.5</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.7</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -83,8 +83,8 @@
 			<StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.7</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>			
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>			
 			<SharpDamageMultiplier>0.5</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.4</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -148,8 +148,8 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.1</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -209,8 +209,8 @@
 			<StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.4</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -274,8 +274,8 @@
 			<StuffPower_Armor_Blunt>0.7</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-5</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-5</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.6</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.6</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
@@ -17,7 +17,7 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
 			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.5</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.7</BluntDamageMultiplier>
@@ -83,7 +83,7 @@
 			<StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.7</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
 			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>			
 			<SharpDamageMultiplier>0.5</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.4</BluntDamageMultiplier>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
@@ -17,8 +17,8 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>-4</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>-3</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.5</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.7</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -80,6 +80,11 @@
 		<stackLimit>300</stackLimit>
 		<statBases>
 			<MarketValue>2</MarketValue>
+			<StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
+			<StuffPower_Armor_Sharp>0.7</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>			
 			<SharpDamageMultiplier>0.5</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.4</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -113,11 +118,6 @@
 				<WorkToBuild>1.3</WorkToBuild>
 				<DoorOpenSpeed>1.25</DoorOpenSpeed>
 				<MeleeWeapon_CooldownMultiplier>0.7</MeleeWeapon_CooldownMultiplier>
-				<StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
-				<StuffPower_Armor_Sharp>0.7</StuffPower_Armor_Sharp>
-				<StuffPower_Armor_Heat>0.7</StuffPower_Armor_Heat>
-				<StuffPower_Insulation_Cold>0.8</StuffPower_Insulation_Cold>
-				<StuffPower_Insulation_Heat>0.85</StuffPower_Insulation_Heat>
 				<MoveSpeed>1.05</MoveSpeed>
 				<MarketValue>0.7</MarketValue>
 				<BedRestEffectiveness>1</BedRestEffectiveness>
@@ -148,8 +148,8 @@
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.85</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.8</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.7</SharpDamageMultiplier>
 			<BluntDamageMultiplier>1.1</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -209,8 +209,8 @@
 			<StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.85</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.8</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.4</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.5</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -274,8 +274,8 @@
 			<StuffPower_Armor_Blunt>0.7</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.6</StuffPower_Armor_Heat>
-			<StuffPower_Insulation_Cold>0.85</StuffPower_Insulation_Cold>
-			<StuffPower_Insulation_Heat>0.8</StuffPower_Insulation_Heat>
+			<StuffPower_Insulation_Cold>-1</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>-1</StuffPower_Insulation_Heat>
 			<SharpDamageMultiplier>0.6</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.6</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>


### PR DESCRIPTION
Fixed Tin's stuff properties. Gave Carbon Fiber Alloy some properties so it'll have an effect on apparel made out of it.
Gave all metals slightly thermally conductive properties, so they're useless as insulators in apparel. Except Alpha and Beta poly. Since they're used in stellar construction, I expect they have some amazing properties. Or not. Can always change them later.
Gave them all -5 heat/cold insulation, which, currently, makes both values worse for the pawn. Subject to balance changes based on how it plays with the stuff multipliers of the apparel, etc.