### PR TITLE
Delete wood planks from hand assembling workbench craft

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -2444,9 +2444,6 @@
 			<li>RuggedMetallic</li>
 		</stuffCategories>
 		<costStuffCount>125</costStuffCount>
-		<costList>
-			<WoodPlank>50</WoodPlank>
-		</costList>
 		<minifiedDef>MinifiedThing</minifiedDef>
 		<thingCategories>
 			<li>BuildingsProduction</li>


### PR DESCRIPTION
Imagine the next situation:
You choose start without totems, cairns and ship's chunks (some custom scenario, example);
- if you need some wood planks - you need to build hand sawmill;
- to build hand sawmill - you need some industrial components;
- to craft industrial components - you need to build hand assembling workbench;
- to build hand assembling workbench - you need 50 wood planks;
- to craft 50 wood planks - you need... oh wait... 
to build hand sawmill!
This weird I think.

Alternative ways to solve this problems:
1) delete industrial components from hand sawmill recipe craft;
2) adds industrial component recipe craft to craftsman table.

[RUS]
Предлагаю удалить деревянные доски из рецепта стола компонентов.
Представим следующую ситуацию:
Выбираем старт без тотемов, каирнов и обломков кораблей (например, какой-нибудь кастомный сценарий);
- чтобы получить деревянные доски - нужно построить ручную деревопилилку;
- чтобы построить деревопилилку - нужны компоненты;
- чтобы сделать компоненты - нужно построить стол компонентов;
- чтобы построить стол компонентов - нужно 50 деревянных досок;
- чтобы сделать 50 деревянных досок - нужно... ой... подождите ка...
построить деревопилилку!
Разве это не странно?

Альтернативные варианты решения данной проблемы:
1) удалить компоненты из крафта деревопилилки;
2) добавить крафт компонентов в какое-нибудь доступное место (например, рабочее место).