### PR TITLE
Remove duplicate think class. CE also have this

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
@@ -2604,7 +2604,6 @@
 		<defName>RK_WoodenShield</defName>
 		<label>ratkin wooden Shield</label>
 		<description>목재 방패.</description>
-		<thingClass>NewRatkin.Shield</thingClass>
 		<graphicData>
 			<texPath>Apparel/RK_WoodenShield</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -2693,7 +2692,6 @@
 		<defName>RK_HeavyShield</defName>
 		<label>ratkin heavy Shield</label>
 		<description>금속 방패.</description>
-		<thingClass>NewRatkin.Shield</thingClass>
 		<graphicData>
 			<texPath>Apparel/RK_HeavyShield</texPath>
 			<graphicClass>Graphic_Single</graphicClass>


### PR DESCRIPTION
Удалил think class для блока щитов, в СЕ есть свой аналог, который щиты раткинов получают из Shield_Base.
![image](https://user-images.githubusercontent.com/62516232/87225233-e313cd00-c3a4-11ea-9208-6a62ddf534e8.png)
