### PR TITLE
Foodchange

### DIFF
--- a/Mods/Core_SK/Defs/HediffDefs/Meal/Hediffs_Food.xml
+++ b/Mods/Core_SK/Defs/HediffDefs/Meal/Hediffs_Food.xml
@@ -39,32 +39,6 @@
 		</stages>
 	</HediffDef>
 	<HediffDef>
-		<defName>HedGmeat</defName>
-		<label>ate grilled meat</label>
-		<description>I ate hearty meat. Yau!</description>
-		<isBad>false</isBad>
-		<initialSeverity>1</initialSeverity>
-		<hediffClass>HediffWithComps</hediffClass>
-		<comps>
-			<li Class="HediffCompProperties_SeverityPerDay">
-				<severityPerDay>-0.7</severityPerDay>
-			</li>
-		</comps>
-		<stages>
-			<li>
-				<minSeverity>0</minSeverity>
-				<label>Well Fed: Grilled Food</label>
-				<painFactor>0.9</painFactor>
-				<capMods>
-					<li>
-						<capacity>Metabolism</capacity>
-						<offset>0.5</offset>
-					</li>
-				</capMods>
-			</li>
-		</stages>
-	</HediffDef>
-	<HediffDef>
 		<defName>HedPizza</defName>
 		<label>ate pizza</label>
 		<description>The best cutted food in the world!</description>

--- a/Mods/Core_SK/Defs/HediffDefs/Meal/Hediffs_Meals.xml
+++ b/Mods/Core_SK/Defs/HediffDefs/Meal/Hediffs_Meals.xml
@@ -128,4 +128,97 @@
 			</li>
 		</stages>
 	</HediffDef>
+	
+	<HediffDef>
+		<defName>HadCoconutCurry</defName>
+		<label>ate coconut curry</label>
+		<description>Ate a delicious exotic dish.</description>
+		<isBad>false</isBad>
+		<initialSeverity>1</initialSeverity>
+		<hediffClass>HediffWithComps</hediffClass>
+		<comps>
+			<li Class="HediffCompProperties_SeverityPerDay">
+				<severityPerDay>-0.7</severityPerDay>
+			</li>
+		</comps>
+		<stages>
+			<li>
+				<minSeverity>0</minSeverity>
+				<capMods>
+					<li>
+						<capacity>Moving</capacity>
+						<offset>0.1</offset>
+					</li>
+					<li>
+						<capacity>Sight</capacity>
+						<offset>0.3</offset>
+					</li>
+				</capMods>
+				<statOffsets>
+					<ComfyTemperatureMax>7.0</ComfyTemperatureMax>					
+				</statOffsets>
+			</li>
+		</stages>
+	</HediffDef>	
+	
+	<HediffDef>
+		<defName>HadCheeseBurger</defName>
+		<label>ate cheese burger</label>
+		<description>I ate a filling cheese burger. Yau!</description>
+		<isBad>false</isBad>
+		<initialSeverity>1</initialSeverity>
+		<hediffClass>HediffWithComps</hediffClass>
+		<comps>
+			<li Class="HediffCompProperties_SeverityPerDay">
+				<severityPerDay>-0.7</severityPerDay>
+			</li>
+		</comps>
+		<stages>
+			<li>
+				<minSeverity>0</minSeverity>
+				<painFactor>0.85</painFactor>
+				<capMods>
+					<li>
+						<capacity>Moving</capacity>
+						<offset>0.2</offset>
+					</li>
+				</capMods>
+				<statOffsets>
+					<HungerRateMultiplier>-0.2</HungerRateMultiplier>					
+				</statOffsets>
+			</li>
+		</stages>
+	</HediffDef>
+	
+	<HediffDef>
+		<defName>HadMisoSoup</defName>
+		<label>ate miso soup</label>
+		<description>Ate an extremely healthy dish. I feel power of healthy diet flowing through my veins...</description>
+		<isBad>false</isBad>
+		<initialSeverity>1</initialSeverity>
+		<hediffClass>HediffWithComps</hediffClass>
+		<comps>
+			<li Class="HediffCompProperties_SeverityPerDay">
+				<severityPerDay>-0.7</severityPerDay>
+			</li>
+		</comps>
+		<stages>
+			<li>
+				<minSeverity>0</minSeverity>
+				<capMods>
+					<li>
+						<capacity>Consciousness</capacity>
+						<offset>0.2</offset>
+					</li>
+					<li>
+						<capacity>Moving</capacity>
+						<offset>0.15</offset>
+					</li>
+				</capMods>
+				<statOffsets>
+					<GlobalLearningFactor>0.4</GlobalLearningFactor>					
+				</statOffsets>
+			</li>
+		</stages>
+	</HediffDef>	
 </Defs>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Special.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Special.xml
