### PR TITLE
Add android leather armor stats

### DIFF
--- a/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
@@ -315,7 +315,9 @@
 		</graphicData>
 		<statBases>
 			<MarketValue>5.4</MarketValue>
-			<StuffPower_Armor_Sharp>0.24</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Sharp>0.81</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Blunt>0.81</StuffPower_Armor_Blunt>
+			<StuffPower_Armor_Heat>0.15</StuffPower_Armor_Heat>
 			<StuffPower_Insulation_Cold>12</StuffPower_Insulation_Cold>
 			<StuffPower_Insulation_Heat>12</StuffPower_Insulation_Heat>
 		</statBases>


### PR DESCRIPTION
Add android leather armor stats. It's had 150% heat armor and no have any sharp and blunt armor.

Добавил кожи андроидов броню. У неё было 150% защиты от нагрева (которую она подтягивала из ванильной "LeatherBase") и не было вообще никакой защиты от удара и проникновения. Добавил немного.
https://i.ibb.co/xDqZYmt/image.png