### PR TITLE
Some flammability, base hunger rate and king hamster textiles tweaks and fixes

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
@@ -456,7 +456,7 @@
 			<MarketValue>2000</MarketValue>
 			<Mass>40</Mass>
 			<MoveSpeed>5.25</MoveSpeed> 
-			<Flammability>1.6</Flammability>
+			<Flammability>1.1</Flammability>
 			<ComfyTemperatureMax>31</ComfyTemperatureMax>
 			<ComfyTemperatureMin>6</ComfyTemperatureMin>
 			<ImmunityGainSpeed>1.10</ImmunityGainSpeed>
@@ -556,7 +556,7 @@
 			<body>Ratkin</body>
 			<baseBodySize>0.8</baseBodySize>
 			<baseHealthScale>1</baseHealthScale>
-			<baseHungerRate>0.94</baseHungerRate>
+			<baseHungerRate>0.9</baseHungerRate>
 			<foodType>OmnivoreHuman</foodType>
 			<gestationPeriodDays>21</gestationPeriodDays>
 			<soundMeleeHitPawn>Pawn_Melee_Punch_HitPawn</soundMeleeHitPawn>

--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_LeatherAndWool.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_LeatherAndWool.xml
@@ -13,11 +13,11 @@
 		<statBases>
 			<MaxHitPoints>100</MaxHitPoints>
 			<MarketValue>2.3</MarketValue>
-			<Flammability>0.9</Flammability>
+			<Flammability>0.8</Flammability>
 			<DeteriorationRate>0</DeteriorationRate>
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.0</StuffPower_Armor_Sharp>
-			<StuffPower_Armor_Heat>1.5</StuffPower_Armor_Heat>
+			<StuffPower_Armor_Heat>0.15</StuffPower_Armor_Heat>
 			<StuffPower_Insulation_Cold>10</StuffPower_Insulation_Cold>
 			<StuffPower_Insulation_Heat>12</StuffPower_Insulation_Heat>
 			<Mass>0.01</Mass>
@@ -34,6 +34,7 @@
 			<statFactors>
 				<MaxHitPoints>1.1</MaxHitPoints>
 				<Beauty>1.0</Beauty>
+				<Flammability>0.8</Flammability>
 				<MoveSpeed>1</MoveSpeed>
 				<MarketValue>0.8</MarketValue>
 				<WorkToMake>1</WorkToMake>
@@ -64,7 +65,7 @@
 			<DeteriorationRate>0</DeteriorationRate>
 			<StuffPower_Armor_Blunt>1.12</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.12</StuffPower_Armor_Sharp>
-			<StuffPower_Armor_Heat>1.25</StuffPower_Armor_Heat>
+			<StuffPower_Armor_Heat>0.125</StuffPower_Armor_Heat>
 			<StuffPower_Insulation_Cold>16</StuffPower_Insulation_Cold>
 			<StuffPower_Insulation_Heat>26</StuffPower_Insulation_Heat>
 			<Mass>0.02</Mass>
@@ -78,6 +79,7 @@
 			<statFactors>
 				<MaxHitPoints>1.25</MaxHitPoints>
 				<Beauty>1.25</Beauty>
+				<Flammability>0.9</Flammability>
 				<MoveSpeed>1.0</MoveSpeed>
 				<MarketValue>0.7</MarketValue>
 				<WorkToMake>1.15</WorkToMake>


### PR DESCRIPTION
1 ratkins hasn't wool like orassans (they have 1.6 too). Suggest decrease this value to 1.1;
2 some correcting hunger rate (ratkins has lower than other body size => they need to eat often than other races... too often);
3 fix heat armor of king hamster wool and leather, some flammability tweaks.

1 раткины не орассаны и шерсти у них нет (у последних 1.6). Предлагаю понизить значение до 1.1. (1.0 + хвост = 1.1);
2 продолжаю изучать прожорство жраткинов, ещё немного корректировки для множителя голода, сейчас все равно слишком часто едят... и много...
3 несколько правок текстиля королевского хомяка (забыл перенести из 1.0 их статы).