@@ -73,6 +73,10 @@
 		</recipeUsers>
 	</RecipeDef>
 	
+	
+<!--         Fine Meals          -->
+	
+	
 	<RecipeDef>
 		<defName>CookHeartyStew</defName>
 		<label>cook hearty stew</label>
@@ -215,7 +219,7 @@
 			</disallowedCategories>
 		</defaultIngredientFilter>
 		<skillRequirements>
-			<Cooking>11</Cooking>
+			<Cooking>9</Cooking>
 		</skillRequirements>
 		<workSkill>Cooking</workSkill>
 		<recipeUsers>
@@ -223,85 +227,6 @@
 			<li>ElectricStove_Pro</li>
 		</recipeUsers>
 	</RecipeDef>
-
-	<RecipeDef>
-		<defName>MakeBurgerCheese</defName>
-		<label>cook cheese burger</label>
-		<description>Cooks a burger made from bread, meat and cheese. Delicious! Produces 2.</description>
-		<jobString>Cooking cheese burger.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<workAmount>700</workAmount>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
-		<ingredients>
-			<li>
-				<filter>
-					<categories>
-						<li>MeatRaw</li>
-						<li>AnimalProductRaw</li>	
-					</categories>
-				</filter>
-				<count>0.2</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>bread</li>
-					</thingDefs>
-				</filter>
-				<count>0.2</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Cheese</li>
-					</thingDefs>
-				</filter>
-				<count>0.2</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<categories>
-				<li>MeatRaw</li>
-				<li>AnimalProductRaw</li>	
-			</categories>
-			<thingDefs>
-				<li>bread</li>
-				<li>Cheese</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<defaultIngredientFilter>
-			<thingDefs>
-				<li>bread</li>
-				<li>Cheese</li>
-			</thingDefs>
-			<categories>
-				<li>MeatRaw</li>
-				<li>AnimalProductRaw</li>	
-			</categories>
-			<disallowedThingDefs>
-				<li>Meat_Megaspider</li>
-				<li>Meat_Human</li>
-			</disallowedThingDefs>
-			<disallowedCategories>
-				<li>EggsFertilized</li>
-			</disallowedCategories>
-		</defaultIngredientFilter>
-		<products>
-			<CheeseBurger>2</CheeseBurger>
-		</products>
-		<skillRequirements>
-			<Cooking>8</Cooking>
-		</skillRequirements>
-		<recipeUsers>
-			<li>ElectricStove_Pro</li>
-		</recipeUsers>
-		<workSkill>Cooking</workSkill>
-	</RecipeDef>
-	
 
 	<RecipeDef>
 		<defName>MakeCheeseGrilled</defName>
@@ -514,4 +439,256 @@
 		</recipeUsers>
 		<researchPrerequisite>SK_FungiIII</researchPrerequisite>
 	</RecipeDef>
