### PR TITLE
(enough) big changes on storage

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage.xml
@@ -1,7 +1,6 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 	<!--============================== Storage ==============================-->
-
 	<!-- Template:
 //// Basics
 <ThingDef Name="OPTIONAL-Unique_Name-Optional_but_you_can_use_it_as_ParentName_later_if_you_want"
@@ -134,7 +133,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
   </comps>
 </ThingDef>
   -->
-
 	<ThingDef Name="LWM_DeepStorage" ParentName="StandartBuilding" Abstract="true">
 		<defName>LWM_DeepStorage</defName>
 		<thingClass>Building_Storage</thingClass>
@@ -174,11 +172,10 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</building>
 		<designationCategory>LWM_DS_Storage</designationCategory>
 	</ThingDef>
-
 	<ThingDef Name="LWM_Pallet" ParentName="LWM_DeepStorage">
 		<defName>LWM_Pallet</defName>
 		<label>Pallet</label>
-		<description>A flat pallet for packing things.  Does not protect against the weather.  Sometimes difficult to manage, but useful nonetheless.</description>
+		<description>A flat pallet for packing things.  Does not protect against the weather. Sometimes difficult to manage, but useful nonetheless.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Storage/woodpallet</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>
@@ -190,7 +187,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<size>(2,1)</size>
 		<statBases>
 			<MarketValue>100</MarketValue>
-			<MaxHitPoints>60</MaxHitPoints>
+			<MaxHitPoints>95</MaxHitPoints>
 			<WorkToBuild>400</WorkToBuild>
 			<Flammability>1.0</Flammability>
 			<Beauty>-4</Beauty>
@@ -211,29 +208,26 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<fixedStorageSettings>
 				<priority>Important</priority>
 				<filter>
-					<categories>
+						<categories>
 						<li>Manufactured</li>
 						<li>ResourcesRaw</li>
-						<li>SeedsCategory</li>
 						<li>FoodRaw</li>
 						<li>CookingSupplies</li>
 						<li>LuxuryStuffs</li>
-						<li>SweetMeals</li>
 						<li>Alcohol</li>
-						<li>Energetics</li>
-						<li>Drugs</li>
-						<li>Animalfood</li>
-						<li>Textiles</li>
 					</categories>
 					<disallowedCategories>
-						<!--Again, no loose things-->
-						<li>PlantMatter</li>						
+						<li>Textiles</li>
+						<li>Medicine</li>
+						<li>WeaponCrate</li>
+						<li>WeaponParts</li>
+						<li>SeedsCategory</li>
 					</disallowedCategories>
 				</filter>
 			</fixedStorageSettings>
 		</building>
 		<comps>
-			<li Class="LWM.DeepStorage.Properties" >
+			<li Class="LWM.DeepStorage.Properties">
 				<maxNumberStacks>6</maxNumberStacks>
 				<minTimeStoringTakes>25</minTimeStoringTakes>
 				<additionalTimeEachStack>22</additionalTimeEachStack>
@@ -247,12 +241,11 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>2</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<ThingDef Name="LWM_DeepStorage_Skip" ParentName="LWM_DeepStorage">
 		<!--Ready-->
 		<defName>LWM_DeepStorage_Skip</defName>
 		<label>Skip</label>
-		<description>A large metal bin for tossing heavy things in.  These skips are not covered; they are open to the weather.</description>
+		<description>A large metal bin for tossing heavy things in. These skips are not covered; they are open to the weather.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Storage/steelpallet</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>
@@ -272,7 +265,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</statBases>
 		<stuffCategories>
 			<li>Metallic</li>
-			<li>Woody</li>
 		</stuffCategories>
 		<costStuffCount>30</costStuffCount>
 		<costList>
@@ -288,21 +280,23 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 					<categories>
 						<li>Manufactured</li>
 						<li>ResourcesRaw</li>
-						<li>SeedsCategory</li>
 						<li>FoodRaw</li>
 						<li>CookingSupplies</li>
 						<li>LuxuryStuffs</li>
-						<li>SweetMeals</li>
 						<li>Alcohol</li>
-						<li>Energetics</li>
-						<li>Drugs</li>
-						<li>Animalfood</li>
 					</categories>
+					<disallowedCategories>
+						<li>Textiles</li>
+						<li>Medicine</li>
+						<li>WeaponCrate</li>
+						<li>WeaponParts</li>
+						<li>SeedsCategory</li>
+					</disallowedCategories>
 				</filter>
 			</fixedStorageSettings>
 		</building>
 		<comps>
-			<li Class="LWM.DeepStorage.Properties" >
+			<li Class="LWM.DeepStorage.Properties">
 				<maxNumberStacks>8</maxNumberStacks>
 				<minTimeStoringTakes>15</minTimeStoringTakes>
 				<!--Got to climb in, get it positioned right, etc-->
@@ -314,11 +308,10 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			</li>
 		</comps>
 		<researchPrerequisites>
-			<li>SK_StorageII</li>
+			<li>SK_StorageIII</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>2</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<ThingDef ParentName="LWM_DeepStorage">
 		<defName>Pot</defName>
 		<label>pot</label>
@@ -360,6 +353,9 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 					<categories>
 						<li>Foods</li>
 					</categories>
