### PR TITLE
Fix workSpeedStat for medicine craft recipes

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Medicine.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Medicine.xml
@@ -7,7 +7,7 @@
 		<description>Crafts herbal medicine from Raw Healroot. Produces 1.</description>
 		<jobString>Crafting herbal medicine.</jobString>
 		<workAmount>500</workAmount>
-		<workSpeedStat>CookSpeed</workSpeedStat>
+		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
 		<effectWorking>Cook</effectWorking>
 		<soundWorking>Chemlab_Herbal</soundWorking>
 		<ingredients>
@@ -50,7 +50,7 @@
 		<description>Crafts a medicine kit from herbal medicine and various other resources. Produces 1.</description>
 		<jobString>Crafting medicine.</jobString>
 		<workAmount>800</workAmount>
-		<workSpeedStat>SmeltingSpeed</workSpeedStat>
+		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
 		<effectWorking>Cook</effectWorking>
 		<soundWorking>Chemlab_Medicine</soundWorking>
 		<ingredients>
@@ -112,7 +112,7 @@
 		<description>Crafts advanced medicine from plants with high medical potency. Produces 1.</description>
 		<jobString>Crafting advanced medicine.</jobString>
 		<workAmount>1400</workAmount>
-		<workSpeedStat>CookSpeed</workSpeedStat>
+		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
 		<effectWorking>Cook</effectWorking>
 		<soundWorking>Chemlab_Medicine</soundWorking>
 		<ingredients>


### PR DESCRIPTION
Was cook and smelting (wat?) workSpeedStat. Replace to drug synthesis speed.

Исправил стат пешки, отвечающий за крафт медицины. Требовался навык готовки и переплавки (ват?). Заменил на скорость синтеза препаратов.