### PR TITLE
Fix Glitter Tech Shocking Melee infuse

### DIFF
--- a/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
@@ -5198,7 +5198,6 @@
          <key>MeleeWeapon_DamageMultiplier</key>
         <value>
           <multiplier>1.20</multiplier>
-          <offset>12</offset>
         </value>
       </li>
     </stats>


### PR DESCRIPTION
[ENG]
Fix Glitter Tech Shocking Melee infuse.
It was very-very-very powerful infuse (+1200 % (!!!)...).
[RUS]
Исправил зачарование ГиперТех шокирующий.
Он был слишком мощным (+1200 % (!!!)...).
- до фикса:
https://i.ibb.co/527VfsK/image.png
- после фикса:
https://i.ibb.co/NyqW69d/image.png
Почти 10-кратная разница в уроне была...