+					<disallowedCategories>
+						<li>Alcohol</li>
+					</disallowedCategories>
 				</filter>
 			</fixedStorageSettings>
 		</building>
@@ -368,8 +364,8 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<li Class="SK.CompProperties_RotModified">
 				<rotmodifier>0.4</rotmodifier>
 			</li>
-			<li Class="LWM.DeepStorage.Properties" >
-				<maxNumberStacks>5</maxNumberStacks>
+			<li Class="LWM.DeepStorage.Properties">
+				<maxNumberStacks>6</maxNumberStacks>
 				<timeStoringTakes>25</timeStoringTakes>
 				<overlayType>SumOfItemsPerCell</overlayType>
 			</li>
@@ -377,11 +373,10 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<researchPrerequisites Inherit="false"/>
 		<constructionSkillPrerequisite>2</constructionSkillPrerequisite>
 	</ThingDef>
-	
 	<ThingDef ParentName="LWM_DeepStorage">
 		<defName>Basket</defName>
 		<label>basket</label>
-		<description>A basket made of leather or textile. Used to store various things inside. Up to 6 items.</description>
+		<description>A basket made of leather or textile. Used to store various things inside.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Containers/Basket</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -430,7 +425,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<li Class="SK.CompProperties_RotModified">
 				<rotmodifier>0.4</rotmodifier>
 			</li>
-			<li Class="LWM.DeepStorage.Properties" >
+			<li Class="LWM.DeepStorage.Properties">
 				<maxNumberStacks>5</maxNumberStacks>
 				<timeStoringTakes>15</timeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
@@ -441,11 +436,10 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<researchPrerequisites Inherit="false"/>
 		<constructionSkillPrerequisite>2</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<ThingDef ParentName="LWM_DeepStorage">
 		<defName>Barrel</defName>
 		<label>barrel</label>
-		<description>A barrel made of wood or metal. Used to store various things inside. Up to 5 items.</description>
+		<description>A barrel made of wood or metal. Used to store clothes.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Containers/barrel</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -481,32 +475,29 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<fixedStorageSettings>
 				<filter>
 					<categories>
-						<li>Root</li>
+						<li>Apparel</li>
 					</categories>
-					<disallowedCategories>
-						<li>Corpses</li>
-						<li>Chunks</li>
-						<li>StoneBlocks</li>
-					</disallowedCategories>
 				</filter>
 			</fixedStorageSettings>
 		</building>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties">
-				<maxNumberStacks>5</maxNumberStacks>
+				<maxNumberStacks>8</maxNumberStacks>
 				<minTimeStoringTakes>15</minTimeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
 				<showContents>false</showContents>
 				<overlayType>SumOfItemsPerCell</overlayType>
 			</li>
 		</comps>
+		<researchPrerequisites>
+			<li>SK_StorageI</li>
+		</researchPrerequisites>
 		<constructionSkillPrerequisite>3</constructionSkillPrerequisite>
 	</ThingDef>
-	
 	<ThingDef ParentName="LWM_DeepStorage">
 		<defName>Chest</defName>
 		<label>chest</label>
-		<description>A simple chest. Used to store various things inside. Up to 6 items.</description>
+		<description>A simple chest. Used to store various things inside.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Containers/Chest</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -556,7 +547,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</building>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties">
-				<maxNumberStacks>6</maxNumberStacks>
+				<maxNumberStacks>5</maxNumberStacks>
 				<minTimeStoringTakes>35</minTimeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
 				<showContents>false</showContents>
@@ -566,15 +557,14 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			</li>
 		</comps>
 		<researchPrerequisites>
-			<li>SK_Craftsmanship</li>
+			<li>SK_StorageI</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>4</constructionSkillPrerequisite>
 	</ThingDef>
-	
 	<ThingDef ParentName="LWM_DeepStorage">
 		<defName>IndustrialChest</defName>
 		<label>armored chest</label>
-		<description>An armored chest made of metal. Used to store various things inside. Up to 6 items.</description>
+		<description>An armored chest made of metal. Used to store various things inside.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Containers/AdvChest</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -589,7 +579,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<costStuffCount>50</costStuffCount>
 		<stuffCategories>
 			<li>Metallic</li>
-			<li>Precious</li>
 		</stuffCategories>
 		<costList>
 			<ComponentIndustrial>4</ComponentIndustrial>
@@ -616,13 +605,14 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 						<li>Corpses</li>
 						<li>Chunks</li>
 						<li>StoneBlocks</li>
+						<li>Buildings</li>
 					</disallowedCategories>
 				</filter>
 			</fixedStorageSettings>
 		</building>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties">
-				<maxNumberStacks>6</maxNumberStacks>
+				<maxNumberStacks>7</maxNumberStacks>
 				<minTimeStoringTakes>40</minTimeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
 				<showContents>false</showContents>
@@ -636,12 +626,10 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>9</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<ThingDef Name="LWM_Meat_Hook" ParentName="LWM_DeepStorage">
 		<defName>LWM_Meat_Hook</defName>
 		<label>Meat Hook</label>
 		<description>A tall metal frame with several hooks hanging from chains.  A simple crank allows hoisting several hanging things into the air.  A way to store the dead bodies of fellow animals you have killed, before cutting them up and consuming their flesh.  You monster.
-
 			Note that you can only fit so many giant corpses into one space, even if you stack them.  The frame will only hold so much weight.</description>
 		<graphicData>
 			<texPath>Things/Building/StorageTest/MeatHook</texPath>
