### PR TITLE
Light boost to GlitterTech dam0-dam5 infused

### DIFF
--- a/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
@@ -503,6 +503,7 @@
          <key>MeleeWeapon_DamageMultiplier</key>
         <value>
           <multiplier>1.03</multiplier>
+          <offset>1.02</offset>
         </value>
       </li>
     </stats>
@@ -1446,6 +1447,7 @@
          <key>MeleeWeapon_DamageMultiplier</key>
         <value>
           <multiplier>1.06</multiplier>
+          <offset>1.04</offset>
         </value>
       </li>
     </stats>
@@ -2411,6 +2413,7 @@
          <key>MeleeWeapon_DamageMultiplier</key>
         <value>
           <multiplier>1.09</multiplier>
+          <offset>1.06</offset>
         </value>
       </li>
     </stats>
@@ -3340,6 +3343,7 @@
          <key>MeleeWeapon_DamageMultiplier</key>
         <value>
           <multiplier>1.12</multiplier>
+          <offset>1.08</offset>
         </value>
       </li>
     </stats>
@@ -4269,6 +4273,7 @@
          <key>MeleeWeapon_DamageMultiplier</key>
         <value>
           <multiplier>1.15</multiplier>
+          <offset>1.1</offset>
         </value>
       </li>
     </stats>
@@ -5198,6 +5203,7 @@
          <key>MeleeWeapon_DamageMultiplier</key>
         <value>
           <multiplier>1.20</multiplier>
+          <offset>1.12</offset>
         </value>
       </li>
     </stats>


### PR DESCRIPTION
Light boost GlitterTech dam0-dam5 infused.
Before Infused_SK update this infusions give two type damage boost:
- multiplier damage boost;
- flat damage boost.

After Infused_SK update flat damage boost was deleted and GlitterTech dam0-dam5 became worst melee infusion with high market price boost.
I offer to return second damage mod to this infusions type.
Example GlitterTech dam5 after this patch: https://i.ibb.co/0tbh4fX/image.png
Before: https://i.ibb.co/NyqW69d/image.png

Небольшой буст зачарования типа ГиперТех dam0-dam5.
До обновления мода Infused_SK, данные типы зачарования давали два усиления урона в ближнем бою:
- множитель;
- чистая прибавка к урону.

После обновления этого мода, чистая прибавка к урону стала работать как % прибавка и была впоследствии удалена.
Теперь данное зачарование является одним из худших, если сравнивать с остальными.
Пример:
- топовый модификатор из этой серии GlitterTech dam5:
https://i.ibb.co/NyqW69d/image.png

он дает множитель 120% и... больше ничего, при этом множитель стоимости составляет 250% как у других более мощных артефактных зачарований.
Вот другие зачарования:
- сгибатель:
https://user-images.githubusercontent.com/46481732/80784802-e447a300-8b86-11ea-83ce-a1855abaae18.png

дает больший множитель урона + другие бонусы;
- гипертех продвинутый:
https://user-images.githubusercontent.com/46481732/80785365-b5323100-8b88-11ea-9480-05fa4d783241.png

дает чуть меньше урона, но сильно бустит точность.

Предлагаю вернуть исходную задумку GlitterTech dam0-dam5 - в добавке чистого и грубого урона. Пусть будет урон и ничего больше, кроме урона.
Пример топового GlitterTech dam5 модификатора после данного исправления:
https://i.ibb.co/0tbh4fX/image.png
предлагаю пока что усилить таким образом. Если покажется слабым усилением, до позже усилить ещё немного.