### PR TITLE
Fixed dark environment impacting hearing not sight

### DIFF
--- a/Mods/Core_SK/Defs/HediffDefs/HediffDefs_Enlighten.xml
+++ b/Mods/Core_SK/Defs/HediffDefs/HediffDefs_Enlighten.xml
@@ -10,12 +10,12 @@
       <li>
         <capMods>
           <li>
-            <capacity>Manipulation</capacity>
-            <offset>0.2</offset>
-          </li>
-          <li>
             <capacity>Moving</capacity>
             <postFactor>1.1</postFactor>
+          </li>
+          <li>
+            <capacity>Sight</capacity>
+            <offset>0.2</offset>
           </li>
         </capMods>
       </li>
@@ -36,8 +36,8 @@
             <postFactor>0.8</postFactor>
           </li>
           <li>
-            <capacity>Hearing</capacity>
-            <postFactor>0.8</postFactor>
+            <capacity>Sight</capacity>
+            <offset>-0.2</offset>
           </li>
         </capMods>
       </li>


### PR DESCRIPTION
At the moment, fishing, electronics, foraging and collecting scale with sight uncapped.
Combat, Medicine, and research have caps>1.
How about giving things who profit from better sight in reality higher caps?
Something like:
Tailoring 1,2
Sculpting 1,3
Drugsynthesis 1,2
Fishing down to 1,1
leave electronics, forage, collecting uncapped or something high like 1,5
Operations same as tending(why does tending scale with sight but not operating? OP?)

Or just slap Manipulation there instead of sight, which I would find quite meh.
What do you think?