@@ -692,7 +680,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			</defaultStorageSettings>
 		</building>
 		<comps>
-			<li Class="LWM.DeepStorage.Properties" >
+			<li Class="LWM.DeepStorage.Properties">
 				<minNumberStacks>2</minNumberStacks>
 				<!-- minimum one in the air, one on the ground -->
 				<maxNumberStacks>12</maxNumberStacks>
@@ -706,16 +694,13 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 				<!--We only recently realized what these weird caves were.-->
 				<overlayType>CountOfStacksPerCell</overlayType>
 			</li>
-			<li>
-				<compClass>CompQuality</compClass>
-			</li>
+			
 			<!--TOOD: <li><compClass>CompQuality</compClass></li> make this add storage capacity-->
 		</comps>
-		<researchPrerequisites Inherit="false">
-			<li>Smithing</li>
+		<researchPrerequisites>
+			<li>SK_StorageI</li>
 		</researchPrerequisites>
 	</ThingDef>
-
 	<ThingDef ParentName="SK_FurnitureBase">
 		<defName>FeedingBowl</defName>
 		<label>feeding bowl</label>
@@ -781,11 +766,10 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>3</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<ThingDef ParentName="LWM_DeepStorage">
 		<defName>FabricHamperSingle</defName>
 		<label>Hamper</label>
-		<description>This is a smaller hamper made out of fabric.  The various pockets allow storing large amounts of diverse small items with ease.</description>
+		<description>This is a smaller hamper made out of fabric. The various pockets allow storing large amounts of diverse small items with ease.</description>
 		<graphicData>
 			<texPath>Things/Building/StorageTest/FabricHamperSingle/FabricHamperSingle</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -817,39 +801,37 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 					<!-- No "Fabric" here - I think hampers are a terrible say to store
                fabric, and if players want to, they can add via Mod Settings -->
 					<categories>
+						<li>Textiles</li>
 						<li>PlantFoodRaw</li>
 						<!-- Do use sense, eh? -->
 						<li>EggsUnfertilized</li>
 						<li>EggsFertilized</li>
 						<li>Medicine</li>
 						<li>Drugs</li>
-						<li>MortarShells</li>
 						<li>PlantMatter</li>
 						<!--Ammo, etc-->
 						<!--Fleeces, raw cotton, etc-->
 					</categories>
-					<thingDefs>
-						<li>Gold</li>
-						<li>Silver</li>
-					</thingDefs>
 				</filter>
 			</fixedStorageSettings>
 		</building>
 		<comps>
-			<li Class="LWM.DeepStorage.Properties" >
-				<maxNumberStacks>6</maxNumberStacks>
+			<li Class="LWM.DeepStorage.Properties">
+				<maxNumberStacks>8</maxNumberStacks>
 				<minTimeStoringTakes>15</minTimeStoringTakes>
 				<additionalTimeEachStack>12</additionalTimeEachStack>
 				<showContents>false</showContents>
 				<overlayType>SumOfItemsPerCell</overlayType>
 			</li>
 		</comps>
+		<researchPrerequisites>
+			<li>SK_StorageIII</li>
+		</researchPrerequisites>
 	</ThingDef>
-
 	<ThingDef Name="LWM_BigShelf" ParentName="LWM_DeepStorage">
 		<defName>LWM_BigShelf</defName>
 		<label>Double Shelf</label>
-		<description>A shelf for storing miscellaneous items, from artillery shells to artwork, from bionic arms to bricks, from chairs to corpses.  It doesn't ask questions, it just stores things.\n\nItems stored in this will not deteriorate, even if outside.\n\nThis shelf holds twice as much as the regular one.</description>
+		<description>A shelf for storing miscellaneous items, from artillery shells to artwork, from bionic arms to stone chunks, from chairs to corpses.  It doesn't ask questions, it just stores things.\n\nItems stored in this will not deteriorate, even if outside.</description>
 		<thingClass>Building_Storage</thingClass>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Shelf</texPath>
@@ -884,21 +866,20 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<staticSunShadowHeight>0.9</staticSunShadowHeight>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties">
-				<maxNumberStacks>2</maxNumberStacks>
+				<maxNumberStacks>5</maxNumberStacks>
 				<minTimeStoringTakes>5</minTimeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
 				<overlayType>SumOfItemsPerCell</overlayType>
 			</li>
 		</comps>
 		<researchPrerequisites>
-			<li>ComplexFurniture</li>
+			<li>SK_StorageII</li>
 		</researchPrerequisites>
 	</ThingDef>
-
 	<ThingDef Name="LWM_VeryBigShelf" ParentName="LWM_DeepStorage">
 		<defName>LWM_VeryBigShelf</defName>
 		<label>tall shelf</label>
-		<description>A set of tall covered shelves for storing miscellaneous items, from artillery shells to artwork, from bionic arms to bricks, from chairs to corpses. It doesn't ask questions, it just stores things.</description>
+		<description>A set of tall covered shelves for storing single items.</description>
 		<thingClass>Building_Storage</thingClass>
 		<graphicData>
 			<texPath>Things/Building/StorageTest/VBig_Shelf</texPath>
@@ -909,7 +890,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<castEdgeShadows>true</castEdgeShadows>
 		<stuffCategories>
 			<li>Metallic</li>
