### PR TITLE
Fix same name in russian localization for two different traits. Fix misprint.

### DIFF
--- a/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/RCT_Traits.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/RCT_Traits.xml
@@ -57,7 +57,7 @@
   <EatingSpeed.degreeDatas.0.label>гурман</EatingSpeed.degreeDatas.0.label>
   <EatingSpeed.degreeDatas.0.description>{PAWN_nameDef} разборчив в пище. У {PAWN_possessive} уходит больше времени чтобы ее съесть.</EatingSpeed.degreeDatas.0.description>
   <EatingSpeed.degreeDatas.1.label>едок</EatingSpeed.degreeDatas.1.label>
-  <EatingSpeed.degreeDatas.1.description>{PAWN_nameDef} поглащает пищу быстрее обычного.</EatingSpeed.degreeDatas.1.description>
+  <EatingSpeed.degreeDatas.1.description>{PAWN_nameDef} поглощает пищу быстрее обычного.</EatingSpeed.degreeDatas.1.description>
 
   <Nyctophobe.degreeDatas.0.label>никтофоб</Nyctophobe.degreeDatas.0.label>
   <Nyctophobe.degreeDatas.0.description>{PAWN_nameDef} очень боиться темноты.</Nyctophobe.degreeDatas.0.description>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/RCT_Traits.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/RCT_Traits.xml
@@ -56,7 +56,7 @@
 
   <EatingSpeed.degreeDatas.0.label>гурман</EatingSpeed.degreeDatas.0.label>
   <EatingSpeed.degreeDatas.0.description>{PAWN_nameDef} разборчив в пище. У {PAWN_possessive} уходит больше времени чтобы ее съесть.</EatingSpeed.degreeDatas.0.description>
-  <EatingSpeed.degreeDatas.1.label>обжора</EatingSpeed.degreeDatas.1.label>
+  <EatingSpeed.degreeDatas.1.label>едок</EatingSpeed.degreeDatas.1.label>
   <EatingSpeed.degreeDatas.1.description>{PAWN_nameDef} поглащает пищу быстрее обычного.</EatingSpeed.degreeDatas.1.description>
 
   <Nyctophobe.degreeDatas.0.label>никтофоб</Nyctophobe.degreeDatas.0.label>


### PR DESCRIPTION
1) Fix same name in russian localization for two different traits.

![same-name](https://user-images.githubusercontent.com/62516232/77857050-d663d280-7214-11ea-9d8e-6f6227b7a800.png)

2) Fix "поглащает" to "поглощает"