### PR TITLE
Same salt and sulfur fix for 1.1 version

### DIFF
--- a/Mods/Minerals/Patches/01_HardcoreSK/DynamicMinerals.xml
+++ b/Mods/Minerals/Patches/01_HardcoreSK/DynamicMinerals.xml
@@ -108,7 +108,7 @@
           <!-- Chance of spawning de novo each check -->
           <spawnProb>0.04</spawnProb>
           <!-- Can spawn on items, pawns, and plants-->
-          <canSpawnOnThings>true</canSpawnOnThings>
+          <canSpawnOnThings>false</canSpawnOnThings>
           <!-- Growth rate modifiers -->
           <tempGrowthRateModifer>
             <active>true</active>
@@ -273,7 +273,7 @@
           <!-- Chance of spawning de novo each check -->
           <spawnProb>0.005</spawnProb>
           <!-- Can spawn on items, pawns, and plants-->
-          <canSpawnOnThings>true</canSpawnOnThings>
+          <canSpawnOnThings>false</canSpawnOnThings>
           <!-- Growth rate modifiers -->
           <tempGrowthRateModifer>
             <active>true</active>


### PR DESCRIPTION
stops sulfur and salt crystal spawns from destroying buildings