### PR TITLE
Some salt mining fix

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_saltmine.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_saltmine.xml
@@ -5,15 +5,15 @@
 		<label>mine salt</label>
 		<description>Mine salt from rough stone. Takes a lot of work</description>
 		<jobString>Mining salt.</jobString>
-		<workSpeedStat>StonecuttingSpeed</workSpeedStat>
+		<workSpeedStat>MiningSpeed</workSpeedStat>
 		<effectWorking>CutStone</effectWorking>
 		<workSkillLearnFactor>0.5</workSkillLearnFactor>
 		<soundWorking>Recipe_Smith</soundWorking>
-		<workAmount>2000</workAmount>
+		<workAmount>1800</workAmount>
 		<products>
 			<Salt>5</Salt>
 		</products>
-		<workSkill>Crafting</workSkill>
+		<workSkill>Mining</workSkill>
   		<recipeUsers>
 			<li>VG_SaltMine</li>
 		</recipeUsers>


### PR DESCRIPTION
It's require crafting instead mining.

Добыча соли в соляной шахте требовало ремесло, хотя сама работа добычи соли находится в горном деле.
Также немного снизил объем работ для добычи соли (на 10%).
![image](https://user-images.githubusercontent.com/62516232/85920416-0579f680-b88d-11ea-9485-a341bce700e6.png)

теперь требует горное дело.
