### PR TITLE
Why was it necessary to put advanced components in ALL weapon recipes?

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_WeaponComponents.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_WeaponComponents.xml
@@ -25,7 +25,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>30</count>
@@ -45,7 +45,7 @@
 				<li>USLDBar</li>
 			</categories>
 			<thingDefs>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Mechanism</li>
 			</thingDefs>
 		</fixedIngredientFilter>
@@ -96,7 +96,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>6</count>
@@ -125,7 +125,7 @@
 				<li>HCMBar</li>
 			</categories>
 			<thingDefs>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Wire</li>
 				<li>Mechanism</li>
 			</thingDefs>
@@ -175,7 +175,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>18</count>
@@ -204,7 +204,7 @@
 				<li>HCMBar</li>
 			</categories>
 			<thingDefs>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Wire</li>
 				<li>Mechanism</li>
 			</thingDefs>
@@ -254,7 +254,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>17</count>
@@ -283,7 +283,7 @@
 				<li>HCMBar</li>
 			</categories>
 			<thingDefs>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Wire</li>
 				<li>Mechanism</li>
 			</thingDefs>
@@ -333,7 +333,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>20</count>
@@ -362,7 +362,7 @@
 				<li>HCMBar</li>
 			</categories>
 			<thingDefs>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Wire</li>
 				<li>Mechanism</li>
 			</thingDefs>
@@ -477,7 +477,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>10</count>
@@ -493,7 +493,7 @@
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Glass</li>
 				<li>Rifle_Component</li>
 			</thingDefs>
@@ -626,7 +626,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>40</count>
@@ -655,7 +655,7 @@
 				<li>HCMBar</li>
 			</categories>
 			<thingDefs>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Wire</li>
 				<li>Mechanism</li>
 			</thingDefs>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Carabines.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Carabines.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>12</count>
@@ -59,7 +59,7 @@
 			<thingDefs>
 				<li>Rifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -101,7 +101,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>9</count>
@@ -138,7 +138,7 @@
 			<thingDefs>
 				<li>Rifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -181,7 +181,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>10</count>
@@ -218,7 +218,7 @@
 			<thingDefs>
 				<li>Rifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -261,7 +261,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>9</count>
@@ -298,7 +298,7 @@
 			<thingDefs>
 				<li>Rifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Grenades.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Grenades.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>5</count>
@@ -62,7 +62,7 @@
 			</categories>
 			<thingDefs>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Mechanism</li>
 				<li>ElectronicComponents</li>
 			</thingDefs>
@@ -211,7 +211,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>5</count>
@@ -235,7 +235,7 @@
 			</categories>
 			<thingDefs>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Mechanism</li>
 			</thingDefs>
 		</fixedIngredientFilter>
@@ -274,7 +274,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>5</count>
@@ -306,7 +306,7 @@
 			</categories>
 			<thingDefs>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Mechanism</li>
 				<li>ElectronicComponents</li>
 			</thingDefs>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Heavy.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Heavy.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>13</count>
@@ -59,7 +59,7 @@
 			<thingDefs>
 				<li>Heavy_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -102,7 +102,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentSpacer</li>
+						<li>ComponentAdvanced</li>
 					</thingDefs>
 				</filter>
 				<count>8</count>
@@ -139,7 +139,7 @@
 			<thingDefs>
 				<li>Heavy_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentSpacer</li>
+				<li>ComponentAdvanced</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -236,9 +236,9 @@
 
 	<RecipeDef ParentName="RangedWeaponRecipeBase">
 		<defName>BuildGalilBurstRifle</defName>
-		<label>Build RPK-74</label>
+		<label>Build RPK-47</label>
 		<description>Builds the RPK-47, an ancient pattern military rifle. Fires an 8-round burst. Good range, low power and high rate of fire.\nCaliber: 7.62x39mm Soviet</description>
-		<jobString>Building RPK-74.</jobString>
+		<jobString>Building RPK-47.</jobString>
 		<workAmount>20500</workAmount>
 		<skillRequirements>
 			<Crafting>8</Crafting>
@@ -263,7 +263,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>15</count>
@@ -300,7 +300,7 @@
 			<thingDefs>
 				<li>Heavy_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -344,7 +344,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>17</count>