+
+	<RecipeDef>
+		<defName>MakeCoconutCurry</defName>
+		<label>cook coconut curry</label>
+		<description>Prepares an exotic dish from meat, rice and coconut milk. Produces 2.</description>
+		<jobString>Cooking coconut curry.</jobString>
+		<workSpeedStat>CookSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<workAmount>700</workAmount>
+		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
+		<soundWorking>Chemlab_Medicine_Drink</soundWorking>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>MeatRaw</li>
+					</categories>
+				</filter>
+				<count>0.3</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>coconutmilk</li>
+					</thingDefs>
+				</filter>
+				<count>0.5</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawRice</li>
+					</thingDefs>
+				</filter>
+				<count>0.4</count>
+			</li>
+		</ingredients>
+		<products>
+			<CoconutCurry>2</CoconutCurry>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawRice</li>
+				<li>coconutmilk</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>RawRice</li>
+				<li>coconutmilk</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+		</defaultIngredientFilter>
+		<skillRequirements>
+			<Cooking>9</Cooking>
+		</skillRequirements>
+		<workSkill>Cooking</workSkill>
+		<recipeUsers>
+			<li>ElectricStove</li>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+	</RecipeDef>
+
+
+<!--         Lavish Meals              -->
+	
+	
+	<RecipeDef>
+		<defName>MakeBurgerCheese</defName>
+		<label>cook cheese burger</label>
+		<description>Cooks a burger made from bread, meat and cheese. Delicious! Produces 2.</description>
+		<jobString>Cooking cheese burger.</jobString>
+		<workSpeedStat>CookSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<workAmount>900</workAmount>
+		<soundWorking>Recipe_CookMeal</soundWorking>
+		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Meat_Muffalo</li>
+						<li>MetalCannedMeat_prime</li>
+					</thingDefs>
+				</filter>
+				<count>0.5</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>bread</li>
+					</thingDefs>
+				</filter>
+				<count>0.6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Cheese</li>
+					</thingDefs>
+				</filter>
+				<count>0.3</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawTomatoes</li>
+					</thingDefs>
+				</filter>
+				<count>0.3</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Meat_Muffalo</li>
+				<li>MetalCannedMeat_prime</li>
+				<li>bread</li>
+				<li>Cheese</li>
+				<li>RawTomatoes</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>Meat_Muffalo</li>
+				<li>MetalCannedMeat_prime</li>
+				<li>bread</li>
+				<li>Cheese</li>
+				<li>RawTomatoes</li>
+			</thingDefs>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+			<disallowedCategories>
+				<li>EggsFertilized</li>
+			</disallowedCategories>
+		</defaultIngredientFilter>
+		<products>
+			<CheeseBurger>2</CheeseBurger>
+		</products>
+		<skillRequirements>
+			<Cooking>13</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<workSkill>Cooking</workSkill>
+	</RecipeDef>
+	
+	<RecipeDef>
+		<defName>MakeMisoSoup</defName>
+		<label>cook miso soup</label>
+		<description>Prepares a luxury miso soup from tofu, algae, mushrooms and onion. Produces 2.</description>
+		<jobString>Cooking coconut curry.</jobString>
+		<workSpeedStat>CookSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<workAmount>900</workAmount>
+		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
+		<soundWorking>Chemlab_Medicine_Drink</soundWorking>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Tofu</li>
+					</thingDefs>
+				</filter>
+				<count>0.5</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawShimmershroom</li>
+						<li>RawGlowbulb</li>
+						<li>Rawmushroom</li>
+					</thingDefs>
+				</filter>
+				<count>0.4</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Rawonion</li>
+					</thingDefs>
+				</filter>
+				<count>0.03</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawAlgae</li>
+					</thingDefs>
+				</filter>
+				<count>0.25</count>
+			</li>
+		</ingredients>
+		<products>
+			<MisoSoup>2</MisoSoup>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawShimmershroom</li>
+				<li>RawGlowbulb</li>
+				<li>Rawmushroom</li>
+				<li>Tofu</li>
+				<li>Rawonion</li>
+				<li>RawAlgae</li>
+			</thingDefs>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>RawShimmershroom</li>
+				<li>RawGlowbulb</li>
+				<li>Rawmushroom</li>
+				<li>Tofu</li>
+				<li>Rawonion</li>
+				<li>RawAlgae</li>
+			</thingDefs>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+		</defaultIngredientFilter>
+		<skillRequirements>
+			<Cooking>14</Cooking>
+		</skillRequirements>
+		<workSkill>Cooking</workSkill>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+	</RecipeDef>
+	
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
@@ -321,7 +321,7 @@
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>5</daysToRotStart>
+				<daysToRotStart>4</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>
@@ -351,7 +351,7 @@
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>5</daysToRotStart>
+				<daysToRotStart>4</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Special.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Special.xml
@@ -24,11 +24,15 @@
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>7</daysToRotStart>
+				<daysToRotStart>5</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>
 	</ThingDef>
