### PR TITLE
Added spacer tech level to some ratkin spacer pawn

### DIFF
--- a/Mods/ArcaneTechnology_SK/Patches/Pawn/Pawns.xml
+++ b/Mods/ArcaneTechnology_SK/Patches/Pawn/Pawns.xml
@@ -39,4 +39,18 @@
 		</match>
 	</Operation>
 
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>NewRatkinPlus</li>
+		</mods>
+		<match Class="PatchOperationAddModExtension">
+			<xpath>Defs/PawnKindDef[defName="RatkinSubject" or defName="RatkinEliteSoldier" or defName="RatkinDemonMan"]</xpath>
+			<value>
+				<li Class="DArcaneTechnology.PawnKindExtension">
+					<pawnKindTechLevel>Spacer</pawnKindTechLevel>
+				</li>				
+			</value>
+		</match>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
Added space tech level to some ratkin pawns (these pawns carry weapons / armor, available only with researching power armor / 3D printing).

**Pawn list**:
- Ratkin Subject.
- Ratkin Elite Soldier.
- Ratkin Demon Man.

Добавил некоторым пешкам раткинов космический технологический уровень (эти пешки носят оружие/броню, доступные только с исследованием силовой брони/3D печати).

**Список пешек**:
- Раткин Подопытный.
- Раткин Элитный Солдат.
- Раткин Подрывник.