@@ -381,7 +381,7 @@
 			<thingDefs>
 				<li>Heavy_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -424,7 +424,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>18</count>
@@ -453,7 +453,7 @@
 			<thingDefs>
 				<li>Heavy_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Launchers.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Launchers.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>15</count>
@@ -67,7 +67,7 @@
 			<thingDefs>
 				<li>Heavy_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -110,7 +110,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>15</count>
@@ -147,7 +147,7 @@
 			<thingDefs>
 				<li>Heavy_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -190,7 +190,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>15</count>
@@ -219,7 +219,7 @@
 			<thingDefs>
 				<li>Launcher_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -262,7 +262,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>14</count>
@@ -291,7 +291,7 @@
 			<thingDefs>
 				<li>Launcher_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -333,7 +333,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>17</count>
@@ -362,7 +362,7 @@
 			<thingDefs>
 				<li>Launcher_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Misc.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Misc.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>15</count>
@@ -59,7 +59,7 @@
 			<thingDefs>
 				<li>Heavy_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -94,7 +94,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>12</count>
@@ -114,7 +114,7 @@
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Pistols.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Pistols.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>8</count>
@@ -59,7 +59,7 @@
 			<thingDefs>
 				<li>Pistol_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -101,7 +101,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>9</count>
@@ -130,7 +130,7 @@
 			<thingDefs>
 				<li>Pistol_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -173,7 +173,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>7</count>
@@ -210,7 +210,7 @@
 			<thingDefs>
 				<li>Pistol_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -254,7 +254,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>9</count>
@@ -284,7 +284,7 @@
 			<thingDefs>
 				<li>Pistol_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -326,7 +326,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>7</count>
@@ -363,7 +363,7 @@
 			<thingDefs>
 				<li>Pistol_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -407,7 +407,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>7</count>
@@ -444,7 +444,7 @@
 			<thingDefs>
 				<li>Pistol_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -487,7 +487,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>8</count>
@@ -524,7 +524,7 @@
 			<thingDefs>
 				<li>Pistol_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Rifle.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Rifle.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>11</count>
@@ -67,7 +67,7 @@
 			<thingDefs>
 				<li>AdvRifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -111,7 +111,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>11</count>
@@ -148,7 +148,7 @@
 			<thingDefs>
 				<li>AdvRifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -192,7 +192,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>11</count>
@@ -229,7 +229,7 @@
 			<thingDefs>
 				<li>AdvRifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -273,7 +273,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>11</count>
@@ -310,7 +310,7 @@
 			<thingDefs>
 				<li>AdvRifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -354,7 +354,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>10</count>
@@ -391,7 +391,7 @@
 			<thingDefs>
 				<li>AdvRifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -434,7 +434,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>16</count>
@@ -471,7 +471,7 @@
 			<thingDefs>
 				<li>AdvRifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -515,7 +515,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>16</count>
@@ -552,7 +552,7 @@
 			<thingDefs>
 				<li>AdvRifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -596,7 +596,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>18</count>
@@ -633,7 +633,7 @@
 			<thingDefs>
 				<li>AdvRifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -676,7 +676,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>13</count>
@@ -705,7 +705,7 @@
 			<thingDefs>
 				<li>AdvRifle_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_SMGs.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_SMGs.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>13</count>
@@ -59,7 +59,7 @@
 			<thingDefs>
 				<li>SMG_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -102,7 +102,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>9</count>
@@ -139,7 +139,7 @@
 			<thingDefs>
 				<li>SMG_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -182,7 +182,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>12</count>
@@ -211,7 +211,7 @@
 			<thingDefs>
 				<li>SMG_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -253,7 +253,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>13</count>
@@ -282,7 +282,7 @@
 			<thingDefs>
 				<li>SMG_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -325,7 +325,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>8</count>
@@ -354,7 +354,7 @@
 			<thingDefs>
 				<li>SMG_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -397,7 +397,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>8</count>
@@ -434,7 +434,7 @@
 			<thingDefs>
 				<li>SMG_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -478,7 +478,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>9</count>
@@ -515,7 +515,7 @@
 			<thingDefs>
 				<li>SMG_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -559,7 +559,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>9</count>
