### PR TITLE
Fix Thermobaric 30x64 mm ammo. It's not exlosing.

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/30x64mmFuelCell.xml
@@ -125,6 +125,7 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Base30x64mmFuelBullet">
 		<defName>Bullet_30x64mmFuel_Thermobaric</defName>
+		<thingClass>CombatExtended.ProjectileCE_Explosive</thingClass>
 		<label>thermobaric bolt</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>2</explosionRadius>


### PR DESCRIPTION
Fix Thermobaric 30x64 mm ammo. Its not exlosing.

Исправил термобарические 30х64 мм боеприпасы (Солнцепёк). Не взрывались при контакте.