### PR TITLE
Fix general labor speed rus translation

### DIFF
--- a/Mods/CoreTranslation/Languages/Russian-SK/DefInjected/StatDef/Stats_Pawns_WorkRecipes.xml
+++ b/Mods/CoreTranslation/Languages/Russian-SK/DefInjected/StatDef/Stats_Pawns_WorkRecipes.xml
@@ -44,7 +44,7 @@
   <FoodPoisonChance.labelForFullStatList>шанс пищевого отравления (шанс отравить блюдо)</FoodPoisonChance.labelForFullStatList>
   
   <!-- EN: general labor speed -->
-  <GeneralLaborSpeed.label>скорость общей работы</GeneralLaborSpeed.label>
+  <GeneralLaborSpeed.label>скорость простой работы</GeneralLaborSpeed.label>
   <!-- EN: The speed at which this person carries out general labor like making stone blocks, making chemfuel at a refinery, burning items, tailoring clothes, creating art, smithing armor and weapons or smelting slag. This stat applies both to activities that involve no skill, as well as those where the skill affects the quality of the product instead of the speed of production. -->
   <GeneralLaborSpeed.description>Скорость, с которой персонаж выполняет общую работу, такую как обработка камня, работа с перегонным аппаратом, сжигание, пошив одежды, создание предметов искусства, ковка и переплавка. Этот показатель применяется как к занятиям, не требующим специальных навыков, так и к тем, в которых навык влияет на качество конечного продукта вместо скорости работы.</GeneralLaborSpeed.description>
   


### PR DESCRIPTION
Fix general labor speed rus translation

Исправил перевод параметра "general labor speed". 
Причины:
- задвоение и пресечение возможных недопониманий (у нас есть "Общая скорость работы" и "Скорость общей работы"...);
![1](https://user-images.githubusercontent.com/62516232/84591857-1e30e800-ae5b-11ea-94f4-ef36105bd22b.png)
- не знаю, кто и зачем переводил его как "Скорость общей работы", когда само слово означает именно неквалифицированный труд. В 1.1. как я понял туда засунули шитье и ковку, в ХСК эти параметры все ещё остались и функционируют. Пока что сменю только название. Описание можно будет поправить позже, когда будет ясно, останутся ли с нами параметры ковки и шитья или нет.