### PR TITLE
Fix pawn fists and some weapons attack priority pt.1

### DIFF
--- a/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
@@ -224,6 +224,7 @@
 				</capacities>
 				<power>8</power>
 				<cooldownTime>1.2</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<surpriseAttack>
 					<extraMeleeDamages>
 						<li>
@@ -233,7 +234,7 @@
 					</extraMeleeDamages>
 				</surpriseAttack>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-				<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+				<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>right fist</label>
@@ -242,6 +243,7 @@
 				</capacities>
 				<power>8</power>
 				<cooldownTime>1.2</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<surpriseAttack>
 					<extraMeleeDamages>
 						<li>
@@ -251,7 +253,7 @@
 					</extraMeleeDamages>
 				</surpriseAttack>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-				<armorPenetrationBlunt>0.25</armorPenetrationBlunt>
+				<armorPenetrationBlunt>1.25</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>head</label>
@@ -262,7 +264,7 @@
 				<cooldownTime>3.8</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<chanceFactor>0.2</chanceFactor>
-				<armorPenetrationBlunt>0.5</armorPenetrationBlunt>
+				<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 			</li>
 		</tools>

--- a/Mods/Androids/Defs/AlienRace/AlienRace_Droids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Droids.xml
@@ -203,6 +203,7 @@
 			</capacities>
 			<power>8</power>
 			<cooldownTime>1.5</cooldownTime>
+			<chanceFactor>0.6</chanceFactor>
 			<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 			<surpriseAttack>
 				<extraMeleeDamages>
@@ -212,7 +213,7 @@
 					</li>
 				</extraMeleeDamages>
 			</surpriseAttack>
-			<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
 		</li>
 		<li Class="CombatExtended.ToolCE">
 			<label>right fist</label>
@@ -221,6 +222,7 @@
 			</capacities>
 			<power>8</power>
 			<cooldownTime>1.5</cooldownTime>
+			<chanceFactor>0.6</chanceFactor>
 			<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 			<surpriseAttack>
 				<extraMeleeDamages>
@@ -230,7 +232,7 @@
 					</li>
 				</extraMeleeDamages>
 			</surpriseAttack>
-			<armorPenetrationBlunt>0.36</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.6</armorPenetrationBlunt>
 		</li>
 		<li Class="CombatExtended.ToolCE">
 			<label>head</label>
@@ -241,7 +243,7 @@
 			<cooldownTime>2.8</cooldownTime>
 			<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 			<chanceFactor>0.2</chanceFactor>
-			<armorPenetrationBlunt>0.3</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3</armorPenetrationBlunt>
 			<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 		</li>
 	</tools>
@@ -593,8 +595,8 @@
 					</li>
 				</extraMeleeDamages>
 			</surpriseAttack>
-			<armorPenetrationBlunt>1.44</armorPenetrationBlunt>
-			<armorPenetrationSharp>0.32</armorPenetrationSharp>
+			<armorPenetrationBlunt>9.6</armorPenetrationBlunt>
+			<armorPenetrationSharp>4.8</armorPenetrationSharp>
 		</li>
 		<li Class="CombatExtended.ToolCE">
 			<label>right bladed fist</label>
@@ -612,8 +614,8 @@
 					</li>
 				</extraMeleeDamages>
 			</surpriseAttack>
-			<armorPenetrationBlunt>1.44</armorPenetrationBlunt>
-			<armorPenetrationSharp>0.32</armorPenetrationSharp>
+			<armorPenetrationBlunt>9.6</armorPenetrationBlunt>
+			<armorPenetrationSharp>4.8</armorPenetrationSharp>
 		</li>
 		<li Class="CombatExtended.ToolCE">
 			<label>head</label>
@@ -624,7 +626,7 @@
 			<cooldownTime>2.8</cooldownTime>
 			<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 			<chanceFactor>0.2</chanceFactor>
-			<armorPenetrationBlunt>1</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4</armorPenetrationBlunt>
 			<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 		</li>
 	</tools>

