### PR TITLE
Fix droids melee armor penetration

### DIFF
--- a/Mods/Androids/Defs/AlienRace/AlienRace_Droids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Droids.xml
@@ -168,7 +168,7 @@
 						</li>
 					</extraMeleeDamages>
 				</surpriseAttack>
-				<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+				<armorPenetrationBlunt>1.36</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>right fist</label>
@@ -186,7 +186,7 @@
 						</li>
 					</extraMeleeDamages>
 				</surpriseAttack>
-				<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+				<armorPenetrationBlunt>1.36</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>head</label>
@@ -197,7 +197,7 @@
 				<cooldownTime>2.8</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<chanceFactor>0.2</chanceFactor>
-				<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+				<armorPenetrationBlunt>1.3</armorPenetrationBlunt>
 				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 			</li>
 		</tools>
@@ -503,8 +503,8 @@
 						</li>
 					</extraMeleeDamages>
 				</surpriseAttack>
-				<armorPenetrationBlunt>1.44</armorPenetrationBlunt>
-				<armorPenetrationSharp>0.32</armorPenetrationSharp>
+				<armorPenetrationBlunt>9.44</armorPenetrationBlunt>
+				<armorPenetrationSharp>4.32</armorPenetrationSharp>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>right bladed fist</label>
@@ -522,8 +522,8 @@
 						</li>
 					</extraMeleeDamages>
 				</surpriseAttack>
-				<armorPenetrationBlunt>1.44</armorPenetrationBlunt>
-				<armorPenetrationSharp>0.32</armorPenetrationSharp>
+				<armorPenetrationBlunt>9.44</armorPenetrationBlunt>
+				<armorPenetrationSharp>4.32</armorPenetrationSharp>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>head</label>
@@ -534,7 +534,7 @@
 				<cooldownTime>2.8</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<chanceFactor>0.2</chanceFactor>
-				<armorPenetrationBlunt>1</armorPenetrationBlunt>
+				<armorPenetrationBlunt>2</armorPenetrationBlunt>
 				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 			</li>
 		</tools>


### PR DESCRIPTION
It was lesser than other races and some medieval weapon.

Исправил бронепробитие дроидов врукопашную. Значения были ниже, чем у других рас и некоторого оружия средневековья.