### PR TITLE
Fix uranium name

### DIFF
--- a/Mods/Minerals/Defs/ThingsDefs_Minerals/StaticMinerals.xml
+++ b/Mods/Minerals/Defs/ThingsDefs_Minerals/StaticMinerals.xml
@@ -720,7 +720,7 @@
 
   <ThingDef ParentName="MetalOxideBase" Class="Minerals.ThingDef_StaticMineral">
     <defName>UraniniteDeposit</defName>
-    <label>Uraninite Deposit</label>
+    <label>Uranium Deposit</label>
     <description>Formations of uranium oxide, a major uranium ore. Often assocaited with silver.</description>
     <graphicData>
       <texPath>Things/Mineral/UraniniteDeposit</texPath>

--- a/Mods/Minerals/Languages/Russian/DefInjected/ThingDef/StaticMinerals.xml
+++ b/Mods/Minerals/Languages/Russian/DefInjected/ThingDef/StaticMinerals.xml
@@ -40,7 +40,7 @@
   <DiamondCrystal.label>Алмазный кристалл</DiamondCrystal.label>
   <DiamondCrystal.description>Кристаллы чистого углерода. Самое твердое из известных веществ и ценный драгоценный камень.</DiamondCrystal.description>
 
-  <UraniniteDeposit.label>Уранитовые залежи</UraniniteDeposit.label>
+  <UraniniteDeposit.label>Урановые залежи</UraniniteDeposit.label>
   <UraniniteDeposit.description>Формации оксида урана, крупной урановой руды. Часто ассоциируется с серебром.</UraniniteDeposit.description>
 
   <MalachiteDeposit.label>Малахитовые залежи</MalachiteDeposit.label>


### PR DESCRIPTION
Change name from Uraninite Deposit to Uranium Deposit.
Переименовано с Уранитовых залежей на Урановые