### PR TITLE
Some changes to new diseases system (1.0)

### DIFF
--- a/Mods/Androids/Defs/ThingDefs/Apparel_Android.xml
+++ b/Mods/Androids/Defs/ThingDefs/Apparel_Android.xml
@@ -34,6 +34,8 @@
 			<Suppressability>-0.05</Suppressability>
 			<ArmorRating_Toxin>0.02</ArmorRating_Toxin>
 			<Radiation>-0.01</Radiation>
+			<GermResistance>0.01</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<thingCategories>
 			<li>Apparel</li>

--- a/Mods/CombatExtended/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Mods/CombatExtended/Defs/HediffDefs/Hediffs_CE.xml
@@ -6,8 +6,8 @@
   <HediffDef>
     <defName>WearingGasMask</defName>
     <hediffClass>HediffWithComps</hediffClass>
-    <defaultLabelColor>(0.88, 0.88, 0.88)</defaultLabelColor>
-    <label>mask</label>
+    <defaultLabelColor>(0.88, 0.83, 0.78)</defaultLabelColor>
+    <label>heavy mask</label>
     <makesSickThought>false</makesSickThought>
     <scenarioCanAdd>false</scenarioCanAdd>
     <stages>
@@ -26,6 +26,35 @@
           <li>
             <capacity>Talking</capacity>
             <offset>-0.15</offset>
+          </li>
+        </capMods>
+      </li>
+    </stages>
+  </HediffDef>
+
+  <HediffDef>
+    <defName>WearingLightGasMask</defName>
+    <hediffClass>HediffWithComps</hediffClass>
+    <defaultLabelColor>(0.78, 0.83, 0.88)</defaultLabelColor>
+    <label>light mask</label>
+    <makesSickThought>false</makesSickThought>
+    <scenarioCanAdd>false</scenarioCanAdd>
+    <stages>
+      <li>
+        <label>wearing</label>
+        <minSeverity>0</minSeverity>
+        <capMods>
+          <li>
+            <capacity>Breathing</capacity>
+            <offset>-0.1</offset>
+          </li>
+          <li>
+            <capacity>Sight</capacity>
+            <offset>-0.04</offset>
+          </li>
+          <li>
+            <capacity>Talking</capacity>
+            <offset>-0.06</offset>
           </li>
         </capMods>
       </li>

--- a/Mods/CombatExtended/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Mods/CombatExtended/Defs/HediffDefs/Hediffs_CE.xml
@@ -7,7 +7,7 @@
     <defName>WearingGasMask</defName>
     <hediffClass>HediffWithComps</hediffClass>
     <defaultLabelColor>(0.88, 0.83, 0.78)</defaultLabelColor>
-    <label>heavy mask</label>
+    <label>mask</label>
     <makesSickThought>false</makesSickThought>
     <scenarioCanAdd>false</scenarioCanAdd>
     <stages>

--- a/Mods/CombatExtended/Languages/Russian/DefInjected/HediffDefs/Hediffs_CE.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/HediffDefs/Hediffs_CE.xml
@@ -1,6 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
+	<WearingLightGasMask.label>Облегченная маска</WearingLightGasMask.label>
+	<WearingLightGasMask.stages.0.label>надета</WearingLightGasMask.stages.0.label>
+
 	<WearingGasMask.label>Маска</WearingGasMask.label>
 	<WearingGasMask.stages.0.label>надета</WearingGasMask.stages.0.label>
 

--- a/Mods/Core_SK/Defs/HediffGiverSetDefs/HediffGiverSets_Diseases.xml
+++ b/Mods/Core_SK/Defs/HediffGiverSetDefs/HediffGiverSets_Diseases.xml
@@ -8,7 +8,7 @@
 	  <li Class="SK.HediffGiver_CommunicateDiseaseDirect">
 		<diseaseDef>Animal_Flu</diseaseDef>
 		<diseaseFilth>Filth_AnimalFluGerms</diseaseFilth>
-		<germDropRate>50</germDropRate>
+		<germDropRate>45</germDropRate>
 		<humanlikeDisease>false</humanlikeDisease>
 		<animalDisease>true</animalDisease>
 	  </li>
@@ -17,7 +17,7 @@
 	  <li Class="SK.HediffGiver_CommunicateDiseaseDirect">
 		<diseaseDef>Animal_Plague</diseaseDef>
 		<diseaseFilth>Filth_AnimalPlagueGerms</diseaseFilth>
-		<germDropRate>50</germDropRate>
+		<germDropRate>45</germDropRate>
 		<humanlikeDisease>false</humanlikeDisease>
 		<animalDisease>true</animalDisease>
 	  </li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
@@ -130,6 +130,7 @@
 			<MeleeHitChance>0.1</MeleeHitChance>
 			<NegotiationAbility>0.08</NegotiationAbility>
 			<TradePriceImprovement>0.07</TradePriceImprovement>
+			<GermResistance>0.02</GermResistance>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -205,6 +206,7 @@
 			<MeleeHitChance>0.1</MeleeHitChance>
 			<NegotiationAbility>0.05</NegotiationAbility>
 			<TradePriceImprovement>0.05</TradePriceImprovement>
+			<GermResistance>0.02</GermResistance>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -280,6 +282,8 @@
 			<ShootingAccuracyPawn>0.07</ShootingAccuracyPawn>
 			<AimingDelayFactor>-0.03</AimingDelayFactor>
 			<MeleeHitChance>0.05</MeleeHitChance>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -532,6 +536,7 @@
 			<MedicalTendSpeed>0.1</MedicalTendSpeed>
 			<MedicalTendQuality>0.05</MedicalTendQuality>
 			<MedicalSurgerySuccessChance>0.05</MedicalSurgerySuccessChance>
+			<GermResistance>0.03</GermResistance>
 		</equippedStatOffsets>
 		<generateCommonality>0.5</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Industrial.xml
@@ -44,6 +44,8 @@
 			<MeleeHitChance>-0.06</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.11</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.15</Suppressability>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -145,6 +147,8 @@
 			<MedicalTendSpeed>0.2</MedicalTendSpeed>
 			<MedicalTendQuality>0.1</MedicalTendQuality>
 			<MedicalSurgerySuccessChance>0.1</MedicalSurgerySuccessChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.2</generateCommonality>
 		<apparel>