-			<li>Woody</li>
 		</stuffCategories>
 		<costStuffCount>120</costStuffCount>
 		<costList>
@@ -926,6 +906,17 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<size>(2,1)</size>
 		<defaultPlacingRot>South</defaultPlacingRot>
 		<building>
+			<fixedStorageSettings>
+				<filter>
+					<categories>
+						<li>Items</li>
+						<li>BodyParts</li>
+					</categories>
+					<disallowedCategories>
+						<li>BodyPartsNatural</li>
+					</disallowedCategories>
+				</filter>
+			</fixedStorageSettings>
 			<preventDeteriorationOnTop>true</preventDeteriorationOnTop>
 			<ignoreStoredThingsBeauty>true</ignoreStoredThingsBeauty>
 			<defaultStorageSettings>
@@ -935,7 +926,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<staticSunShadowHeight>1</staticSunShadowHeight>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties">
-				<maxNumberStacks>4</maxNumberStacks>
+				<maxNumberStacks>8</maxNumberStacks>
 				<minTimeStoringTakes>5</minTimeStoringTakes>
 				<additionalTimeEachStack>30</additionalTimeEachStack>
 				<additionalTimeStackSize>10</additionalTimeStackSize>
@@ -943,14 +934,13 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			</li>
 		</comps>
 		<researchPrerequisites>
-			<li>ComplexFurniture</li>
+			<li>SK_StorageIII</li>
 		</researchPrerequisites>
 	</ThingDef>
-
 	<ThingDef Name="LWM_MealRack" ParentName="LWM_DeepStorage">
 		<defName>TrayRackSingle</defName>
 		<label>serving table</label>
-		<description>This is a smaller tall tray rack; haulers carry meals and treats here for storage.</description>
+		<description>This is a smaller tall tray rack; haulers carry meals and treats here for storage. Slows rotting process.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Containers/Servingtable/servingtable</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>
@@ -972,7 +962,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</statBases>
 		<stuffCategories>
 			<li>Metallic</li>
-			<li>Woody</li>
 			<li>Plastic</li>
 		</stuffCategories>
 		<costStuffCount>35</costStuffCount>
@@ -986,23 +975,22 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 					<categories>
 						<li>FoodMeals</li>
 						<li>SweetMeals</li>
-						<li>Medicine</li>
+						<li>Energetics</li>
 					</categories>
 					<thingDefs>
 						<li>MintLeaves</li>
 						<li>Hypericum</li>
 						<li>WildRose</li>
-						<li>aloe</li>
-						<li>RawTea</li>
-						<li>RawTobacco</li>
+				<!--	<li>RawTea</li>
+						<li>RawTobacco</li> -->
 					</thingDefs>
 				</filter>
 			</fixedStorageSettings>
 		</building>
 		<tickerType>Rare</tickerType>
 		<comps>
-			<li Class="LWM.DeepStorage.Properties" >
-				<maxNumberStacks>5</maxNumberStacks>
+			<li Class="LWM.DeepStorage.Properties">
+				<maxNumberStacks>8</maxNumberStacks>
 				<!--<timeStoringTakes>50</timeStoringTakes>-->
 				<minTimeStoringTakes>30</minTimeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
@@ -1012,7 +1000,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			</li>
 			<li Class="SK.CompProperties_RotModified">
 				<compClass>SK.CompRotModified</compClass>
-				<rotmodifier>0.3</rotmodifier>
+				<rotmodifier>0.4</rotmodifier>
 			</li>
 			<li Class="RimFridge.CompProperties_SecondLayer">
 				<graphicData>
@@ -1023,21 +1011,18 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 				</graphicData>
 				<altitudeLayer>Projectile</altitudeLayer>
 			</li>
-			<li>
-				<compClass>CompQuality</compClass>
-			</li>			
+			
 		</comps>
 		<researchPrerequisites>
-			<li>SK_StorageII</li>
+			<li>SK_StorageIII</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>4</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<ThingDef Name="LWM_Hayloft" ParentName="LWM_DeepStorage">
 		<!--LWM Creation-->
 		<defName>LWM_Hayloft</defName>
 		<label>Hayloft</label>
-		<description>This structure can be used to store hay, silage, and various other plant materials off of damp floors. You probably want to build it under a (very tall) roof.</description>
+		<description>This structure can be used to store hay, silage, and another animal food. You probably want to build it under a (very tall) roof.</description>
 		<graphicData>
 			<graphicClass>Graphic_Multi</graphicClass>
 			<texPath>Things/Building/StorageTest/Hayloft</texPath>
@@ -1059,8 +1044,8 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<pathCost>100</pathCost>
 		<!--structure off the ground, just have to get around posts?-->
 		<stuffCategories>
-			<li>Woody</li>
 			<li>Metallic</li>
+			<li>Woody</li>
 			<!-- solid gold haylofts?  If you can afford this, you can afford to pretend you used some steel ;p -->
 		</stuffCategories>
 		<costStuffCount>85</costStuffCount>
@@ -1068,11 +1053,11 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<preventDeteriorationOnTop>false</preventDeteriorationOnTop>
 			<fixedStorageSettings>
 				<filter>
-					<categories>
-						<li>PlantMatter</li>
-					</categories>
 					<thingDefs>
 						<li>Hay</li>
