### PR TITLE
Ceramic floor bug fix

### DIFF
--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorStone.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorStone.xml
@@ -625,7 +625,7 @@ Beauty: 5.</description>
 Beauty: 5.</description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites>
-			<li>FloorArtII</li>
+			<li>FloorArtIII</li>
 		</researchPrerequisites>
 		<statBases>
 			<WorkToBuild>1200</WorkToBuild>


### PR DESCRIPTION
Поправил баг, с керамическим полом случайного мощения, который открывался тир 2 технологией, а не тир 3, как остальные полы того же типа.

I fixed a bug with a random-paving ceramic floor, which was opened by Tier 2 technology, and not Tier 3, like the rest of the floors of the same type.