@@ -217,6 +221,8 @@
 			<FoodPoisonChance>-0.100</FoodPoisonChance>
 			<DrugCookingSpeed>0.3</DrugCookingSpeed>
 			<ButcheryFleshSpeed>0.3</ButcheryFleshSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>0.1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Medieval.xml
@@ -44,6 +44,8 @@
 			<TradePriceImprovement>0.2</TradePriceImprovement>
 			<MeleeHitChance>-0.3</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.35</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -117,6 +119,8 @@
 			<AimingDelayFactor>0.06</AimingDelayFactor>
 			<MeleeHitChance>-0.05</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.04</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -199,6 +203,8 @@
 			<AimingDelayFactor>0.03</AimingDelayFactor>
 			<MeleeHitChance>-0.04</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.03</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.5</generateCommonality>
 		<apparel>
@@ -280,6 +286,8 @@
 			<AimingDelayFactor>0.03</AimingDelayFactor>
 			<MeleeHitChance>-0.04</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.03</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -360,6 +368,8 @@
 			<AimingDelayFactor>0.03</AimingDelayFactor>
 			<MeleeHitChance>-0.03</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.03</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -462,6 +472,8 @@
 			<AimingDelayFactor>0.03</AimingDelayFactor>
 			<MeleeHitChance>-0.03</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.03</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.5</generateCommonality>
 		<apparel>
@@ -564,6 +576,8 @@
 			<MoveSpeed>-0.11</MoveSpeed>
 			<WorkSpeedGlobal>-0.06</WorkSpeedGlobal>
 			<AimingDelayFactor>-0.07</AimingDelayFactor>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.8</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Neolitic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Neolitic.xml
@@ -40,6 +40,8 @@
 			<AimingDelayFactor>0.02</AimingDelayFactor>
 			<MeleeHitChance>-0.02</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.02</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.5</generateCommonality>
 		<apparel>
@@ -105,6 +107,8 @@
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
 			<SocialImpact>-0.1</SocialImpact>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2.8</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Spacer.xml
@@ -52,6 +52,8 @@
 			<MeleeWeapon_CooldownMultiplier>0.06</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.16</Suppressability>
 			<ArmorRating_Toxin>0.15</ArmorRating_Toxin>
+			<GermResistance>0.05</GermResistance>
+			<GermContainment>0.05</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.6</generateCommonality>
 		<apparel>
@@ -143,6 +145,8 @@
 			<ImmunityGainSpeed>0.2</ImmunityGainSpeed>
 			<Suppressability>-0.2</Suppressability>
 			<ArmorRating_Toxin>0.16</ArmorRating_Toxin>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.15</generateCommonality>
 		<apparel>
@@ -265,6 +269,8 @@
 			<ImmunityGainSpeed>0.2</ImmunityGainSpeed>
 			<Suppressability>-0.22</Suppressability>
 			<ArmorRating_Toxin>0.16</ArmorRating_Toxin>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.1</generateCommonality>
 		<apparel>
@@ -355,6 +361,8 @@
 			<MeleeWeapon_CooldownMultiplier>0.03</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.17</Suppressability>
 			<ArmorRating_Toxin>0.18</ArmorRating_Toxin>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.4</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
@@ -37,6 +37,8 @@
 			<WorkSpeedGlobal>0.1</WorkSpeedGlobal>
 			<SocialImpact>-0.02</SocialImpact>
 			<MentalBreakThreshold>0.02</MentalBreakThreshold>
+			<GermResistance>0.01</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -95,6 +97,8 @@
 			<WorkSpeedGlobal>0.12</WorkSpeedGlobal>
 			<SocialImpact>0.04</SocialImpact>
 			<MentalBreakThreshold>-0.03</MentalBreakThreshold>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -155,6 +159,8 @@
 		<equippedStatOffsets>
 			<MoveSpeed>-0.07</MoveSpeed>
 			<WorkSpeedGlobal>0.04</WorkSpeedGlobal>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -229,6 +235,8 @@
 			<WorkSpeedGlobal>0.05</WorkSpeedGlobal>
 			<SocialImpact>0.05</SocialImpact>
 			<MentalBreakThreshold>-0.05</MentalBreakThreshold>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -290,6 +298,8 @@
 			<WorkSpeedGlobal>0.12</WorkSpeedGlobal>
 			<SocialImpact>0.05</SocialImpact>
 			<MentalBreakThreshold>-0.05</MentalBreakThreshold>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -359,6 +369,8 @@
 			<WorkSpeedGlobal>0.12</WorkSpeedGlobal>
 			<SocialImpact>0.05</SocialImpact>
 			<MentalBreakThreshold>-0.05</MentalBreakThreshold>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -425,6 +437,8 @@
 			<WorkSpeedGlobal>.15</WorkSpeedGlobal>
 			<SocialImpact>0.07</SocialImpact>
 			<MentalBreakThreshold>-0.07</MentalBreakThreshold>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -488,6 +502,8 @@
 			<MoveSpeed>0.05</MoveSpeed>
 			<WorkSpeedGlobal>0.12</WorkSpeedGlobal>
 			<MentalBreakThreshold>0.01</MentalBreakThreshold>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -554,6 +570,8 @@
 			<WorkSpeedGlobal>0.2</WorkSpeedGlobal>
 			<SocialImpact>0.07</SocialImpact>
 			<MentalBreakThreshold>-0.07</MentalBreakThreshold>
+			<GermResistance>0.05</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -625,6 +643,8 @@
 			<WorkSpeedGlobal>0.15</WorkSpeedGlobal>
 			<SocialImpact>0.07</SocialImpact>
 			<MentalBreakThreshold>-0.07</MentalBreakThreshold>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Feral.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Feral.xml
@@ -36,6 +36,8 @@
 			<SocialImpact>-0.2</SocialImpact>
 			<TrainAnimalChance>0.11</TrainAnimalChance>
 			<TameAnimalChance>0.13</TameAnimalChance>
+			<GermResistance>0.1</GermResistance>
+			<GermContainment>0.15</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -108,6 +110,8 @@
 			<SocialImpact>-0.2</SocialImpact>
 			<TrainAnimalChance>0.11</TrainAnimalChance>
 			<TameAnimalChance>0.13</TameAnimalChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -180,6 +184,8 @@
 			<SocialImpact>-0.2</SocialImpact>
 			<TrainAnimalChance>0.11</TrainAnimalChance>
 			<TameAnimalChance>0.13</TameAnimalChance>