+						<li>Kibble</li>
+						<li>Silage</li>
+						<li>CatFood</li>
 					</thingDefs>
 				</filter>
 			</fixedStorageSettings>
@@ -1080,13 +1065,16 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 				<filter>
 					<thingDefs>
 						<li>Hay</li>
+						<li>Kibble</li>
+						<li>Silage</li>
+						<li>CatFood</li>
 					</thingDefs>
 				</filter>
 			</defaultStorageSettings>
 		</building>
 		<comps>
-			<li Class="LWM.DeepStorage.Properties" >
-				<maxNumberStacks>4</maxNumberStacks>
+			<li Class="LWM.DeepStorage.Properties">
+				<maxNumberStacks>8</maxNumberStacks>
 				<minTimeStoringTakes>15</minTimeStoringTakes>
 				<additionalTimeStackSize>8</additionalTimeStackSize>
 				<showContents>false</showContents>
@@ -1095,27 +1083,25 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			</li>
 		</comps>
 		<researchPrerequisites>
-			<li>ComplexFurniture</li>
+			<li>SK_StorageII</li>
 		</researchPrerequisites>
 	</ThingDef>
-
 	<ThingDef Name="LWM_Medicine_Cabinet" ParentName="LWM_DeepStorage">
 		<defName>LWM_Medicine_Cabinet</defName>
 		<label>Medicine Cabinet</label>
-		<description>A set of cabinets and shelves for stocking medicines and drugs.  Recommended: keep an eye on children.</description>
+		<description>A set of cabinets and shelves for stocking medicines and drugs.  Recommended: keep an eye on children. Slows rotting process.</description>
 		<pathCost>100</pathCost>
 		<graphicData>
 			<texPath>Things/Building/StorageTest/skullywag/MedCab/MedCab</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>
 			<drawSize>(3,2)</drawSize>
-			<shadowData>				
+			<shadowData>
 				<volume>(1.7,0.4,.7)</volume>
 				<offset>(.1,0,0)</offset>
 			</shadowData>
 		</graphicData>
 		<stuffCategories>
 			<li>Metallic</li>
-			<li>Woody</li>
 		</stuffCategories>
 		<costStuffCount>60</costStuffCount>
 		<statBases>
@@ -1135,6 +1121,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 					<thingDefs>
 						<li>MedicineHerbal</li>
 						<li>Biomatter</li>
+				<!--	<li>aloe</li>
 						<li>Paraffins</li>
 						<li>SyntheticAmmonia</li>
 						<li>BioDiesel</li>
@@ -1142,12 +1129,11 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 						<li>MintLeaves</li>
 						<li>Hypericum</li>
 						<li>WildRose</li>
-						<li>aloe</li>
 						<li>RawTea</li>
 						<li>RawTobacco</li>
 						<li>NeutroPetals</li>
 						<li>PsychoidLeaves</li>
-						<li>Neutroamine</li>
+						<li>Neutroamine</li>	-->
 					</thingDefs>
 				</filter>
 			</fixedStorageSettings>
@@ -1155,7 +1141,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<tickerType>Rare</tickerType>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties">
-				<maxNumberStacks>5</maxNumberStacks>
+				<maxNumberStacks>8</maxNumberStacks>
 				<!--<timeStoringTakes>350</timeStoringTakes>-->
 				<minTimeStoringTakes>30</minTimeStoringTakes>
 				<additionalTimeEachStack>5</additionalTimeEachStack>
@@ -1169,16 +1155,13 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 				<compClass>SK.CompRotModified</compClass>
 				<rotmodifier>0.3</rotmodifier>
 			</li>
-			<li>
-				<compClass>CompQuality</compClass>
-			</li>
+			
 		</comps>
 		<researchPrerequisites>
 			<li>VitalsMonitor</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>5</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<ThingDef Name="Shelf" ParentName="LWM_DeepStorage">
 		<defName>Shelf</defName>
 		<label>Clothing Rack</label>
@@ -1199,8 +1182,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</statBases>
 		<stuffCategories>
 			<li>Metallic</li>
-			<li>Woody</li>
-			<li>Plastic</li>
 		</stuffCategories>
 		<costStuffCount>70</costStuffCount>
 		<costList>
@@ -1226,22 +1207,18 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<comps>
 			<li Class="LWM.DeepStorage.Properties">
 				<maxNumberStacks>10</maxNumberStacks>
-				<minNumberStacks>5</minNumberStacks>
 				<minTimeStoringTakes>35</minTimeStoringTakes>
 				<additionalTimeEachStack>10</additionalTimeEachStack>
 				<overlayType>CountOfStacksPerCell</overlayType>
 			</li>
-			<li>
-				<compClass>CompQuality</compClass>
-			</li>
+			
 			<!--Ideal todo: some sort of armoir with this quality base and prettiness-->
 		</comps>
 		<researchPrerequisites>
-			<li>SK_StorageII</li>
+			<li>SK_StorageIII</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<ThingDef Name="LWM_WeaponsCabinet" ParentName="LWM_DeepStorage">
 		<defName>LWM_WeaponsCabinet</defName>
 		<label>Weapons Cabinet</label>
@@ -1265,7 +1242,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<Mass>48</Mass>
 		</statBases>
 		<stuffCategories>
