### PR TITLE
Delete duplicate gear tab (ratkins)

### DIFF
--- a/Mods/RatkinRaceHSK/Patches/ThingDefs_Races/Race_Rakinlike.xml
+++ b/Mods/RatkinRaceHSK/Patches/ThingDefs_Races/Race_Rakinlike.xml
@@ -125,14 +125,6 @@
 		</li>
 
 		<!--Adding Inventory Support-->
-		<li Class="PatchOperationAdd">
-			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]</xpath>
-			<value>
-			<inspectorTabs>
-				<li>CombatExtended.ITab_Inventory</li>
-			</inspectorTabs>				
-			</value>
-		</li>
 
 		<li Class="PatchOperationAdd">
 			<xpath>Defs/AlienRace.ThingDef_AlienRace[defName="Ratkin"]/comps</xpath>


### PR DESCRIPTION
Удалил дублирующуюся вкладку инвентаря у раткинов.