### PR TITLE
Fix some thermal wrapping stats and categories

### DIFF
--- a/Mods/Androids/Defs/ThingDefs/Apparel_Android.xml
+++ b/Mods/Androids/Defs/ThingDefs/Apparel_Android.xml
@@ -12,7 +12,7 @@
 		<costStuffCount>15</costStuffCount>
 		<stuffCategories>
 			<li>Fabric</li>
-			<li>Leathery</li>
+			<li>HF</li>
 		</stuffCategories>
 		<tradeability>Sellable</tradeability>
 		<statBases>
@@ -24,9 +24,17 @@
 			<EquipDelay>2.6</EquipDelay>	
 			<Insulation_Heat>5</Insulation_Heat>
 			<Insulation_Cold>5</Insulation_Cold>
-			<StuffEffectMultiplierArmor>0.08</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>0.8</StuffEffectMultiplierArmor>
 			<StuffEffectMultiplierInsulation_Cold>0.20</StuffEffectMultiplierInsulation_Cold>
 		</statBases>
+		<equippedStatOffsets>
+			<CarryBulk>5</CarryBulk>
+			<PsychicSensitivity>-0.03</PsychicSensitivity>
+			<MentalBreakThreshold>-0.02</MentalBreakThreshold>
+			<Suppressability>-0.05</Suppressability>
+			<ArmorRating_Toxin>0.02</ArmorRating_Toxin>
+			<Radiation>-0.01</Radiation>
+		</equippedStatOffsets>
 		<thingCategories>
 			<li>Apparel</li>
 		</thingCategories>


### PR DESCRIPTION
Fix some thermal wrapping stats and craft categories:
1) add some general stats (carrybulk, suppressability and other) like other apparels;
2) fix StuffEffectMultiplierArmor. It had old CE value;
3) replace "Leather" from craft to "HF" (thermal wrapping craft unlock only after android printer research and can't be created from spacer stuff, but you can craft it from neolithic leather... for real? :) )

Пофиксил некоторые параметры и изменил категорию крафта у Термической шали:
1) добавил основные статы по аналогии с другой одеждой (переносимый объем, подавляемость и т.д., добавил чуть-чуть, т.к. шаль слабовато походит на одежду, но все же обидно, что она ничего не дает);
2) пофиксил значение множителя брони материала, он был из старой версии CE;
3) заменил крафтовую категорию "Кожа" на "Высокотехнологичный текстиль" (крафт термической шали открывается после исследования принтера андроидов (в позднем лейте, это космическая эра уже) и не может быть создана из высокотехнологичных материалов, но может быть при этом сделана из обычной кожи эры неолита... серьезно? :) )