+			<GermResistance>0.1</GermResistance>
+			<GermContainment>0.15</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -256,6 +262,8 @@
 			<SocialImpact>-0.2</SocialImpact>
 			<TrainAnimalChance>0.10</TrainAnimalChance>
 			<TameAnimalChance>0.12</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -388,6 +396,8 @@
 			<AimingDelayFactor>0.15</AimingDelayFactor>
 			<MeleeHitChance>-0.25</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.26</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.1</generateCommonality>
 		<apparel>
@@ -456,6 +466,8 @@
 			<AimingDelayFactor>0.15</AimingDelayFactor>
 			<MeleeHitChance>-0.25</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.26</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.2</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Industrial.xml
@@ -48,6 +48,8 @@
 			<MeleeWeapon_CooldownMultiplier>0.21</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.17</Suppressability>
 			<ArmorRating_Toxin>0.25</ArmorRating_Toxin>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Medieval.xml
@@ -43,6 +43,8 @@
 			<MeleeHitChance>-0.07</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.05</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.12</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -126,6 +128,8 @@
 			<MeleeHitChance>-0.12</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.11</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.08</Suppressability>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2.4</generateCommonality>
 		<apparel>
@@ -202,6 +206,8 @@
 			<MeleeHitChance>-0.15</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.15</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.09</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2.4</generateCommonality>
 		<apparel>
@@ -277,6 +283,8 @@
 			<MoveSpeed>-0.1</MoveSpeed>
 			<WorkSpeedGlobal>-0.05</WorkSpeedGlobal>
 			<Suppressability>-0.08</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -378,6 +386,8 @@
 			<MeleeHitChance>-0.12</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.15</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.11</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2.2</generateCommonality>
 		<apparel>
@@ -462,6 +472,8 @@
 			<MeleeHitChance>-0.18</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.2</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.13</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2.1</generateCommonality>
 		<apparel>
@@ -545,6 +557,8 @@
 			<MeleeHitChance>-0.27</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.28</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.12</Suppressability>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>3</generateCommonality>
 		<apparel>
@@ -630,6 +644,8 @@
 			<MeleeHitChance>-0.15</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.15</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.08</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>3.4</generateCommonality>
 		<apparel>
@@ -717,6 +733,8 @@
 			<MeleeHitChance>-0.18</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.21</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.11</Suppressability>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<thingCategories>
 			<li>HeavyFullArmorCat</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Spacer.xml
@@ -57,6 +57,8 @@
 			<Suppressability>-0.23</Suppressability>
 			<ArmorRating_Toxin>0.35</ArmorRating_Toxin>
 			<Radiation>-0.25</Radiation>
+			<GermResistance>0.05</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -142,6 +144,8 @@
 			<Suppressability>-0.22</Suppressability>
 			<ArmorRating_Toxin>0.4</ArmorRating_Toxin>
 			<Radiation>-0.3</Radiation>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -243,6 +247,8 @@
 			<Suppressability>-0.24</Suppressability>
 			<ArmorRating_Toxin>0.4</ArmorRating_Toxin>
 			<Radiation>-0.35</Radiation>
+			<GermResistance>0.05</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -335,6 +341,8 @@
 			<Suppressability>-0.23</Suppressability>
 			<ArmorRating_Toxin>0.4</ArmorRating_Toxin>
 			<Radiation>-0.2</Radiation>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -433,6 +441,8 @@
 			<Suppressability>-0.24</Suppressability>
 			<ArmorRating_Toxin>0.45</ArmorRating_Toxin>
 			<Radiation>-0.35</Radiation>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -542,6 +552,8 @@
 			<Suppressability>-0.19</Suppressability>
 			<ArmorRating_Toxin>0.3</ArmorRating_Toxin>
 			<Radiation>-0.25</Radiation>
+			<GermResistance>0.05</GermResistance>
+			<GermContainment>0.05</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -637,6 +649,8 @@
 			<Suppressability>-0.31</Suppressability>
 			<ArmorRating_Toxin>0.5</ArmorRating_Toxin>
 			<Radiation>-0.3</Radiation>
+			<GermResistance>0.05</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -741,6 +755,8 @@
 			<Suppressability>-0.32</Suppressability>
 			<ArmorRating_Toxin>0.5</ArmorRating_Toxin>
 			<Radiation>-0.3</Radiation>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -838,6 +854,8 @@
 			<Suppressability>-0.24</Suppressability>
 			<ArmorRating_Toxin>0.35</ArmorRating_Toxin>
 			<Radiation>-0.3</Radiation>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.05</GermContainment>
 		</equippedStatOffsets>
 		<thingCategories>
 			<li>HeavyFullArmorCat</li>
@@ -940,6 +958,8 @@
 			<Suppressability>-0.22</Suppressability>
 			<ArmorRating_Toxin>0.4</ArmorRating_Toxin>
 			<Radiation>-0.3</Radiation>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.05</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.2</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Industrial.xml
@@ -485,7 +485,7 @@
 		</thingCategories>
 		<modExtensions>
 			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
+				<hediff>WearingLightGasMask</hediff>
 			</li>
 		</modExtensions>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Spacer.xml
@@ -80,11 +80,6 @@
 			<li>HeavyHelmetsCat</li>
 			<li>Setpowerarmor</li>
 		</thingCategories>
-		<modExtensions>
-			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
-			</li>
-		</modExtensions>
 	</ThingDef>
 
 	<ThingDef ParentName="ArmorSpacerSimpleBase">
@@ -110,7 +105,7 @@
 			<WorkToMake>18000</WorkToMake>
 			<MaxHitPoints>90</MaxHitPoints>
 			<Flammability>1</Flammability>
-			<Mass>1</Mass>
+			<Mass>1.2</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.9</EquipDelay>
@@ -240,8 +235,8 @@
 			<ToxicSensitivity>-0.5</ToxicSensitivity>
 			<SmokeSensitivity>-1</SmokeSensitivity>
 			<Radiation>-0.3</Radiation>
-			<GermResistance>0.70</GermResistance>
-			<GermContainment>0.80</GermContainment>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -280,11 +275,6 @@
 			<li>HeavyHelmetsCat</li>
 			<li>SetCombatarmor</li>
 		</thingCategories>
-		<modExtensions>
-			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
-			</li>
-		</modExtensions>
 	</ThingDef>
 
 
@@ -373,11 +363,6 @@
 		<thingCategories>
 			<li>SpecialHelmetsCat</li>
 		</thingCategories>
