### PR TITLE
Some grenade min range and norb hammer smelting drop correcting

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
@@ -128,7 +128,7 @@
 				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<range>12</range>
-				<minRange>5</minRange>
+				<minRange>3</minRange>
 				<warmupTime>1.20</warmupTime>
 				<noiseRadius>4</noiseRadius>
 				<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
@@ -223,7 +223,7 @@
 				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<range>11</range>
-				<minRange>4</minRange>
+				<minRange>3</minRange>
 				<warmupTime>1.50</warmupTime>
 				<noiseRadius>3</noiseRadius>
 				<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
@@ -249,7 +249,7 @@
 			</li>
 		</comps>
 		<smeltProducts>
-			<ComponentAdvanced>1</ComponentAdvanced>
+			<ComponentIndustrial>1</ComponentIndustrial>
 		</smeltProducts>
 	</ThingDef>
 	<!-- MOLOTOV -->
@@ -310,7 +310,7 @@
 				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<range>11</range>
-				<minRange>4</minRange>
+				<minRange>2</minRange>
 				<warmupTime>1.20</warmupTime>
 				<noiseRadius>4</noiseRadius>
 				<ai_AvoidFriendlyFireRadius>3</ai_AvoidFriendlyFireRadius>
@@ -392,7 +392,7 @@
 				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<range>12</range>
-				<minRange>4</minRange>
+				<minRange>3</minRange>
 				<warmupTime>1.30</warmupTime>
 				<noiseRadius>4</noiseRadius>
 				<ai_AvoidFriendlyFireRadius>2</ai_AvoidFriendlyFireRadius>
@@ -553,7 +553,7 @@
 				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<range>12</range>
-				<minRange>4</minRange>
+				<minRange>3</minRange>
 				<warmupTime>1.20</warmupTime>
 				<noiseRadius>4</noiseRadius>
 				<ai_AvoidFriendlyFireRadius>4</ai_AvoidFriendlyFireRadius>
@@ -648,7 +648,7 @@
 				<warmupTime>1.20</warmupTime>
 				<noiseRadius>4</noiseRadius>
 				<ai_AvoidFriendlyFireRadius>5</ai_AvoidFriendlyFireRadius>
-				<minRange>5</minRange>
+				<minRange>4</minRange>
 				<ai_IsBuildingDestroyer>true</ai_IsBuildingDestroyer>
 				<soundCast>ThrowGrenade</soundCast>
 				<targetParams>
@@ -734,7 +734,7 @@
 				<verbClass>CombatExtended.Verb_ShootCEOneUse</verbClass>
 				<hasStandardCommand>true</hasStandardCommand>
 				<range>12</range>
-				<minRange>5</minRange>
+				<minRange>3</minRange>
 				<!--<forcedMissRadius>1.2</forcedMissRadius>-->
 				<warmupTime>1.20</warmupTime>
 				<noiseRadius>4</noiseRadius>


### PR DESCRIPTION
I was test this and it's still safe to throw grenades to new min range 
(except frag grenade. It's still very random thing):
![image](https://user-images.githubusercontent.com/62516232/85220987-8d618b80-b3c9-11ea-89fb-b29606335017.png)
Also fix norb hammer smelting drop.

Снизил минимальный радиус броска гранат. Протестировал, с новым радиусом все ещё довольно безопасно бросать гранаты (кроме осколочной, это настолько рандомная штука, что никакой минимальный радиус не спасет от этого (см. скриншот выше)).
Также исправил дроп после переплавки молота тора, дропались сверхпрочные компоненты