+	
+	
+<!--         Fine Meals          -->
+	
 	
 	<ThingDef ParentName="SK_MealBase">
 		<defName>HeartyStew</defName>
@@ -60,7 +64,7 @@
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>6</daysToRotStart>
+				<daysToRotStart>4</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>
@@ -92,43 +96,6 @@
 				<li Class="IngestionOutcomeDoer_GiveHediff">
 					<hediffDef>HadMakiRolls</hediffDef>
 					<severity>0.6</severity>
-				</li>
-			</outcomeDoers>
-		</ingestible>
-		<comps>
-			<li Class="CompProperties_Rottable">
-				<daysToRotStart>5</daysToRotStart>
-				<rotDestroys>true</rotDestroys>
-			</li>
-		</comps>
-	</ThingDef>
-	
-	<ThingDef ParentName="SK_MealBase">
-		<defName>CheeseBurger</defName>
-		<label>cheese burger</label>
-		<description>Two slices of bread with grilled meat and cheese melt. \n\nFood Effects: Metabolism.</description>
-		<graphicData>
-			<texPath>Things/Item/Meal/Meal_BurgerCheese</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>
-		<statBases>
-			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>39</MarketValue>
-			<Bulk>1.5</Bulk>
-			<Mass>1.2</Mass>	 
-			<Nutrition>0.9</Nutrition>
-		</statBases>
-		<ingestible>
-			<tasteThought>AteLavishMeal</tasteThought>
-			<preferability>MealLavish</preferability>
-			<joy>0.045</joy>
-			<ingestEffect>EatVegetarian</ingestEffect>
-			<ingestSound>Meal_Eat</ingestSound>
-			<joyKind>Gluttonous</joyKind>
-			<outcomeDoers>
-				<li Class="IngestionOutcomeDoer_GiveHediff">
-					<hediffDef>HedGmeat</hediffDef>
-					<severity>0.25</severity>
 				</li>
 			</outcomeDoers>
 		</ingestible>
