### PR TITLE
Fixed Flashbang grenade recipe x3

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Recipes_HandGrenades.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Recipes_HandGrenades.xml
@@ -172,7 +172,7 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Proj_GrenadeFlashbang>3</Proj_GrenadeFlashbang>
+      <Weapon_GrenadeFlashbang>3</Weapon_GrenadeFlashbang>
     </products>
   </RecipeDef>
   


### PR DESCRIPTION
It's didn't work.

Не работал.
P.S. зачем-то вместо гранаты прописали сам летящий снаряд этой гранаты.