### PR TITLE
Added stonecutter's bench Wood Logs stuff Categories

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -2660,6 +2660,7 @@
 		<stuffCategories>
 			<li>Stony</li>
 			<li>Bricks</li>
+			<li>WoodLogs</li>
 		</stuffCategories>
 		<costStuffCount>160</costStuffCount>
 		<minifiedDef>MinifiedThing</minifiedDef>


### PR DESCRIPTION
after this changes https://github.com/skyarkhangel/Hardcore-SK/commit/667124d4679dd07d167aa91ad3a22c4092b0392e
it's impossible to build stonecutter table (not enough same stone blocks drop from cairn)

после этих изменений невозможно построить на старте обычный каменный станок (каирны из разных материалов, просто не хватает одного типа материалов).
Учитывая будущие перерисовки станков, дерево будет выглядеть нормально.

P.S. я конечно не уверен, но вроде бы что-то подобное с каирнами было уже когда-то давным-давно...