@@ -208,7 +175,7 @@
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>5</daysToRotStart>
+				<daysToRotStart>4</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>
@@ -245,7 +212,120 @@
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>5</daysToRotStart>
+				<daysToRotStart>4</daysToRotStart>
+				<rotDestroys>true</rotDestroys>
+			</li>
+		</comps>
+	</ThingDef>
+	
+	<ThingDef ParentName="SK_MealBase">
+		<defName>CoconutCurry</defName>
+		<label>Coconut Curry</label>
+		<description>Exotic dish that allows you to stay in the heat for longer.</description>
+		<graphicData>
+			<texPath>Things/Item/Meal/Mushrooms</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<statBases>
+			<DeteriorationRate>10</DeteriorationRate>
+			<MarketValue>20</MarketValue>
+			<Bulk>1.5</Bulk>
+			<Mass>1.2</Mass>	
+			<Nutrition>0.85</Nutrition>	
+		</statBases>
+		<stackLimit>10</stackLimit>
+		<ingestible>
+			<tasteThought>AteFineMeal</tasteThought>
+			<preferability>MealFine</preferability>
+			<ingestEffect>EatVegetarian</ingestEffect>
+			<ingestSound>Meal_Eat</ingestSound>
+			<outcomeDoers>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>HadCoconutCurry</hediffDef>
+					<severity>0.6</severity>
+				</li>
+			</outcomeDoers>
+		</ingestible>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+				<rotDestroys>true</rotDestroys>
+			</li>
+		</comps>
+	</ThingDef>
+	
+<!--           Lavish Meals              -->
+	
+	<ThingDef ParentName="SK_MealBase">
+		<defName>CheeseBurger</defName>
+		<label>cheese burger</label>
+		<description>A delicious cheese burger made of only the finest meat.</description>
+		<graphicData>
+			<texPath>Things/Item/Meal/Meal_BurgerCheese</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<statBases>
+			<DeteriorationRate>10</DeteriorationRate>
+			<MarketValue>39</MarketValue>
+			<Bulk>1.5</Bulk>
+			<Mass>1.2</Mass>	 
+			<Nutrition>0.95</Nutrition>
+		</statBases>
+		<ingestible>
+			<tasteThought>AteLavishMeal</tasteThought>
+			<preferability>MealLavish</preferability>
+			<joy>0.2</joy>
+			<ingestEffect>EatVegetarian</ingestEffect>
+			<ingestSound>Meal_Eat</ingestSound>
+			<joyKind>Gluttonous</joyKind>
+			<outcomeDoers>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>HadCheeseBurger</hediffDef>
+					<severity>0.6</severity>
+				</li>
+			</outcomeDoers>
+		</ingestible>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
+				<rotDestroys>true</rotDestroys>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef ParentName="SK_MealBase">
+		<defName>MisoSoup</defName>
+		<label>Miso Soup</label>
+		<description>A healthy vegan food that boosts your body and mind. Even learning things becomes easier.</description>
+		<graphicData>
+			<texPath>Things/Item/Meal/Mushrooms</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
+		<statBases>
+			<DeteriorationRate>10</DeteriorationRate>
+			<MarketValue>45</MarketValue>
+			<Bulk>1.5</Bulk>
+			<Mass>1.2</Mass>	
+			<Nutrition>0.95</Nutrition>	
+		</statBases>
+		<stackLimit>10</stackLimit>
+		<ingestible>
+			<tasteThought>AteLavishMeal</tasteThought>
+			<preferability>MealLavish</preferability>
+			<joy>0.2</joy>
+			<ingestEffect>EatVegetarian</ingestEffect>
+			<ingestSound>Meal_Eat</ingestSound>
+			<joyKind>Gluttonous</joyKind>
+			<outcomeDoers>
+				<li Class="IngestionOutcomeDoer_GiveHediff">
+					<hediffDef>HadMisoSoup</hediffDef>
+					<severity>0.6</severity>
+				</li>
+			</outcomeDoers>
+		</ingestible>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>4</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Fruits.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Fruits.xml
@@ -35,7 +35,7 @@
 		</thingCategories>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>14</daysToRotStart>
+				<daysToRotStart>6</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>
@@ -65,7 +65,7 @@
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>25</daysToRotStart>
+				<daysToRotStart>7</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>
@@ -91,7 +91,7 @@
 		</thingCategories>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>4</daysToRotStart>
+				<daysToRotStart>7</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>    
@@ -118,7 +118,7 @@
 		</thingCategories>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>4</daysToRotStart>
+				<daysToRotStart>7</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>    
@@ -145,7 +145,7 @@
 		</thingCategories>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>4</daysToRotStart>
+				<daysToRotStart>6</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>    
@@ -172,7 +172,7 @@
 		</thingCategories>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>4</daysToRotStart>
+				<daysToRotStart>7</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>    
@@ -199,7 +199,7 @@
 		</thingCategories>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>4</daysToRotStart>