-		<modExtensions>
-			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
-			</li>
-		</modExtensions>
 	</ThingDef>
 
 
@@ -466,11 +451,6 @@
 		<thingCategories>
 			<li>SpecialHelmetsCat</li>
 		</thingCategories>
-		<modExtensions>
-			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
-			</li>
-		</modExtensions>
 	</ThingDef>
 
 
@@ -525,11 +505,11 @@
 			<ImmunityGainSpeed>0.15</ImmunityGainSpeed>
 			<Suppressability>-0.12</Suppressability>
 			<ArmorRating_Toxin>0.2</ArmorRating_Toxin>
-			<ToxicSensitivity>-0.5</ToxicSensitivity>
+			<ToxicSensitivity>-0.45</ToxicSensitivity>
 			<SmokeSensitivity>-1</SmokeSensitivity>
 			<Radiation>-0.4</Radiation>
-			<GermResistance>0.70</GermResistance>
-			<GermContainment>0.80</GermContainment>
+			<GermResistance>0.65</GermResistance>
+			<GermContainment>0.75</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -566,7 +546,7 @@
 		</thingCategories>
 		<modExtensions>
 			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
+				<hediff>WearingLightGasMask</hediff>
 			</li>
 		</modExtensions>
 	</ThingDef>
@@ -656,11 +636,6 @@
 		<thingCategories>
 			<li>SpecialHelmetsCat</li>
 		</thingCategories>
-		<modExtensions>
-			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
-			</li>
-		</modExtensions>
 	</ThingDef>
 
 
@@ -686,7 +661,7 @@
 			<WorkToMake>15000</WorkToMake>
 			<MaxHitPoints>90</MaxHitPoints>
 			<Flammability>1</Flammability>
-			<Mass>1</Mass>
+			<Mass>1.1</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.5</EquipDelay>
@@ -780,7 +755,7 @@
 			<WorkToMake>16000</WorkToMake>
 			<MaxHitPoints>90</MaxHitPoints>
 			<Flammability>1</Flammability>
-			<Mass>1</Mass>
+			<Mass>1.15</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.8</EquipDelay>
@@ -995,7 +970,7 @@
 			<EnergyShieldEnergyMax>0.5</EnergyShieldEnergyMax>
 			<MaxHitPoints>60</MaxHitPoints>
 			<Flammability>1</Flammability>
-			<Mass>1</Mass>
+			<Mass>1.05</Mass>
 			<Bulk>3</Bulk>
 			<WornBulk>0</WornBulk>
 			<EquipDelay>2.3</EquipDelay>
@@ -1003,9 +978,9 @@
 			<Insulation_Cold>5</Insulation_Cold>
 			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
-			<StuffEffectMultiplierArmor>5.06</StuffEffectMultiplierArmor>
-			<ArmorRating_Sharp>10.12</ArmorRating_Sharp>
-			<ArmorRating_Blunt>28.842</ArmorRating_Blunt>
+			<StuffEffectMultiplierArmor>7.06</StuffEffectMultiplierArmor>
+			<ArmorRating_Sharp>12.12</ArmorRating_Sharp>
+			<ArmorRating_Blunt>34.842</ArmorRating_Blunt>
 			<ArmorRating_Heat>0.08</ArmorRating_Heat>
 		</statBases>
 		<equippedStatOffsets>
@@ -1087,7 +1062,7 @@
 			<EnergyShieldEnergyMax>0.9</EnergyShieldEnergyMax>
 			<MaxHitPoints>64</MaxHitPoints>
 			<Flammability>1</Flammability>
-			<Mass>1</Mass>
+			<Mass>1.1</Mass>
 			<Bulk>4</Bulk>
 			<WornBulk>1</WornBulk>
 			<EquipDelay>2.6</EquipDelay>
@@ -1095,9 +1070,9 @@
 			<Insulation_Cold>5</Insulation_Cold>
 			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
-			<StuffEffectMultiplierArmor>4.75</StuffEffectMultiplierArmor>
-			<ArmorRating_Sharp>9.50</ArmorRating_Sharp>
-			<ArmorRating_Blunt>27.094</ArmorRating_Blunt>
+			<StuffEffectMultiplierArmor>6.75</StuffEffectMultiplierArmor>
+			<ArmorRating_Sharp>12.50</ArmorRating_Sharp>
+			<ArmorRating_Blunt>36.094</ArmorRating_Blunt>
 			<ArmorRating_Heat>0.085</ArmorRating_Heat>
 		</statBases>
 		<equippedStatOffsets>
@@ -1204,10 +1179,10 @@
 			<Suppressability>-0.10</Suppressability>
 			<ArmorRating_Toxin>0.2</ArmorRating_Toxin>
 			<ToxicSensitivity>-0.5</ToxicSensitivity>
-			<SmokeSensitivity>-1</SmokeSensitivity>
+			<SmokeSensitivity>-1.0</SmokeSensitivity>
 			<Radiation>-0.2</Radiation>
-			<GermResistance>0.70</GermResistance>
-			<GermContainment>0.80</GermContainment>
+			<GermResistance>0.60</GermResistance>
+			<GermContainment>0.70</GermContainment>
 		</equippedStatOffsets>	
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -1241,7 +1216,7 @@
 		</thingCategories>
 		<modExtensions>
 			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
+				<hediff>WearingLightGasMask</hediff>
 			</li>
 		</modExtensions>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Medieval.xml
@@ -42,6 +42,8 @@
 			<TradePriceImprovement>0.05</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -116,6 +118,8 @@
 			<TradePriceImprovement>0.05</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -189,6 +193,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Neolitic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Neolitic.xml
@@ -38,6 +38,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.11</TrainAnimalChance>
 			<TameAnimalChance>0.12</TameAnimalChance>
+			<GermResistance>0.01</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.1</generateCommonality>
 		<apparel>
@@ -112,6 +114,8 @@
 			<MeleeHitChance>-0.05</MeleeHitChance>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -188,6 +192,8 @@
 			<MeleeHitChance>-0.05</MeleeHitChance>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -260,6 +266,8 @@
 			<TradePriceImprovement>0.04</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -336,6 +344,8 @@
 			<TradePriceImprovement>0.05</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -411,6 +421,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.01</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.5</generateCommonality>
 		<apparel>
@@ -484,6 +496,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.01</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -556,6 +570,8 @@
 			<TradePriceImprovement>0.06</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Outlander.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Outlander.xml
