### PR TITLE
Fixed pawns not picking up food, fixed translation

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
@@ -415,7 +415,7 @@
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>7</daysToRotStart>
+				<daysToRotStart>4</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
@@ -17,7 +17,7 @@
 	<CookScrambledEggs.description>Приготовить яичницу-болтунью</CookScrambledEggs.description>
 	<CookScrambledEggs.jobString>Готовит яичницу-болтунью</CookScrambledEggs.jobString>
 	
-	<CookScrambledEggs.label>Приготовить яичницу-болтунью (x4)</CookScrambledEggs_Bulk.label>
+	<CookScrambledEggs_Bulk.label>Приготовить яичницу-болтунью (x4)</CookScrambledEggs_Bulk.label>
 	<CookScrambledEggs_Bulk.description>Приготовить яичницу-болтунью (x4)</CookScrambledEggs_Bulk.description>
 	<CookScrambledEggs_Bulk.jobString>Готовит яичницу-болтунью (x4)</CookScrambledEggs_Bulk.jobString>
 

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Meals_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Meals_SK.xml
@@ -5,7 +5,7 @@
 	<ScrambledEggs.description>Блюдо из взбитых и нагретых яиц.</ScrambledEggs.description>
 	
 	<FriedMushrooms.label>Жаренные пещерные грибы</FriedMushrooms.label>
-	<FriedMushrooms.description>Пожаренные, богатые белком пещерные грибы.</FriedMushrooms.description>
+	<FriedMushrooms.description>Пожаренные богатые белком пещерные грибы.</FriedMushrooms.description>
 
 	<MealLuxury.label>Роскошное блюдо</MealLuxury.label>
 	<MealLuxury.description>Комплексное блюдо из нескольких ингредиентов с добавлением специй.</MealLuxury.description>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Meals_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Meals_SK.xml
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
+	<ScrambledEggs.label>Яичница-болтунья</ScrambledEggs.label>
+	<ScrambledEggs.description>Блюдо из взбитых и нагретых яиц.</ScrambledEggs.description>
+	
+	<FriedMushrooms.label>Жаренные пещерные грибы</FriedMushrooms.label>
+	<FriedMushrooms.description>Пожаренные, богатые белком пещерные грибы.</FriedMushrooms.description>
+
 	<MealLuxury.label>Роскошное блюдо</MealLuxury.label>
 	<MealLuxury.description>Комплексное блюдо из нескольких ингредиентов с добавлением специй.</MealLuxury.description>
 


### PR DESCRIPTION
Поправил перевод, теперь новая еда должны быть переведена.
Пешки теперь корректно берут в инвентарь жаренное ассорти. Заметка на будущее для дочитавших: опция "любой рацион" в настройках снаряжения СЕ распознаёт только готовую еду с временем хранения не более 5-6 дней (пока что под это попадают все стандартные блюда).