--- a/Mods/AsariRace/Defs/ThingDefs_Races/Races_Asari.xml
+++ b/Mods/AsariRace/Defs/ThingDefs_Races/Races_Asari.xml
@@ -158,6 +158,7 @@
 				</capacities>
 				<power>8</power>
 				<cooldownTime>1.3</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			</li>
@@ -168,6 +169,7 @@
 				</capacities>
 				<power>8</power>
 				<cooldownTime>1.3</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
@@ -305,6 +305,7 @@
 				</capacities>
 				<power>6</power>
 				<cooldownTime>1.26</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			</li>
@@ -315,6 +316,7 @@
 				</capacities>
 				<power>6</power>
 				<cooldownTime>1.26</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			</li>
@@ -646,6 +648,7 @@
 				</capacities>
 				<power>7</power>
 				<cooldownTime>1.2</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			</li>
@@ -656,6 +659,7 @@
 				</capacities>
 				<power>7</power>
 				<cooldownTime>1.2</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			</li>
@@ -1071,6 +1075,7 @@
 				</capacities>
 				<power>7</power>
 				<cooldownTime>1.3</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
 				<surpriseAttack>
@@ -1089,6 +1094,7 @@
 				</capacities>
 				<power>7</power>
 				<cooldownTime>1.3</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
 				<surpriseAttack>
@@ -1196,8 +1202,9 @@
 				</capacities>
 				<power>8</power>
 				<cooldownTime>1.35</cooldownTime>
+				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-				<armorPenetrationBlunt>1</armorPenetrationBlunt>
+				<armorPenetrationBlunt>2</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>right fist</label>
@@ -1206,8 +1213,9 @@
 				</capacities>
 				<power>8</power>
 				<cooldownTime>1.35</cooldownTime>
+				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-				<armorPenetrationBlunt>1</armorPenetrationBlunt>
+				<armorPenetrationBlunt>2</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>teeth</label>
@@ -1231,7 +1239,7 @@
 				<cooldownTime>2.8</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<chanceFactor>0.2</chanceFactor>
-				<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
+				<armorPenetrationBlunt>2.4</armorPenetrationBlunt>
 				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 			</li>
 		</tools>
@@ -1630,6 +1638,7 @@
 				</capacities>
 				<power>7</power>
 				<cooldownTime>1.15</cooldownTime>
+				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 				<armorPenetrationSharp>1.30</armorPenetrationSharp>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
@@ -1641,6 +1650,7 @@
 				</capacities>
 				<power>7</power>
 				<cooldownTime>1.15</cooldownTime>
+				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 				<armorPenetrationSharp>1.30</armorPenetrationSharp>
 				<armorPenetrationBlunt>1</armorPenetrationBlunt>
@@ -1652,6 +1662,7 @@
 				</capacities>
 				<power>10</power>
 				<cooldownTime>2.7</cooldownTime>
+				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>Tailblunt</linkedBodyPartsGroup>
 				<surpriseAttack>
 					<extraMeleeDamages>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Hightech.xml
@@ -44,7 +44,7 @@
 				</capacities>
 				<power>6</power>
 				<cooldownTime>1.25</cooldownTime>
-				<chanceFactor>0.1</chanceFactor>
+				<chanceFactor>0.2</chanceFactor>
 				<armorPenetrationBlunt>4</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 			</li>
@@ -55,7 +55,7 @@
 				</capacities>
 				<power>14</power>
 				<cooldownTime>1.1</cooldownTime>
-				<chanceFactor>0.4</chanceFactor>
+				<chanceFactor>0.8</chanceFactor>
 				<armorPenetrationBlunt>1.2</armorPenetrationBlunt>
 				<armorPenetrationSharp>4.5</armorPenetrationSharp>
 				<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
@@ -118,7 +118,7 @@
 				</capacities>
 				<power>7</power>
 				<cooldownTime>1.25</cooldownTime>
-				<chanceFactor>0.1</chanceFactor>
+				<chanceFactor>0.2</chanceFactor>
 				<armorPenetrationBlunt>4</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 			</li>