-			<li>Woody</li>
 			<li>Metallic</li>
 		</stuffCategories>
 		<costStuffCount>70</costStuffCount>
@@ -1282,8 +1258,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 						<li>Weapons</li>
 						<li>WeaponParts</li>
 						<li>WeaponCrate</li>
-						<li>Artifacts</li>
-						<li>Ammo</li>
 					</categories>
 				</filter>
 			</fixedStorageSettings>
@@ -1301,18 +1275,15 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 				<showContents>false</showContents>
 				<overlayType>CountOfStacksPerCell</overlayType>
 			</li>
-			<li>
-				<compClass>CompQuality</compClass>
-			</li>			
+			
 		</comps>
 		<researchPrerequisites>
-			<li>SK_StorageII</li>
+			<li>SK_StorageIII</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>7</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<!-- Metallic Weapons Locker for industrial, modern and spacer playthroughs -->
-	<!--   or for anyone who builds some good careful metal-working tools -->	
+	<!--   or for anyone who builds some good careful metal-working tools -->
 	<ThingDef Name="LWM_WeaponsLocker" ParentName="LWM_DeepStorage">
 		<!--TODO: make this non-quality based?-->
 		<defName>LWM_WeaponsLocker</defName>
@@ -1353,8 +1324,6 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 						<li>Weapons</li>
 						<li>WeaponParts</li>
 						<li>WeaponCrate</li>
-						<li>Artifacts</li>
-						<li>Ammo</li>
 					</categories>
 				</filter>
 			</fixedStorageSettings>
@@ -1365,7 +1334,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			</defaultStorageSettings>
 		</building>
 		<comps>
-			<li Class="LWM.DeepStorage.Properties" >
+			<li Class="LWM.DeepStorage.Properties">
 				<maxNumberStacks>8</maxNumberStacks>
 				<timeStoringTakes>50</timeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
@@ -1380,11 +1349,10 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
 	</ThingDef>
-	
 	<ThingDef ParentName="LWM_DeepStorage">
 		<defName>Storage_HazMatContainer</defName>
 		<label>ammo box</label>
-		<description>Stores ammos; prevents deterioration. Up to 8 items.</description>
+		<description>Stores ammos; prevents deterioration.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Containers/ammobox</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -1422,9 +1390,9 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 				<filter>
 					<categories>
 						<li>Ammo</li>
-						<li>Weapons</li>
 						<li>WeaponParts</li>
 						<li>WeaponCrate</li>
+						<li>MortarShells</li>
 					</categories>
 				</filter>
 			</fixedStorageSettings>
@@ -1441,15 +1409,14 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			</li>
 		</comps>
 		<researchPrerequisites>
-			<li>SK_StorageIII</li>
+			<li>SK_StorageII</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>7</constructionSkillPrerequisite>
 	</ThingDef>
-	
 	<ThingDef ParentName="LWM_DeepStorage">
 		<defName>Storage_ExplosiveContainer</defName>
 		<label>armored ammo box</label>
-		<description>Stores ammos; prevents deterioration. Up to 8 items.</description>
+		<description>Stores ammos; prevents deterioration.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Containers/explossbox</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -1487,16 +1454,16 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 				<filter>
 					<categories>
 						<li>Ammo</li>
-						<li>Weapons</li>
 						<li>WeaponParts</li>
 						<li>WeaponCrate</li>
+						<li>MortarShells</li>
 					</categories>
 				</filter>
 			</fixedStorageSettings>
 		</building>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties">
-				<maxNumberStacks>8</maxNumberStacks>
+				<maxNumberStacks>10</maxNumberStacks>
 				<minTimeStoringTakes>40</minTimeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
 				<showContents>false</showContents>
@@ -1510,8 +1477,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>9</constructionSkillPrerequisite>
 	</ThingDef>
-	
-	<ThingDef ParentName="LWM_DeepStorage">
+	<!--<ThingDef ParentName="LWM_DeepStorage">
 		<defName>ClutterLockerA</defName>
 		<label>armored box</label>
 		<description>Stores weapons, weapon parts, weapon crates, ammo and apparel; prevents deterioration. Up to 8 items.</description>
@@ -1582,9 +1548,8 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<li>SK_StorageIII</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>9</constructionSkillPrerequisite>
-	</ThingDef>
-	
-	<ThingDef ParentName="LWM_DeepStorage">
+	</ThingDef> -->
+	<!--<ThingDef ParentName="LWM_DeepStorage">
 		<defName>Commode</defName>
 		<label>commode</label>
 		<description>A place for colonist to store personal belongings. When placed with a bed it will increase comfort and rest effectiveness slightly. Up to 8 items.</description>
@@ -1662,6 +1627,5 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<li>SK_BedroomII</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
-	</ThingDef>
-
+	</ThingDef> -->
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage.xml
@@ -1549,10 +1549,10 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>9</constructionSkillPrerequisite>
 	</ThingDef> -->
-	<!--<ThingDef ParentName="LWM_DeepStorage">
+	<ThingDef ParentName="LWM_DeepStorage">
 		<defName>Commode</defName>
 		<label>commode</label>
-		<description>A place for colonist to store personal belongings. When placed with a bed it will increase comfort and rest effectiveness slightly. Up to 8 items.</description>
+		<description>A place for colonist to store personal belongings. When placed with a bed it will increase comfort and rest effectiveness slightly.</description>
 		<graphicData>
 			<texPath>Things/Building/Furniture/Containers/lightnightstand</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>
