### PR TITLE
Fix Nova skin color generator

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
@@ -516,9 +516,17 @@
 							</hiddenUnderApparelFor>
 						</li>
 					</bodyAddons>
-					<alienskincolorgen Class="AlienRace.ColorGenerator_SkinColorMelanin">
-						<minMelanin>0.01</minMelanin>
-						<maxMelanin>0.20</maxMelanin>
+					<alienskincolorgen Class="ColorGenerator_Options">
+						<options>
+							<li>
+								<weight>5</weight>
+								<only>(0.70,0.78,0.88,1)</only>
+							</li>
+							<li>
+								<weight>5</weight>
+								<only>(0.71,0.82,0.87,1)</only>
+							</li>
+						</options>
 					</alienskincolorgen>
 					<alienhaircolorgen Class="ColorGenerator_Options">
 						<options>


### PR DESCRIPTION
Fix Nova skin color generator. Skin color was unnatural by default and cannot be edited.

Исправил генератор цвета для кожи расы Нова. Цвет кожи нельзя было редактировать + у них был неестественный для них цвет кожи по умолчанию.