### PR TITLE
Added alpaca weight & bulk carry param

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Farm.xml
@@ -592,6 +592,8 @@
 		<statBases>
 			<Mass>90</Mass>
 			<MoveSpeed>5.2</MoveSpeed>
+			<CarryWeight>130</CarryWeight>
+			<CarryBulk>110</CarryBulk>
 			<ComfyTemperatureMin>-18</ComfyTemperatureMin>
 			<ComfyTemperatureMax>48</ComfyTemperatureMax>
 			<MarketValue>630</MarketValue>


### PR DESCRIPTION
Additional to https://github.com/skyarkhangel/Hardcore-SK/commit/cba3952ff5e3d9a1af48dcbaa6faf1ff916db39d
Allow to be packed animal but not added pack params.

Дополнение к коммиту выше.
Альпаке вернули возможность быть вьючным животным, но переносимый вес и объем добавить забыли.