@@ -128,7 +128,7 @@
 					<li>Stab</li>
 				</capacities>
 				<power>18</power>
-				<chanceFactor>0.33</chanceFactor>
+				<chanceFactor>0.9</chanceFactor>
 				<cooldownTime>1.2</cooldownTime>
 				<armorPenetrationBlunt>1.3</armorPenetrationBlunt>
 				<armorPenetrationSharp>6.5</armorPenetrationSharp>
@@ -141,7 +141,7 @@
 				</capacities>
 				<power>20</power>
 				<cooldownTime>1.3</cooldownTime>
-				<chanceFactor>1.33</chanceFactor>
+				<chanceFactor>1.25</chanceFactor>
 				<armorPenetrationBlunt>2.1</armorPenetrationBlunt>
 				<armorPenetrationSharp>5.5</armorPenetrationSharp>
 				<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
@@ -190,7 +190,7 @@
 				</capacities>
 				<power>8</power>
 				<cooldownTime>1.5</cooldownTime>
-				<chanceFactor>0.10</chanceFactor>
+				<chanceFactor>0.25</chanceFactor>
 				<armorPenetrationBlunt>6</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 			</li>
@@ -201,7 +201,7 @@
 				</capacities>
 				<power>25</power>
 				<cooldownTime>1.6</cooldownTime>
-				<chanceFactor>0.33</chanceFactor>
+				<chanceFactor>0.75</chanceFactor>
 				<armorPenetrationBlunt>2.5</armorPenetrationBlunt>
 				<armorPenetrationSharp>10</armorPenetrationSharp>
 				<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
@@ -213,7 +213,7 @@
 				</capacities>
 				<power>29</power>
 				<cooldownTime>1.5</cooldownTime>
-				<chanceFactor>1.3</chanceFactor>
+				<chanceFactor>1.15</chanceFactor>
 				<armorPenetrationBlunt>11</armorPenetrationBlunt>
 				<armorPenetrationSharp>8</armorPenetrationSharp>
 				<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Medieval.xml
@@ -190,7 +190,7 @@
 				</capacities>
 				<power>6</power>
 				<cooldownTime>1.2</cooldownTime>
-				<chanceFactor>0.10</chanceFactor>
+				<chanceFactor>0.2</chanceFactor>
 				<armorPenetrationBlunt>4</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Handle</linkedBodyPartsGroup>
 			</li>
@@ -201,7 +201,7 @@
 				</capacities>
 				<power>16</power>
 				<cooldownTime>1.8</cooldownTime>
-				<chanceFactor>0.7</chanceFactor>
+				<chanceFactor>1</chanceFactor>
 				<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
 				<armorPenetrationSharp>4.8</armorPenetrationSharp>
 				<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
@@ -213,7 +213,7 @@
 				</capacities>
 				<power>22</power>
 				<cooldownTime>2</cooldownTime>
-				<chanceFactor>0.30</chanceFactor>
+				<chanceFactor>0.6</chanceFactor>
 				<armorPenetrationBlunt>6.5</armorPenetrationBlunt>
 				<armorPenetrationSharp>3.7</armorPenetrationSharp>
 				<linkedBodyPartsGroup>Edge</linkedBodyPartsGroup>
@@ -352,6 +352,7 @@
 				</capacities>
 				<power>9</power>
 				<cooldownTime>2.1</cooldownTime>
+				<chanceFactor>1.33</chanceFactor>
 				<armorPenetrationSharp>5.5</armorPenetrationSharp>
 				<armorPenetrationBlunt>11</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Neolithic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Neolithic.xml
@@ -176,7 +176,7 @@
 				</capacities>
 				<power>10</power>
 				<cooldownTime>2.1</cooldownTime>
-				<chanceFactor>1</chanceFactor>
+				<chanceFactor>1.33</chanceFactor>
 				<armorPenetrationBlunt>9</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 			</li>
