### PR TITLE
Fix missed apparel recipes (SpurredBoots, MarineShirt, etc.)

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel.xml
@@ -35,17 +35,6 @@
 	</ThingDef>
 
 	<ThingDef Name="ApparelNeoliticSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
-		<equippedStatOffsets>
-			<Suppressability>-0.03</Suppressability>
-		</equippedStatOffsets>
-		<apparel>
-			<tags>
-				<li>UniqueNeolitic</li>
-			</tags>
-		</apparel>
-	</ThingDef>
-	
-	<ThingDef Name="ApparelNeoliticBase" ParentName="ApparelNeoliticSimpleBase" Abstract="True">
 		<recipeMaker>
 			<workSpeedStat>TailoringSpeed</workSpeedStat>
 			<workSkill>Crafting</workSkill>
@@ -59,11 +48,8 @@
 			</skillRequirements>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
 		</recipeMaker>
-	</ThingDef>
-
-	<ThingDef Name="ArmorNeoliticSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<equippedStatOffsets>
-			<Suppressability>-0.06</Suppressability>
+			<Suppressability>-0.03</Suppressability>
 		</equippedStatOffsets>
 		<apparel>
 			<tags>
@@ -72,7 +58,10 @@
 		</apparel>
 	</ThingDef>
 	
-	<ThingDef Name="ArmorNeoliticBase" ParentName="ArmorNeoliticSimpleBase" Abstract="True">
+	<ThingDef Name="ApparelNeoliticBase" ParentName="ApparelNeoliticSimpleBase" Abstract="True">
+	</ThingDef>
+
+	<ThingDef Name="ArmorNeoliticSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<recipeMaker>
 			<workSpeedStat>SmithingSpeed</workSpeedStat>
 			<workSkill>Crafting</workSkill>
@@ -86,20 +75,20 @@
 			</skillRequirements>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
 		</recipeMaker>
-	</ThingDef>
-
-	<ThingDef Name="ApparelMedievalSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<equippedStatOffsets>
-			<Suppressability>-0.03</Suppressability>
+			<Suppressability>-0.06</Suppressability>
 		</equippedStatOffsets>
 		<apparel>
 			<tags>
-				<li>UniqueMedieval</li>
+				<li>UniqueNeolitic</li>
 			</tags>
 		</apparel>
 	</ThingDef>
 	
-	<ThingDef Name="ApparelMedievalBase" ParentName="ApparelMedievalSimpleBase" Abstract="True">
+	<ThingDef Name="ArmorNeoliticBase" ParentName="ArmorNeoliticSimpleBase" Abstract="True">
+	</ThingDef>
+
+	<ThingDef Name="ApparelMedievalSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<recipeMaker>
 			<workSpeedStat>TailoringSpeed</workSpeedStat>
 			<workSkill>Crafting</workSkill>
@@ -113,11 +102,8 @@
 			</skillRequirements>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
 		</recipeMaker>
-	</ThingDef>
-
-	<ThingDef Name="ArmorMedievalSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<equippedStatOffsets>
-			<Suppressability>-0.06</Suppressability>
+			<Suppressability>-0.03</Suppressability>
 		</equippedStatOffsets>
 		<apparel>
 			<tags>
@@ -126,7 +112,10 @@
 		</apparel>
 	</ThingDef>
 	
-	<ThingDef Name="ArmorMedievalBase" ParentName="ArmorMedievalSimpleBase" Abstract="True">
+	<ThingDef Name="ApparelMedievalBase" ParentName="ApparelMedievalSimpleBase" Abstract="True">
+	</ThingDef>
+
+	<ThingDef Name="ArmorMedievalSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<recipeMaker>
 			<workSpeedStat>SmithingSpeed</workSpeedStat>
 			<workSkill>Crafting</workSkill>
@@ -141,20 +130,20 @@
 			</skillRequirements>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
 		</recipeMaker>
-	</ThingDef>
-
-	<ThingDef Name="ApparelIndustrialSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<equippedStatOffsets>
 			<Suppressability>-0.06</Suppressability>
 		</equippedStatOffsets>
 		<apparel>
 			<tags>
-				<li>UniqueIndustrial</li>
+				<li>UniqueMedieval</li>
 			</tags>
 		</apparel>
 	</ThingDef>
 	
-	<ThingDef Name="ApparelIndustrialBase" ParentName="ApparelIndustrialSimpleBase" Abstract="True">
+	<ThingDef Name="ArmorMedievalBase" ParentName="ArmorMedievalSimpleBase" Abstract="True">
+	</ThingDef>
+
+	<ThingDef Name="ApparelIndustrialSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<recipeMaker>
 			<workSpeedStat>TailoringSpeed</workSpeedStat>
 			<workSkill>Crafting</workSkill>
