### PR TITLE
Fix ancient infusion

### DIFF
--- a/Mods/Infused_SK/Defs/InfusionDefs/MedievalEnchanted.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/MedievalEnchanted.xml
@@ -1325,13 +1325,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <multiplier>3.3</multiplier>
+          <multiplier>0.25</multiplier>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <multiplier>3.3</multiplier>
+          <multiplier>0.25</multiplier>
         </value>
       </li>
     </stats>


### PR DESCRIPTION
Fix ancient infusion. Now it give 330% armor multiplier.
https://cdn.discordapp.com/attachments/272924909649395712/705856661499412622/unknown.png
In early infusion version it gave 25% armor multiplier. Return it.

Исправил множитель брони у зачарования "Древний". В старых версиях он имел множитель 25%, после обновления Infused - стал 330%. Возвращаю 25%.