@@ -1627,5 +1627,5 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<li>SK_BedroomII</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
-	</ThingDef> -->
+	</ThingDef> 
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage_Fridge.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage_Fridge.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 	<!-- 	<DesignatorDropdownGroupDef>
 		<defName>StandAloneFridgeDesignatorDropdownDef</defName>
@@ -6,7 +6,6 @@
 	<DesignatorDropdownGroupDef>
 		<defName>WallFridgeDesignatorDropdownDef</defName>
 	</DesignatorDropdownGroupDef> -->
-
 	<ThingDef Name="FridgeBase" ParentName="SK_BuildingBase" Abstract="True">
 		<minifiedDef>MinifiedThing</minifiedDef>
 		<thingClass>Building_Storage</thingClass>
@@ -28,25 +27,23 @@
 			<fixedStorageSettings>
 				<filter>
 					<categories>
-						<li>AnimalProductRaw</li>
-						<li>Corpses</li>
+						<li>Foods</li>
 						<li>Drugs</li>
 						<li>EggsFertilized</li>
 						<li>EggsUnfertilized</li>
-						<li>Foods</li>
 						<li>Medicine</li>
 						<li>PlantMatter</li>
-						<li>PlantFoodRaw</li>
-						<li>BodyParts</li>
 					</categories>
-					<thingDefs>
-						<li>MintLeaves</li>
-						<li>Hypericum</li>
-						<li>WildRose</li>
-						<li>aloe</li>
-						<li>RawTea</li>
-						<li>RawTobacco</li>
-					</thingDefs>
+					<disallowedCategories>
+						<li>Alcohol</li>
+						<li>SeedsCategory</li>
+						<li>Animalfood</li>
+					</disallowedCategories>
+					<disallowedThingDefs>
+						<li>RottedMeat</li>
+						<li>RottedMush</li>
+						<li>MealSurvivalPack</li>
+					</disallowedThingDefs>
 					<specialFiltersToDisallow>
 						<li>AllowRotten</li>
 					</specialFiltersToDisallow>
@@ -56,11 +53,8 @@
 				<priority>Important</priority>
 				<filter>
 					<categories>
-						<li>FoodMeals</li>
+						<li>Foods</li>
 					</categories>
-					<disallowedThingDefs>
-						<li>MealSurvivalPack</li>
-					</disallowedThingDefs>
 				</filter>
 			</defaultStorageSettings>
 		</building>
@@ -71,12 +65,12 @@
 				<glowRadius>2.5</glowRadius>
 				<glowColor>(89,188,255,0)</glowColor>
 			</li>
-			<li Class="RimFridge.CompProperties_Refrigerator"> 
+			<!--	<li Class="RimFridge.CompProperties_Refrigerator"> 
 				<drinksBestCold>
 					<li>Beer</li>
 				</drinksBestCold>
 				<findAllRottableForFilters>true</findAllRottableForFilters>
-			</li>
+			</li>	-->
 		</comps>
 		<inspectorTabs>
 			<li>ITab_Storage</li>
@@ -99,7 +93,6 @@
 		<drawPlaceWorkersWhileSelected>false</drawPlaceWorkersWhileSelected>
 		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
 	</ThingDef>
-
 	<ThingDef ParentName="FridgeBase">
 		<defName>RimFridge_SingleRefrigerator</defName>
 		<label>Single Refrigerator</label>
@@ -142,8 +135,7 @@
 				<altitudeLayer>Projectile</altitudeLayer>
 			</li>
 			<li Class='LWM.DeepStorage.Properties'>
-				<minNumberStacks>2</minNumberStacks>
-				<maxNumberStacks>4</maxNumberStacks>
+				<maxNumberStacks>5</maxNumberStacks>
 				<maxMassOfStoredItem>100</maxMassOfStoredItem>
 				<minTimeStoringTakes>5</minTimeStoringTakes>
 				<additionalTimeEachStack>24</additionalTimeEachStack>
@@ -154,7 +146,6 @@
 			</li>
 		</comps>
 	</ThingDef>
-
 	<ThingDef ParentName="FridgeBase">
 		<defName>RimFridge_Refrigerator</defName>
 		<label>Dual Refrigerator</label>
@@ -197,8 +188,7 @@
 				<altitudeLayer>Projectile</altitudeLayer>
 			</li>
 			<li Class='LWM.DeepStorage.Properties'>
-				<minNumberStacks>2</minNumberStacks>
-				<maxNumberStacks>4</maxNumberStacks>
+				<maxNumberStacks>5</maxNumberStacks>
 				<maxMassOfStoredItem>100</maxMassOfStoredItem>
 				<minTimeStoringTakes>5</minTimeStoringTakes>
 				<additionalTimeEachStack>24</additionalTimeEachStack>
@@ -209,8 +199,6 @@
 			</li>
 		</comps>
 	</ThingDef>
-
-
 	<ThingDef ParentName="FridgeBase">
 		<defName>RimFridge_QuadRefrigerator</defName>
 		<label>Quad Refrigerator</label>
@@ -253,8 +241,7 @@
 				<altitudeLayer>Projectile</altitudeLayer>
 			</li>
 			<li Class='LWM.DeepStorage.Properties'>
