### PR TITLE
Development

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrows.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrows.xml
@@ -155,9 +155,15 @@
 			<damageAmountBase>3</damageAmountBase>
 			<!-- <armorPenetrationBase>0.25</armorPenetrationBase> -->
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>3.160</armorPenetrationBlunt>
+			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>
-			<preExplosionSpawnThingDef>Ammo_Arrow_Steel</preExplosionSpawnThingDef>
+			<preExplosionSpawnThingDef>Ammo_Arrow_Poison</preExplosionSpawnThingDef>
+			<secondaryDamage>
+				<li>
+					<def>ArrowHighVelocity</def>
+					<amount>3</amount>
+				</li>
+			</secondaryDamage>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
@@ -129,7 +129,7 @@
 			<damageDef>Poison</damageDef>
 			<damageAmountBase>3</damageAmountBase>
 			<!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
-			<armorPenetrationBlunt>4.540</armorPenetrationBlunt>
+			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.1</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_Bolt_Poison</preExplosionSpawnThingDef>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
@@ -126,17 +126,17 @@
 		<defName>Projectile_PoisonBolt</defName>
 		<label>poison bolt</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>ArrowVenom</damageDef>
-			<damageAmountBase>6</damageAmountBase>
+			<damageDef>Poison</damageDef>
+			<damageAmountBase>3</damageAmountBase>
 			<!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
 			<armorPenetrationBlunt>4.540</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.1</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
-			<preExplosionSpawnThingDef>Ammo_Bolt_Metallic</preExplosionSpawnThingDef>
+			<preExplosionSpawnThingDef>Ammo_Bolt_Poison</preExplosionSpawnThingDef>
 			<secondaryDamage>
 				<li>
-					<def>Arrow</def>
-					<amount>12</amount>
+					<def>ArrowHighVelocity</def>
+					<amount>6</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Darts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Darts.xml
@@ -65,9 +65,9 @@
 		<defName>PoisonDart</defName>
 		<label>Poison Dart</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>2</damageAmountBase>
+			<damageAmountBase>3</damageAmountBase>
 			<!-- <armorPenetrationBase>0.15</armorPenetrationBase> -->
-			<armorPenetrationBlunt>1</armorPenetrationBlunt>
+			<armorPenetrationBlunt>0</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.2</armorPenetrationSharp>
 		</projectile>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/DamageDefs/Damages_LocalInjury_SK.xml
+++ b/Mods/Core_SK/Defs/DamageDefs/Damages_LocalInjury_SK.xml
@@ -249,7 +249,7 @@
 		<additionalHediffs>
 			<li>
 				<hediff>Soporific</hediff>
-				<severityPerDamageDealt>0.2</severityPerDamageDealt>
+				<severityPerDamageDealt>0.07</severityPerDamageDealt>
 			</li>
 		</additionalHediffs>
 		<modExtensions>

--- a/Mods/Core_SK/Defs/HediffDefs/HediffDefs_miscSK.xml
+++ b/Mods/Core_SK/Defs/HediffDefs/HediffDefs_miscSK.xml
@@ -55,7 +55,7 @@
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.5</offset>
+						<offset>-0.25</offset>
 					</li>
 				</capMods>
 			</li>
@@ -65,7 +65,7 @@
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<setMax>0.10</setMax>
+						<offset>-0.5</offset>
 					</li>
 					<li> 
 						<capacity>BloodPumping</capacity>


### PR DESCRIPTION
1) Поправил тип выпадающего снаряда для отравленных болтов и стрел (было - металлическая, стала - ядовитая)
2) Сделал отравленные болты снотворными, чтобы были как стрелы, но с бОльшим пробитием.
3) Уменьшил дробящее пробивание для отравленных стрел и болтов до нуля, т.к. с ушибов накладывался яд. В идеале нужно было бы как-нибудь убрать накладывание яда с ушибов, но это не критично.
4) Уменьшил снотворный эффект от яда для увеличения количества попаданий перед тем, как существо упадет (4-10 стрел/болтов/дротиков для 100% нейтрализации, в зависимости от брони цели)
5) Ослабил дебафы на ранней стадии снотворного, чтобы существо не вырубалось так легко. 70% для гарантированного падения (было 40%)