### PR TITLE
Fix electronic components recipe.

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Electronics.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Electronics.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>10</count>
@@ -47,7 +47,7 @@
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Glass</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>SilverBar</li>
 			</thingDefs>
 			<categories>


### PR DESCRIPTION
Fix electronic components recipe.

Исправил рецепт электронных компонентов.
Он требовал продвинутый компонент, который можно скрафтить только из сверхпрочных сплавов.
Сверхпрочные сплавы можно скрафтить только после постройки электродуговой печи.
Для постройки электродуговой печи нужны электронные компоненты.
Для крафта электронных компонентов нужна электродуговая печь.
Круг замкнулся...