-				<minNumberStacks>2</minNumberStacks>
-				<maxNumberStacks>4</maxNumberStacks>
+				<maxNumberStacks>5</maxNumberStacks>
 				<maxMassOfStoredItem>100</maxMassOfStoredItem>
 				<minTimeStoringTakes>5</minTimeStoringTakes>
 				<additionalTimeEachStack>24</additionalTimeEachStack>
@@ -264,6 +251,5 @@
 				<overlayType>SumOfAllItems</overlayType>
 			</li>
 		</comps>
-	</ThingDef>	
-
+	</ThingDef>
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage_WallFridge.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage_WallFridge.xml
@@ -54,8 +54,7 @@
 				<altitudeLayer>Projectile</altitudeLayer>
 			</li>
 			<li Class='LWM.DeepStorage.Properties'>
-				<minNumberStacks>2</minNumberStacks>
-				<maxNumberStacks>4</maxNumberStacks>
+				<maxNumberStacks>5</maxNumberStacks>
 				<maxMassOfStoredItem>100</maxMassOfStoredItem>
 				<minTimeStoringTakes>5</minTimeStoringTakes>
 				<additionalTimeEachStack>24</additionalTimeEachStack>
@@ -108,8 +107,7 @@
 				<altitudeLayer>Projectile</altitudeLayer>
 			</li>
 			<li Class='LWM.DeepStorage.Properties'>
-				<minNumberStacks>2</minNumberStacks>
-				<maxNumberStacks>4</maxNumberStacks>
+				<maxNumberStacks>5</maxNumberStacks>
 				<maxMassOfStoredItem>100</maxMassOfStoredItem>
 				<minTimeStoringTakes>5</minTimeStoringTakes>
 				<additionalTimeEachStack>24</additionalTimeEachStack>


### PR DESCRIPTION
1) поменял в некоторых хранилищах дескрипшны, поскольку не соответствовали реальности
2) более менее уравнял существующие хранилища (теперь палеты не имба, хотя и очень юзабельны)
3) поменял кое где категории хранения, потому что было очень странно(например, возможность хранить 4 трупа в холодильнике 1х1, или химтопливо в медицинском шкафу)
4) закомментил бронешкаф, по причине того, что ему попросту не осталось полезного применения (хотел еще закоментить комод, но он дает бафы, так что просто уравнял его)
5) закоментил у холодильников странный нерабочий деф с холодным пивом
6) переделал бочку. теперь она вместо того, чтобы быть сундуком с ретекстуром, хранит одежду и открывается в самом начале
7) перетащил кое какие хранилища(в основном крепкие и те, которые улучшенные старые версии) по разным исследованиям - теперь простая палета будет открыватся в хранилищах 1, а улучшенная - в хранилищах 3(должно добавить смысла существованию простой палете)
8) переделал крепкие хранилища, чтобы их можно было делать только из металла (арпомо предлагал их делать из сверхпрочных, но мне показалось слишком)
9) убрал кусок, который разрешал делать легендарные шкафы - автор хотел как-то привязать это к их вместимости,  но видать не успел
10) в основном сейчас все хранилища имеют 6 или 8 слотов на клетку, а их улучшенные - 8 или 10. исключения - двойной шкаф, который вмещает 5 вещей на клетку, но позволяет хранить все, включая трупы и куски камней, а также обычный и улучшенный сундук, который так же позволяет хранить все, кроме трупов, камней, каменных блоков, имеют 5 и 7 слотов соответственно
11) переделал высокий шкаф, так как в игре было два абсолютно одинаковых шкафа с разными названиями. теперь в высокий шкаф можно складывать много штучных вещей - части тел (кроме натуральных) и айтемы
12) оружейные шкафы и ящики с патронами теперь хранят так, как и положено - шкафы - оружие, ящики - патроны и снаряды. у обоих по 8\10 вместимости у обычной и улучшенной версии

1) changed descriptions in some storage, because they did not make sence
2) more or less equalized the storages
3) changed some storage category, because it was very strange (for example, storing 4 corpses in a 1x1 refrigerator, or chemical fuel in a medical cabinet)
4) commented out the armored box, due to the fact that he simply did not have any useful use left
5) commented a strange non-working def with cold beer on the refrigerators
6) remade the barrel. now, instead of being a chest with retexture, it stores clothes and opens at the very beginning
7) dragged some storages (mostly too cool) to different research - now a simple pallet will open in storages 1, skip - in storages 3 
8) remade armored storage so that they could only be made of metal (arpomo suggested them from solids, but i dont)
9) removed a piece that allowed making legendary storage - the author wanted to somehow tie it to their capacity, but did not have time to make
10) basically now all storages have 6 or 8 slots per cell, and their improved ones have 8 or 10. The exception is a double shelf, which holds 5 stacks per square, but allows you to store everything, including corpses and pieces of stones;regular and armored chest, which also allows you to store everything except corpses, stones and stone blocks, have 5 and 7 slots
11) remade the tall shelf, cause the game had two absolutely identical shelf with different names. now you can put a lot of piece things in a tall cabinet - body parts (except for natural ones) and items
12) weapon cabinets and ammunition boxes are now stored as expected - cabinets - weapons, boxes - ammo and shells. both have 8/10 capacity for regular and improved versions