@@ -168,11 +157,8 @@
 			</skillRequirements>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
 		</recipeMaker>
-	</ThingDef>
-	
-	<ThingDef Name="ArmorIndustrialSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<equippedStatOffsets>
-			<Suppressability>-0.07</Suppressability>
+			<Suppressability>-0.06</Suppressability>
 		</equippedStatOffsets>
 		<apparel>
 			<tags>
@@ -181,7 +167,10 @@
 		</apparel>
 	</ThingDef>
 	
-	<ThingDef Name="ArmorIndustrialBase" ParentName="ArmorIndustrialSimpleBase" Abstract="True">
+	<ThingDef Name="ApparelIndustrialBase" ParentName="ApparelIndustrialSimpleBase" Abstract="True">
+	</ThingDef>
+	
+	<ThingDef Name="ArmorIndustrialSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<recipeMaker>
 			<workSpeedStat>SmithingSpeed</workSpeedStat>
 			<workSkill>Crafting</workSkill>
@@ -195,9 +184,33 @@
 			</skillRequirements>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
 		</recipeMaker>
+		<equippedStatOffsets>
+			<Suppressability>-0.07</Suppressability>
+		</equippedStatOffsets>
+		<apparel>
+			<tags>
+				<li>UniqueIndustrial</li>
+			</tags>
+		</apparel>
+	</ThingDef>
+	
+	<ThingDef Name="ArmorIndustrialBase" ParentName="ArmorIndustrialSimpleBase" Abstract="True">
 	</ThingDef>
 
 	<ThingDef Name="ApparelSpacerSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
+		<recipeMaker>
+			<workSpeedStat>TailoringSpeed</workSpeedStat>
+			<workSkill>Crafting</workSkill>
+			<effectWorking>Tailor</effectWorking>
+			<soundWorking>Recipe_Tailor</soundWorking>
+			<recipeUsers>
+				<li>HyperTailoringBench</li>
+			</recipeUsers>
+			<skillRequirements>
+				<Crafting>15</Crafting>
+			</skillRequirements>
+			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
+		</recipeMaker>
 		<equippedStatOffsets>
 			<Suppressability>-0.09</Suppressability>
 		</equippedStatOffsets>
@@ -212,22 +225,22 @@
 	</ThingDef>
 	
 	<ThingDef Name="ApparelSpacerBase" ParentName="ApparelSpacerSimpleBase" Abstract="True">
+	</ThingDef>
+
+	<ThingDef Name="ArmorSpacerSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<recipeMaker>
-			<workSpeedStat>TailoringSpeed</workSpeedStat>
+			<workSpeedStat>SmithingSpeed</workSpeedStat>
 			<workSkill>Crafting</workSkill>
-			<effectWorking>Tailor</effectWorking>
-			<soundWorking>Recipe_Tailor</soundWorking>
+			<effectWorking>Smith</effectWorking>
+			<soundWorking>Recipe_Machining</soundWorking>
 			<recipeUsers>
 				<li>HyperTailoringBench</li>
 			</recipeUsers>
 			<skillRequirements>
-				<Crafting>15</Crafting>
+				<Crafting>16</Crafting>
 			</skillRequirements>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
 		</recipeMaker>
-	</ThingDef>
-
-	<ThingDef Name="ArmorSpacerSimpleBase" ParentName="SK_ApparelBase" Abstract="True">
 		<equippedStatOffsets>
 			<Suppressability>-0.11</Suppressability>
 		</equippedStatOffsets>
@@ -242,19 +255,6 @@
 	</ThingDef>
 	
 	<ThingDef Name="ArmorSpacerBase" ParentName="ArmorSpacerSimpleBase" Abstract="True">
-		<recipeMaker>
-			<workSpeedStat>SmithingSpeed</workSpeedStat>
-			<workSkill>Crafting</workSkill>
-			<effectWorking>Smith</effectWorking>
-			<soundWorking>Recipe_Machining</soundWorking>
-			<recipeUsers>
-				<li>HyperTailoringBench</li>
-			</recipeUsers>
-			<skillRequirements>
-				<Crafting>16</Crafting>
-			</skillRequirements>
-			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
-		</recipeMaker>
 	</ThingDef>
 
 </Defs>


### PR DESCRIPTION
Привет!

Перенес тег recipeMaker в базовые классы, т.к. есть много одежды, которая наследует Apparel...SimpleBase и рецепты этой одежды пропали.

Возможно, стоит поставить различный skillRequirements для базовой одежды и наследников - смотрите сами)