+				<daysToRotStart>6</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>    

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
@@ -1,6 +1,14 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
+	<MakeMisoSoup.label>Приготовить мисо суп</MakeMisoSoup.label>
+	<MakeMisoSoup.description>Приготовить мисо суп из тофу, водорослей, грибов и лука.</MakeMisoSoup.description>
+	<MakeMisoSoup.jobString>Готовит мисо суп</MakeMisoSoup.jobString>
+
+	<MakeCoconutCurry.label>Приготовить кокосовое карри</MakeCoconutCurry.label>
+	<MakeCoconutCurry.description>Приготовить кокосовое карри из мяса, риса и кокосового молока.</MakeCoconutCurry.description>
+	<MakeCoconutCurry.jobString>Готовит кокосовое карри</MakeCoconutCurry.jobString>
+
 	<MakeMushroomMadness.label>Приготовить грибное безумие</MakeMushroomMadness.label>
 	<MakeMushroomMadness.description>Приготовить грибное безумие из различных грибов.</MakeMushroomMadness.description>
 	<MakeMushroomMadness.jobString>Готовит грибное безумие</MakeMushroomMadness.jobString>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Meals_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Meals_SK.xml
@@ -1,6 +1,12 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
+	<MisoSoup.label>Мисо суп</MisoSoup.label>
+	<MisoSoup.description>Здоровая еда, которая пиатет ваше тело и разум. Даже учиться становится проще.</MisoSoup.description>
+
+	<CoconutCurry.label>Кокосовое карри</CoconutCurry.label>
+	<CoconutCurry.description>Экзотическое блюдо которое позволяет легче переносить жару.</CoconutCurry.description>
+
 	<MushroomMadness.label>Грибное безумие</MushroomMadness.label>
 	<MushroomMadness.description>Только самые приверженные последователи пути Великой Грибницы знают как приготовить грибы увеличив их галюциногенный потенциал при этом не повредив мозг употребляющего.</MushroomMadness.description>
 
@@ -8,7 +14,7 @@
 	<Kebab.description>Нанизанные на шампур куски мяса или рыбы, пожаренные вместе с овощами и грибами.</Kebab.description>
 
 	<MakiRolls.label>Маки роллы</MakiRolls.label>
-	<MakiRolls.description>Цилиндр из риса с водорослями. В середину обычно кладут мясо рыбы.</MakiRolls.description>
+	<MakiRolls.description>Цилиндры из риса с водорослями. В середину обычно кладут мясо рыбы.</MakiRolls.description>
 
 	<MeatSoup.label>Мясной суп</MeatSoup.label>
 	<MeatSoup.description>Варка позволяет извлечь максимальное количество питательности из имещихся ингредиентов. Не самое вкусное блюдо, но оно помогает экономить ресурсы.</MeatSoup.description>

--- a/Mods/RatkinRaceHSK/Defs/ThingDefs_Building/Buildings_Production.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingDefs_Building/Buildings_Production.xml
@@ -186,7 +186,6 @@
 		<size>(2,1)</size>
 		<designationCategory>Production</designationCategory>
 		<recipes>
-			<li>MakeRoastwMushrooms</li>
 			<li>MakeAmmo_Bolt_Metallic</li>
 			<li>MakeAmmo_Bolt_Poison</li>
 			<li>MakeAmmo_Bolt_Explosive</li>


### PR DESCRIPTION
New food: 
- Coconut curry - electric stove tier, boosts movement and increases max comfortable temperature. Great for desert runs
- Miso soup - professional stove tier, boosts consiousness, movement and increases skill learning rate. 

Changed:
- Cheese burger - professional stove tier, boosts pain resistance, movement and lowers hunger rate.
- Fruits have longer shelf time, meals lower shelf time 
-----------------------------
Новая еда: 
- Кокосовое карри - уровень электрической плиты, улучшает движение и увеличивает максимальную комфортную температуру. Идеально для пустынных колоний
- Мисо суп - уровень профессиональной плиты, улучшает сознание и движение, а также увеличивает скорость обучения навыкам

Изменены:
- Чизбургер - уровень профессиональной плиты, улучшает сопротивление боли, движение и снижает скорость голодания
- Фрукты теперь хранятся чуть дольше, а готовая еда чуть меньше