### PR TITLE
Fix Shocker & Electric Baton pawns attack priority.

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Stun_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Stun_SK.xml
@@ -68,8 +68,9 @@
 					<li>ElectricShock</li>
 				</capacities>
 				<power>2</power>
-				<cooldownTime>1.3</cooldownTime>
-				<armorPenetrationBlunt>3</armorPenetrationBlunt>
+				<cooldownTime>2.3</cooldownTime>
+				<chanceFactor>100</chanceFactor>
+				<armorPenetrationBlunt>4</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 			</li>
 		</tools>
@@ -121,8 +122,9 @@
 					<li>ElectricShock</li>
 				</capacities>
 				<power>9</power>
-				<cooldownTime>1.65</cooldownTime>
-				<armorPenetrationBlunt>5</armorPenetrationBlunt>
+				<cooldownTime>2.65</cooldownTime>
+				<chanceFactor>100</chanceFactor>
+				<armorPenetrationBlunt>6</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 			</li>
 		</tools>


### PR DESCRIPTION
This should reduce wanting to use fists instead of a stun gun for all pawns (especially thermoses):

![image](https://user-images.githubusercontent.com/62516232/90534234-ee6fca80-e192-11ea-886a-58596d7abe83.png)

Also I light reduced attack speed and increased melee penetration to balance.

Исправлен приоритет атаки пешек шокером и палкой-воспиталкой.
Эти правки должны сбавить пыл у пешек бить кулаками, держа в руке один из шокеров (особенно у термосов, которые вообще его не использовали (см. скрин выше)).
Взамен немного уменьшил скорость атаки и увеличил бронепробитие.