@@ -596,7 +596,7 @@
 			<thingDefs>
 				<li>SMG_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Shotguns.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Shotguns.xml
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>13</count>
@@ -59,7 +59,7 @@
 			<thingDefs>
 				<li>Shotgun_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -102,7 +102,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>13</count>
@@ -131,7 +131,7 @@
 			<thingDefs>
 				<li>Shotgun_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 			</thingDefs>
 			<categories>
 				<li>SLDBar</li>
@@ -173,7 +173,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>8</count>
@@ -210,7 +210,7 @@
 			<thingDefs>
 				<li>Shotgun_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -254,7 +254,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>11</count>
@@ -291,7 +291,7 @@
 			<thingDefs>
 				<li>Shotgun_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -335,7 +335,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>13</count>
@@ -372,7 +372,7 @@
 			<thingDefs>
 				<li>Shotgun_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -416,7 +416,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>16</count>
@@ -453,7 +453,7 @@
 			<thingDefs>
 				<li>Shotgun_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Snipers.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Snipers.xml
@@ -3,9 +3,9 @@
 
 	<RecipeDef ParentName="RangedWeaponRecipeBase">
 		<defName>BuildSniperRifle</defName>
-		<label>Build M24 Sniper Rifle</label>
+		<label>Build M21 Sniper Rifle</label>
 		<description>Builds an ancient pattern military sniper rifle. Bolt action, long range, great accuracy and power.\nCaliber: 7.62x51mm NATO</description>
-		<jobString>Building M24 Sniper Rifle.</jobString>
+		<jobString>Building M21 Sniper Rifle.</jobString>
 		<workAmount>16600</workAmount>
 		<skillRequirements>
 			<Crafting>13</Crafting>
@@ -30,7 +30,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>9</count>
@@ -67,7 +67,7 @@
 			<thingDefs>
 				<li>Sniper_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -111,7 +111,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>11</count>
@@ -148,7 +148,7 @@
 			<thingDefs>
 				<li>Sniper_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -191,7 +191,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>15</count>
@@ -228,7 +228,7 @@
 			<thingDefs>
 				<li>Sniper_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -271,7 +271,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>15</count>
@@ -308,7 +308,7 @@
 			<thingDefs>
 				<li>AdvSniper_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -352,7 +352,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>15</count>
@@ -389,7 +389,7 @@
 			<thingDefs>
 				<li>AdvSniper_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -433,7 +433,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>21</count>
@@ -470,7 +470,7 @@
 			<thingDefs>
 				<li>AdvSniper_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -513,7 +513,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>28</count>
@@ -550,7 +550,7 @@
 			<thingDefs>
 				<li>AdvSniper_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
@@ -593,7 +593,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>ComponentAdvanced</li>
+						<li>ComponentIndustrial</li>
 					</thingDefs>
 				</filter>
 				<count>16</count>
@@ -622,7 +622,7 @@
 			<thingDefs>
 				<li>Sniper_Component</li>
 				<li>Weapon_Parts</li>
-				<li>ComponentAdvanced</li>
+				<li>ComponentIndustrial</li>
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>


### PR DESCRIPTION
Зачем нужно было класть продвинутые компоненты во ВСЕ рецепты? (они крафтятся из сверхпрочных материалов, большая часть из которых доступна только в космической ветке исследований, к сведению).

Я подозреваю, что это было сделано случайно, ибо крафтить вооружение начала прошлого века (например, ПТРД или пистолет M1911) из ферротитана или штейна это... как бы это так сказать... сильно...

![image](https://user-images.githubusercontent.com/62516232/85046544-02ef1100-b1aa-11ea-8f82-2fa6fd4fd6e7.png)

Для части оружия действительно можно добавить подобные компоненты (например, СмартГан или МикроГан или какое-нибудь продвинутое хайтек оружие, но в обыкновенном огнестреле они избыточны. Достаточно обыкновенных прочных (например, стали) и пластика).

Возможность создания вооружения из-за этих компонентов отсутствует как таковая полностью до выхода в сверхпрочные материалы, которые ещё нужно потом выкопать и переработать.

Продвинутые компоненты оставил только для продвинутого оружия и для некоторых топовых гранат (вроде плазменных, т.е. там, где это вполне уместно).
Пока посмотрел только оружие. Надеюсь, что такого больше нигде не будет...

Скай, посмотри, пожалуйста, остальные рецепты тоже.