### PR TITLE
Added redwood tree plant to boreal forest

### DIFF
--- a/Mods/Core_SK/Defs/BiomeDefs/Biomes_Cold.xml
+++ b/Mods/Core_SK/Defs/BiomeDefs/Biomes_Cold.xml
@@ -184,6 +184,7 @@
 			<Plant_Mushroom_Red>0.17</Plant_Mushroom_Red>
 			<Plant_TreeMaple>0.2</Plant_TreeMaple>
 			<Plant_TreeWillow>0.28</Plant_TreeWillow>
+			<PlantTreeRedwood>0.11</PlantTreeRedwood>
 		</wildPlants>
 		<wildAnimals>
 			<Elk>0.4</Elk>


### PR DESCRIPTION
Redwood trees are found only in the NPS mod, but the trees themselves are in Core_SK (including plants). I suggest adding a small amount of them to some standard biome . For example, boreal forest. According to the description, there is snow in the redwood forest. In the game, the biome itself is located next to the boreal forest and it is also often cold there.

Предлагаю добавить красные деревья в тайгу.
Красные деревья встречаются только в моде NPS_SK, однако, сами деревья при этом находятся в моде Core_SK (в том числе растения). Предлагаю добавить немного этих деревьев в какой-нибудь стандартный биом. Например, тайгу. Согласно описанию леса красных деревьев, там есть снег. В игре этот биом всегда располагается рядом с тайгой и там также холодно, как и в тайге. Появится возможность использовать этот материал не только в одном биоме. Если идея понравится, то можно также добавить меньшее количество и в умеренный лес.