### PR TITLE
Fixing bug with alpaca-carrier and asari that has no meat

### DIFF
--- a/Mods/AsariRace/Defs/ThingDefs_Races/Races_Asari.xml
+++ b/Mods/AsariRace/Defs/ThingDefs_Races/Races_Asari.xml
@@ -136,8 +136,8 @@
 			<Flammability>1</Flammability>
 			<ComfyTemperatureMin>-7</ComfyTemperatureMin>
 			<ComfyTemperatureMax>35</ComfyTemperatureMax>
-			<LeatherAmount>0</LeatherAmount>
-			<MeatAmount>0</MeatAmount>
+			<LeatherAmount>35</LeatherAmount>
+			<MeatAmount>90</MeatAmount>
 			<MeleeDodgeChance>0.7</MeleeDodgeChance>
 			<MeleeCritChance>0.3</MeleeCritChance>
 			<MeleeParryChance>0.3</MeleeParryChance>

--- a/Mods/Core_SK/Defs/BiomeDefs/Biomes_Archipelago.xml
+++ b/Mods/Core_SK/Defs/BiomeDefs/Biomes_Archipelago.xml
@@ -539,7 +539,6 @@
 			<li>Muffalo</li>
 			<li>Dromedary</li>
 			<li>Elephant</li>
-			<li>Alpaca</li>
 		</allowedPackAnimals>
 	</BiomeDef>
 


### PR DESCRIPTION
1. Cannot generate arriving trader caravan for Доминион Солнца because there is a pawn kind (alpaca) who is not a carrier but is in a carriers list.
2. Asari has no meat and leather from butchering. Now they have