@@ -44,6 +44,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -115,6 +117,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -185,6 +189,8 @@
 			<TradePriceImprovement>0.06</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -257,6 +263,8 @@
 			<TradePriceImprovement>0.04</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -335,6 +343,8 @@
 			<TradePriceImprovement>0.06</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -413,6 +423,8 @@
 			<TradePriceImprovement>0.08</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -480,6 +492,8 @@
 			<MarketValue>-0.3</MarketValue>
 			<WorkSpeedGlobal>-0.02</WorkSpeedGlobal>
 			<SocialImpact>-0.1</SocialImpact>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -550,6 +564,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -618,6 +634,8 @@
 			<GlobalLearningFactor>0.02</GlobalLearningFactor>
 			<NegotiationAbility>0.05</NegotiationAbility>
 			<TradePriceImprovement>0.02</TradePriceImprovement>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -694,6 +712,8 @@
 			<TradePriceImprovement>0.05</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -770,6 +790,8 @@
 			<DrugCookingSpeed>0.13</DrugCookingSpeed>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -834,6 +856,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -910,6 +934,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -985,6 +1011,8 @@
 			<TradePriceImprovement>0.2</TradePriceImprovement>
 			<TrainAnimalChance>0.05</TrainAnimalChance>
 			<TameAnimalChance>0.04</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -1058,6 +1086,8 @@
 			<TradePriceImprovement>0.08</TradePriceImprovement>
 			<TrainAnimalChance>0.11</TrainAnimalChance>
 			<TameAnimalChance>0.12</TameAnimalChance>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>0.8</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Spacer.xml
@@ -141,8 +141,8 @@
 			<ArmorRating_Toxin>0.1</ArmorRating_Toxin>
 			<ToxicSensitivity>-0.3</ToxicSensitivity>
 			<SmokeSensitivity>-1</SmokeSensitivity>
-			<GermResistance>0.55</GermResistance>
-			<GermContainment>0.75</GermContainment>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -173,11 +173,6 @@
 		<thingCategories>
 			<li>MediumHelmetsCat</li>
 		</thingCategories>
-		<modExtensions>
-			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
-			</li>
-		</modExtensions>
 	</ThingDef>
 
 
@@ -234,9 +229,9 @@
 			<Suppressability>-0.10</Suppressability>
 			<ArmorRating_Toxin>0.1</ArmorRating_Toxin>
 			<ToxicSensitivity>-0.3</ToxicSensitivity>
-			<SmokeSensitivity>-0.6</SmokeSensitivity>
-			<GermResistance>0.55</GermResistance>
-			<GermContainment>0.75</GermContainment>
+			<SmokeSensitivity>-0.55</SmokeSensitivity>
+			<GermResistance>0.50</GermResistance>
+			<GermContainment>0.70</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -261,7 +256,7 @@
 		</thingCategories>
 		<modExtensions>
 			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
+				<hediff>WearingLightGasMask</hediff>
 			</li>
 		</modExtensions>
 	</ThingDef>
@@ -488,8 +483,8 @@
 			<ArmorRating_Toxin>0.1</ArmorRating_Toxin>
 			<ToxicSensitivity>-0.2</ToxicSensitivity>
 			<SmokeSensitivity>-0.5</SmokeSensitivity>
-			<GermResistance>0.45</GermResistance>
-			<GermContainment>0.55</GermContainment>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -518,11 +513,6 @@
 		<thingCategories>
 			<li>MediumHelmetsCat</li>
 		</thingCategories>
-		<modExtensions>
-			<li Class="CombatExtended.ApparelHediffExtension">
-				<hediff>WearingGasMask</hediff>
-			</li>
-		</modExtensions>
 	</ThingDef>
 
 

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Spacer.xml
@@ -317,6 +317,8 @@
 			<MedicalSurgerySuccessChance>0.11</MedicalSurgerySuccessChance>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -402,6 +404,8 @@
 			<ConstructionSpeed>0.15</ConstructionSpeed>
 			<StonecuttingSpeed>0.15</StonecuttingSpeed>
 			<SmeltingSpeed>0.15</SmeltingSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
@@ -37,6 +37,8 @@
 			<MoveSpeed>-0.02</MoveSpeed>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -100,6 +102,8 @@
 			<MoveSpeed>-0.01</MoveSpeed>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2.7</generateCommonality>
 		<apparel>
@@ -161,6 +165,8 @@
 			<MoveSpeed>-0.02</MoveSpeed>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.03</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -223,6 +229,8 @@
 			<MoveSpeed>-0.02</MoveSpeed>
 			<TrainAnimalChance>0.11</TrainAnimalChance>
 			<TameAnimalChance>0.02</TameAnimalChance>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -287,6 +295,8 @@
 			<CarryBulk>5</CarryBulk>
 			<MoveSpeed>-0.02</MoveSpeed>
 			<PlantWorkSpeed>0.15</PlantWorkSpeed>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -352,6 +362,8 @@
 			<MoveSpeed>-0.015</MoveSpeed>
 			<ConstructionSpeed>0.1</ConstructionSpeed>
 			<MiningSpeed>0.1</MiningSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -439,6 +451,8 @@
 			<MoveSpeed>-0.025</MoveSpeed>
 			<MedicalOperationSpeed>0.03</MedicalOperationSpeed>
 			<MedicalTendSpeed>0.03</MedicalTendSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -507,6 +521,8 @@
 			<AimingDelayFactor>0.06</AimingDelayFactor>
 			<MeleeHitChance>-0.07</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.07</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -574,6 +590,8 @@
 			<TradePriceImprovement>0.1</TradePriceImprovement>
 			<TrainAnimalChance>0.1</TrainAnimalChance>
 			<TameAnimalChance>0.07</TameAnimalChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -647,6 +665,8 @@
 			<MeleeWeapon_CooldownMultiplier>0.03</MeleeWeapon_CooldownMultiplier>
 			<TrainAnimalChance>0.15</TrainAnimalChance>
 			<TameAnimalChance>0.11</TameAnimalChance>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs_Hightech.xml
