### PR TITLE
Fix market value pistols ammo – FMJ .45 ACP (11,43x23 mm) did cost lesser than FMJ 9x19 mm. Also fix speed of .45 ACP bullet. It should be 20-30% slower than 9x19 mm.

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
@@ -57,7 +57,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.07</MarketValue>
+			<MarketValue>0.08</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_45ACP_FMJ</cookOffProjectile>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
@@ -100,7 +100,7 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<speed>118</speed>
+			<speed>98</speed>
 			<dropsCasings>true</dropsCasings>
 		</projectile>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
@@ -57,7 +57,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>0.08</MarketValue>
+			<MarketValue>0.07</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_9x19mmPara_FMJ</cookOffProjectile>


### PR DESCRIPTION
Fix market value pistols ammo – FMJ .45 ACP (11,43x23 mm) did cost lesser than FMJ 9x19 mm.

Also fix speed velocity of .45 ACP bullet (was 118). It should be 20-30% slower than 9x19 mm (now is 115).

![ammo velocity](https://user-images.githubusercontent.com/62516232/77848505-a6014180-71de-11ea-8db0-a03e8619c1f2.png)