@@ -226,7 +226,7 @@
 				</capacities>
 				<power>9</power>
 				<cooldownTime>2.2</cooldownTime>
-				<chanceFactor>1</chanceFactor>
+				<chanceFactor>1.33</chanceFactor>
 				<armorPenetrationBlunt>8</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
 			</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
@@ -37,6 +37,7 @@
 				</capacities>
 				<power>7</power>
 				<cooldownTime>1.6</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<armorPenetrationBlunt>0.80</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
 			</li>
@@ -48,6 +49,7 @@
 				</capacities>
 				<power>8</power>
 				<cooldownTime>1.6</cooldownTime>
+				<chanceFactor>0.5</chanceFactor>
 				<armorPenetrationBlunt>0.60</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
 			</li>

--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Lance.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Lance.xml
@@ -298,6 +298,7 @@
 				</capacities>
 				<power>27</power>
 				<cooldownTime>2.5</cooldownTime>
+				<chanceFactor>1.25</chanceFactor>
 				<armorPenetrationSharp>4.3</armorPenetrationSharp>
 				<armorPenetrationBlunt>9.5</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Head</linkedBodyPartsGroup>
@@ -309,7 +310,7 @@
 				</capacities>
 				<power>21</power>
 				<cooldownTime>2.5</cooldownTime>
-				<chanceFactor>0.8</chanceFactor>
+				<chanceFactor>1.33</chanceFactor>
 				<armorPenetrationSharp>2.4</armorPenetrationSharp>
 				<armorPenetrationBlunt>6.7</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Point</linkedBodyPartsGroup>
@@ -321,7 +322,7 @@
 				</capacities>
 				<power>13</power>
 				<cooldownTime>2.5</cooldownTime>
-				<chanceFactor>0.2</chanceFactor>
+				<chanceFactor>0.4</chanceFactor>
 				<armorPenetrationBlunt>5.0</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Shaft</linkedBodyPartsGroup>
 			</li>

--- a/Mods/RatkinRaceHSK/Patches/ThingDefs_Races/Race_Rakinlike.xml
+++ b/Mods/RatkinRaceHSK/Patches/ThingDefs_Races/Race_Rakinlike.xml
@@ -58,6 +58,7 @@
 						</capacities>
 						<power>4</power>
 						<cooldownTime>1.11</cooldownTime>
+					  	<chanceFactor>0.6</chanceFactor>
 						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 						<armorPenetrationBlunt>2.4</armorPenetrationBlunt>
 						<armorPenetrationSharp>1.8</armorPenetrationSharp>
@@ -69,7 +70,7 @@
 						</capacities>
 						<power>4</power>
 						<cooldownTime>1.11</cooldownTime>
-						<chanceFactor>0.6</chanceFactor>
+						<chanceFactor>0.5</chanceFactor>
 						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 						<armorPenetrationBlunt>1.8</armorPenetrationBlunt>
 				  </li>
@@ -80,6 +81,7 @@
 						</capacities>
 						<power>4</power>
 						<cooldownTime>1.11</cooldownTime>
+					  	<chanceFactor>0.6</chanceFactor>
 						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
 						<armorPenetrationBlunt>2.4</armorPenetrationBlunt>
 						<armorPenetrationSharp>1.8</armorPenetrationSharp>
@@ -91,7 +93,7 @@
 						</capacities>
 						<power>4</power>
 						<cooldownTime>1.11</cooldownTime>
-						<chanceFactor>0.6</chanceFactor>
+						<chanceFactor>0.5</chanceFactor>
 						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
 						<armorPenetrationBlunt>1.8</armorPenetrationBlunt>
 				  </li>


### PR DESCRIPTION
Fix pawn fists and some weapons attack priority pt.1 (hope it would be only one part).
This should reduce wanting to use fists instead of some melee weapon.
Also balancing armor penetration to androids/droids.

Немного подправил вес у кулаков и некоторого оружия. Теперь пешки будут меньше хотеть бить кулаками вместо оружия.
Также подправил бронепробитие у андроидов и дроидов.