@@ -45,6 +45,8 @@
 			<MeleeWeapon_CooldownMultiplier>0.04</MeleeWeapon_CooldownMultiplier>
 			<ConstructionSpeed>0.15</ConstructionSpeed>
 			<ArmorRating_Toxin>0.08</ArmorRating_Toxin>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -114,6 +116,8 @@
 			<MeleeHitChance>-0.04</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.04</MeleeWeapon_CooldownMultiplier>
 			<ArmorRating_Toxin>0.1</ArmorRating_Toxin>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.05</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -199,6 +203,8 @@
 			<MeleeWeapon_CooldownMultiplier>0.06</MeleeWeapon_CooldownMultiplier>
 			<ArmorRating_Toxin>0.12</ArmorRating_Toxin>
 			<Radiation>-0.05</Radiation>
+			<GermResistance>0.05</GermResistance>
+			<GermContainment>0.05</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Industrial.xml
@@ -37,6 +37,8 @@
 		<equippedStatOffsets>
 			<CarryBulk>7</CarryBulk>
 			<MoveSpeed>-0.02</MoveSpeed>
+			<GermResistance>0.1</GermResistance>
+			<GermContainment>0.1</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -100,6 +102,8 @@
 			<CarryBulk>10</CarryBulk>
 			<MoveSpeed>-0.09</MoveSpeed>
 			<WorkSpeedGlobal>-0.07</WorkSpeedGlobal>
+			<GermResistance>0.09</GermResistance>
+			<GermContainment>0.09</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>3</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Medieval.xml
@@ -35,6 +35,8 @@
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
 			<MoveSpeed>-0.01</MoveSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>5</generateCommonality>
 		<apparel>
@@ -101,6 +103,8 @@
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
 			<MoveSpeed>-0.03</MoveSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>4</generateCommonality>
 		<apparel>
@@ -163,6 +167,8 @@
 		<equippedStatOffsets>
 			<CarryBulk>8</CarryBulk>
 			<MoveSpeed>-0.03</MoveSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>4</generateCommonality>
 		<apparel>
@@ -226,6 +232,8 @@
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
 			<MoveSpeed>-0.01</MoveSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -305,6 +313,8 @@
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
 			<MoveSpeed>-0.01</MoveSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -383,6 +393,8 @@
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
 			<MoveSpeed>-0.01</MoveSpeed>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -500,6 +512,8 @@
 		<equippedStatOffsets>
 			<CarryBulk>10</CarryBulk>
 			<MoveSpeed>-0.015</MoveSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -570,6 +584,8 @@
 			<CarryBulk>10</CarryBulk>
 			<MoveSpeed>-0.04</MoveSpeed>
 			<WorkSpeedGlobal>-0.07</WorkSpeedGlobal>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -645,6 +661,8 @@
 			<MedicalTendQuality>0.20</MedicalTendQuality>
 			<MedicalTendSpeed>0.2</MedicalTendSpeed>
 			<MedicalOperationSpeed>0.2</MedicalOperationSpeed>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
@@ -41,6 +41,8 @@
 			<MoveSpeed>-0.07</MoveSpeed>
 			<WorkSpeedGlobal>-0.07</WorkSpeedGlobal>
 			<FixBrokenDownBuildingSuccessChance>-0.02</FixBrokenDownBuildingSuccessChance>
+			<GermResistance>0.1</GermResistance>
+			<GermContainment>0.1</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2.1</generateCommonality>
 		<apparel>
@@ -126,6 +128,8 @@
 			<CarryBulk>13</CarryBulk>
 			<MoveSpeed>-0.07</MoveSpeed>
 			<WorkSpeedGlobal>-0.07</WorkSpeedGlobal>
+			<GermResistance>0.11</GermResistance>
+			<GermContainment>0.11</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>3</generateCommonality>
 		<apparel>
@@ -216,6 +220,8 @@
 			<WorkSpeedGlobal>-0.06</WorkSpeedGlobal>
 			<PsychicSensitivity>-0.05</PsychicSensitivity>
 			<Radiation>-0.05</Radiation>
+			<GermResistance>0.1</GermResistance>
+			<GermContainment>0.1</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>3</generateCommonality>
 		<apparel>
@@ -300,6 +306,8 @@
 			<WorkSpeedGlobal>-0.03</WorkSpeedGlobal>
 			<PsychicSensitivity>-0.05</PsychicSensitivity>
 			<Radiation>-0.05</Radiation>
+			<GermResistance>0.1</GermResistance>
+			<GermContainment>0.1</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>3</generateCommonality>
 		<apparel>
@@ -401,6 +409,8 @@
 			<WorkSpeedGlobal>-0.05</WorkSpeedGlobal>
 			<PsychicSensitivity>-0.05</PsychicSensitivity>
 			<Radiation>-0.1</Radiation>
+			<GermResistance>0.11</GermResistance>
+			<GermContainment>0.11</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.5</generateCommonality>
 		<apparel>
@@ -483,6 +493,8 @@
 			<WorkSpeedGlobal>-0.07</WorkSpeedGlobal>
 			<PsychicSensitivity>-0.05</PsychicSensitivity>
 			<Radiation>-0.08</Radiation>
+			<GermResistance>0.1</GermResistance>
+			<GermContainment>0.1</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_SlaveOutfit.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_SlaveOutfit.xml
@@ -36,6 +36,8 @@
 			<MoveSpeed>-0.012</MoveSpeed>
 			<MarketValue>-0.3</MarketValue>
 			<SocialImpact>-0.05</SocialImpact>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>0.4</generateCommonality>
 		<apparel>
@@ -106,6 +108,8 @@
 			<MentalBreakThreshold>-0.05</MentalBreakThreshold>
 			<MoveSpeed>-0.055</MoveSpeed>
 			<WorkSpeedGlobal>0.05</WorkSpeedGlobal>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>0.6</generateCommonality>
 		<apparel>
@@ -170,6 +174,8 @@
 			<MentalBreakThreshold>-0.05</MentalBreakThreshold>
 			<MoveSpeed>-0.065</MoveSpeed>
 			<WorkSpeedGlobal>0.05</WorkSpeedGlobal>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>0.7</generateCommonality>
 		<apparel>
@@ -236,6 +242,8 @@
 			<MarketValue>-0.3</MarketValue>
 			<MoveSpeed>-0.025</MoveSpeed>
 			<WorkSpeedGlobal>0.06</WorkSpeedGlobal>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>0.6</generateCommonality>
 		<apparel>
@@ -308,6 +316,8 @@
 			<MoveSpeed>-0.02</MoveSpeed>
 			<WorkSpeedGlobal>0.07</WorkSpeedGlobal>
 			<MentalBreakThreshold>-0.08</MentalBreakThreshold>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>0.65</generateCommonality>
 		<apparel>
