### PR TITLE
Remove some weapon tag to prevent spawn with ratkin guerrilla raid

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Weapon.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Weapon.xml
@@ -1111,7 +1111,6 @@
 			</recipeUsers>
 		</recipeMaker>
 		<weaponTags Inherit="false">
-			<li>RK_4TierWeapon</li>
 			<li>RK_HeavyRifle</li>
 		</weaponTags>
 		<tradeTags Inherit="false">


### PR DESCRIPTION
Убрал один тег у снайперки BFR, чтобы предотвратить появление её у пешек в их спец. эвенте (который не подразумевает снайперскую стрельбу).