### PR TITLE
Fix pawn accuracy in gas area (1.1)

### DIFF
--- a/Mods/CombatExtended/Defs/ThingDefs_Misc/Gas_Various.xml
+++ b/Mods/CombatExtended/Defs/ThingDefs_Misc/Gas_Various.xml
@@ -14,7 +14,7 @@
     <gas>
 	  <expireSeconds>15~21</expireSeconds>
       <blockTurretTracking>false</blockTurretTracking>
-      <accuracyPenalty>0.8</accuracyPenalty>
+      <accuracyPenalty>0.03</accuracyPenalty>
       <rotationSpeed>50</rotationSpeed>
     </gas>
   </ThingDef>


### PR DESCRIPTION
Fix pawn accuracy in gas area.
It's temporary fix till things go better (adding scaling value of ppm and accuracy for example. Now even 1 ppm give full penalty. It ridiculous...)

Фикс точности в загазованной области.
Это временный фикс, оставим эту функцию до лучших времен (например, пока не появится скалирование точности от концентрации дыма. Сейчас даже 1 ppm режет точность пешки по максимуму. Это бред...)