@@ -385,6 +395,8 @@
 			<MoveSpeed>-0.02</MoveSpeed>
 			<WorkSpeedGlobal>0.07</WorkSpeedGlobal>
 			<MentalBreakThreshold>-0.08</MentalBreakThreshold>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
 			<bodyPartGroups>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Special.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Special.xml
@@ -41,6 +41,8 @@
 			<NegotiationAbility>0.05</NegotiationAbility>
 			<TradePriceImprovement>0.06</TradePriceImprovement>
 			<MiningSpeed>0.20</MiningSpeed>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>0.01</generateCommonality>
 		<apparel>
@@ -187,6 +189,8 @@
 			<ToxicSensitivity>-0.4</ToxicSensitivity>
 			<Radiation>-0.4</Radiation>
 			<SocialImpact>-0.15</SocialImpact>
+			<GermResistance>0.09</GermResistance>
+			<GermContainment>0.09</GermContainment>
 		</equippedStatOffsets>
 		<comps>
 			<li Class="CompProperties_Forbiddable"/>
@@ -259,6 +263,8 @@
 			<AimingDelayFactor>0.05</AimingDelayFactor>
 			<MeleeHitChance>-0.05</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.07</MeleeWeapon_CooldownMultiplier>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<comps>
 			<li Class="CompProperties_Forbiddable"/>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
@@ -42,6 +42,8 @@
 			<MedicalTendSpeed>0.5</MedicalTendSpeed>
 			<MedicalTendQuality>0.15</MedicalTendQuality>
 			<MedicalSurgerySuccessChance>0.07</MedicalSurgerySuccessChance>
+			<GermResistance>0.04</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.2</generateCommonality>
 		<apparel>
@@ -117,6 +119,8 @@
 			<SculptingSpeed>0.15</SculptingSpeed>
 			<StonecuttingSpeed>0.07</StonecuttingSpeed>
 			<PlantWorkSpeed>0.15</PlantWorkSpeed>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.4</generateCommonality>
 		<apparel>
@@ -187,6 +191,8 @@
 			<DrugCookingSpeed>0.05</DrugCookingSpeed>
 			<ButcheryFleshSpeed>0.10</ButcheryFleshSpeed>
 			<ButcheryFleshEfficiency>0.10</ButcheryFleshEfficiency>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1.1</generateCommonality>
 		<apparel>
@@ -256,6 +262,8 @@
 			<MeleeHitChance>-0.05</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.04</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.08</Suppressability>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -337,6 +345,8 @@
 			<MeleeHitChance>-0.05</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.05</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.07</Suppressability>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -407,6 +417,8 @@
 			<MeleeHitChance>-0.1</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.1</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.11</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -470,6 +482,8 @@
 			<MeleeHitChance>-0.05</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.05</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.10</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>2</generateCommonality>
 		<apparel>
@@ -533,6 +547,8 @@
 			<MeleeHitChance>-0.11</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.12</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.09</Suppressability>
+			<GermResistance>0.02</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -616,6 +632,8 @@
 			<MeleeHitChance>-0.1</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.1</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.1</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>0.4</generateCommonality>
 		<apparel>
@@ -685,6 +703,8 @@
 			<MeleeHitChance>-0.13</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.12</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.14</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>
@@ -778,6 +798,8 @@
 			<MeleeHitChance>-0.14</MeleeHitChance>
 			<MeleeWeapon_CooldownMultiplier>0.12</MeleeWeapon_CooldownMultiplier>
 			<Suppressability>-0.15</Suppressability>
+			<GermResistance>0.03</GermResistance>
+			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<generateCommonality>1</generateCommonality>
 		<apparel>

--- a/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
+++ b/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
@@ -408,6 +408,7 @@
 					<MedicalTendQuality>0.2</MedicalTendQuality>
 					<MedicalOperationSpeed>-0.1</MedicalOperationSpeed>
 					<MedicalTendSpeed>-0.1</MedicalTendSpeed>
+					<GermContainment>0.15</GermContainment>
 				</statOffsets>
 				<skillGains>
 					<li><key>Cooking</key><value>2</value></li>
@@ -534,6 +535,7 @@
 				<statOffsets>
 					<MedicalSurgerySuccessChance>0.2</MedicalSurgerySuccessChance>
 					<MedicalTendQuality>0.2</MedicalTendQuality>
+					<GermContainment>0.1</GermContainment>
 				</statOffsets>
 				<skillGains>
 					<li><key>Medicine</key><value>2</value></li>
@@ -549,6 +551,7 @@
 					<MedicalSurgerySuccessChance>0.4</MedicalSurgerySuccessChance>
 					<MedicalTendSpeed>-0.2</MedicalTendSpeed>
 					<MedicalTendQuality>0.4</MedicalTendQuality>
+					<GermContainment>0.2</GermContainment>
 				</statOffsets>
 				<skillGains>
 					<li><key>Medicine</key><value>4</value></li>
@@ -802,6 +805,7 @@
 				<statOffsets>
 					<ImmunityGainSpeed>-0.25</ImmunityGainSpeed>
 					<ToxicSensitivity>0.5</ToxicSensitivity>
+					<GermResistance>-0.15</GermResistance>
 				</statOffsets>
 			</li>
 			<li>
@@ -811,6 +815,7 @@
 				<statOffsets>
 					<ImmunityGainSpeed>0.25</ImmunityGainSpeed>
 					<ToxicSensitivity>-0.5</ToxicSensitivity>
+					<GermResistance>0.15</GermResistance>
 				</statOffsets>
 			</li>
 		</degreeDatas>

--- a/Mods/Core_SK/Patches/HediffGiverSetChanges.xml
+++ b/Mods/Core_SK/Patches/HediffGiverSetChanges.xml
@@ -8,7 +8,7 @@
 				<hediff>Flu</hediff>
 				<diseaseDef>Flu</diseaseDef>
 				<diseaseFilth>Filth_FluGerms</diseaseFilth>
-				<germDropRate>100</germDropRate>
+				<germDropRate>90</germDropRate>
 				<humanlikeDisease>true</humanlikeDisease>
 				<animalDisease>false</animalDisease>
 			</li>
@@ -22,7 +22,7 @@
 				<hediff>Plague</hediff>
 				<diseaseDef>Plague</diseaseDef>
 				<diseaseFilth>Filth_PlagueGerms</diseaseFilth>
-				<germDropRate>100</germDropRate>
+				<germDropRate>90</germDropRate>
 				<humanlikeDisease>true</humanlikeDisease>
 				<animalDisease>false</animalDisease>
 			</li>
@@ -37,7 +37,7 @@
 				<hediff>CommonCold</hediff>
 				<diseaseDef>CommonCold</diseaseDef>
 				<diseaseFilth>Filth_CommonColdGerms</diseaseFilth>
-				<germDropRate>100</germDropRate>
+				<germDropRate>90</germDropRate>
 				<humanlikeDisease>true</humanlikeDisease>
 				<animalDisease>false</animalDisease>
 			</li>
@@ -51,7 +51,7 @@
 				<hediff>Measles</hediff>
 				<diseaseDef>Measles</diseaseDef>
 				<diseaseFilth>Filth_MeaslesGerms</diseaseFilth>
-				<germDropRate>100</germDropRate>
+				<germDropRate>90</germDropRate>
 				<humanlikeDisease>true</humanlikeDisease>
 				<animalDisease>false</animalDisease>
 			</li>
@@ -65,7 +65,7 @@
 				<hediff>Coronavirus</hediff>
 				<diseaseDef>Coronavirus</diseaseDef>
 				<diseaseFilth>Filth_CoronavirusGerms</diseaseFilth>
-				<germDropRate>100</germDropRate>
+				<germDropRate>90</germDropRate>
 				<humanlikeDisease>true</humanlikeDisease>
 				<animalDisease>false</animalDisease>
 			</li>

--- a/Mods/Rimatomics_SK/Defs/ThingDefs_Misc/RadSuits.xml
+++ b/Mods/Rimatomics_SK/Defs/ThingDefs_Misc/RadSuits.xml
@@ -37,6 +37,8 @@
 			<ShootingAccuracyPawn>-0.12</ShootingAccuracyPawn>
 			<AimingDelayFactor>0.05</AimingDelayFactor>
 			<MeleeHitChance>-0.05</MeleeHitChance>
+			<GermResistance>0.15</GermResistance>
+			<GermContainment>0.15</GermContainment>
 		</equippedStatOffsets>
 		<recipeMaker>
 			<workSpeedStat>TailoringSpeed</workSpeedStat>
@@ -54,6 +56,8 @@
 		<equippedStatOffsets>
 			<MoveSpeed>-0.1</MoveSpeed>
 			<WorkSpeedGlobal>-0.1</WorkSpeedGlobal>
+			<GermResistance>0.15</GermResistance>
+			<GermContainment>0.15</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
 			<bodyPartGroups>
@@ -84,6 +88,8 @@
 		<equippedStatOffsets>
 			<MoveSpeed>-0.04</MoveSpeed>
 			<PsychicSensitivity>-0.3</PsychicSensitivity>
+			<GermResistance>0.7</GermResistance>
+			<GermContainment>0.8</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
 			<bodyPartGroups>
@@ -119,8 +125,8 @@
 		<statBases>
 			<WorkToMake>15000</WorkToMake>
 			<Mass>1.24</Mass>
-			<ArmorRating_Sharp>0.09</ArmorRating_Sharp>
-			<ArmorRating_Blunt>0.09</ArmorRating_Blunt>
+			<ArmorRating_Sharp>1.2</ArmorRating_Sharp>
+			<ArmorRating_Blunt>2.2</ArmorRating_Blunt>
 			<ArmorRating_Heat>0.27</ArmorRating_Heat>
 			<Insulation_Cold>15</Insulation_Cold>
 			<EquipDelay>3.5</EquipDelay>
@@ -142,6 +148,8 @@
 			<MaxHitPoints>90</MaxHitPoints>
 			<WorkToMake>24000</WorkToMake>
 			<Mass>3.8</Mass>
+			<ArmorRating_Sharp>1.0</ArmorRating_Sharp>
+			<ArmorRating_Blunt>1.9</ArmorRating_Blunt>
 			<ArmorRating_Heat>0.23</ArmorRating_Heat>
 			<Insulation_Cold>15</Insulation_Cold>
 			<EquipDelay>4.5</EquipDelay>
@@ -194,10 +202,14 @@
 			<EquipDelay>2.8</EquipDelay>
 			<ArmorRating_Heat>0.3</ArmorRating_Heat>
 			<Insulation_Cold>8</Insulation_Cold>
-			<StuffEffectMultiplierArmor>0.43</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>5.74</StuffEffectMultiplierArmor>
 			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
+		<equippedStatOffsets>
+			<GermResistance>0.7</GermResistance>
+			<GermContainment>0.8</GermContainment>
+		</equippedStatOffsets>
 		<thingCategories>
 			<li>SpecialApparelCat</li>
 			<li>SetChemicalProtectionSuit</li>
@@ -249,12 +261,14 @@
 			<ArmorRating_Heat>0.23</ArmorRating_Heat>
 			<Insulation_Cold>25</Insulation_Cold>
 			<Insulation_Heat>6</Insulation_Heat>
-			<StuffEffectMultiplierArmor>0.58</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>7.74</StuffEffectMultiplierArmor>
 			<StuffEffectMultiplierInsulation_Cold>1</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>1</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
 		<equippedStatOffsets>
 			<CarryBulk>12</CarryBulk>
+			<GermResistance>0.2</GermResistance>
+			<GermContainment>0.2</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
 			<wornGraphicPath>Rimatomics/Things/MopSuit/Mop</wornGraphicPath>


### PR DESCRIPTION
Some changes to new diseases system:
- added few germ resistance and germ containment param to all (almost) apparel;
- added germ resistance and germ containment param to some traits;
- some hightech helmets rebalance (delete "Mask" hediff from some hightech helmets/replaced on light version of it);
- some helmets had mask effect but not look like mask. Corrected it;
- fixed armor param to Rim Atomic armor (had 1.3 ver. param).


Небольшие изменения для новой системы болезней:
- почти всей одежде добавлено совсем небольшое количество "стерильности" и "устойчивости к болезням";
- некоторым чертам характера также добавил эти параметры;
- немного перебалансил все хайтек шлемы (и одну индустриальную тактическую тряпку) - для части шлемов эффект маски был удален или заменен на облегченную версию;
- часть шлемов давала эффект маски, но не выглядела как маска или противогаз. Убрал этот эффект у таких шлемов;
- исправлено значение брони и одежды Рим Атомика. Были значения от старого СЕ v1.3.