### PR TITLE
Artillery

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/CatapultaBalls.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/CatapultaBalls.xml
@@ -85,11 +85,11 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>30</speed>
+			<speed>50</speed>
 			<soundExplode>Explosion</soundExplode>
 			<flyOverhead>true</flyOverhead>
 			<dropsCasings>false</dropsCasings>
-			<gravityFactor>7</gravityFactor>
+			<gravityFactor>12</gravityFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rocket/130mm.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rocket/130mm.xml
@@ -78,11 +78,11 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>40</speed>
+			<speed>80</speed>
 			<soundExplode>Explosion</soundExplode>
 			<flyOverhead>true</flyOverhead>
 			<soundAmbient>RocketPropelledLoop_Small</soundAmbient>
-			<gravityFactor>6</gravityFactor>
+			<gravityFactor>10</gravityFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/155mmHowitzer.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/155mmHowitzer.xml
@@ -103,12 +103,12 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>40</speed>
+			<speed>80</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>true</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Mote_BigShell</casingMoteDefname>
-			<gravityFactor>5</gravityFactor>
+			<gravityFactor>10</gravityFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/81mmMortar.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/81mmMortar.xml
@@ -241,14 +241,14 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>0</speed>
+			<speed>70</speed>
 			<soundHitThickRoof>Artillery_HitThickRoof</soundHitThickRoof>
 			<soundImpactAnticipate>MortarRound_PreImpact</soundImpactAnticipate>
 			<soundAmbient>MortarRound_Ambient</soundAmbient>
 			<flyOverhead>true</flyOverhead>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Mote_BigShell</casingMoteDefname>
-			<gravityFactor>5</gravityFactor>
+			<gravityFactor>9</gravityFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Security.xml
@@ -619,6 +619,9 @@
 		<statBases>
 			<MarketValue>1500</MarketValue>
 			<SightsEfficiency>0.8</SightsEfficiency>
+			<ShotSpread>0.12</ShotSpread>
+			<SwayFactor>1.15</SwayFactor>
+			<RangedWeapon_Cooldown>4</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>
 			<li>TurretGun</li>
@@ -655,7 +658,7 @@
 				<burstShotCount>1</burstShotCount>
 				<soundCast>Mortar_LaunchA</soundCast>
 				<muzzleFlashScale>16</muzzleFlashScale>
-				<indirectFirePenalty>0.2</indirectFirePenalty>
+				<indirectFirePenalty>0.15</indirectFirePenalty>
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>
@@ -1219,7 +1222,7 @@
 			<li>SniperTurret</li>
 		</researchPrerequisites>
 		<designationCategory>Security</designationCategory>
-		<specialDisplayRadius>38</specialDisplayRadius>
+		<specialDisplayRadius>32</specialDisplayRadius>
 		<building>
 			<turretGunDef>Gun_HowitzerTurret</turretGunDef>
 			<turretTopDrawSize>4</turretTopDrawSize>
@@ -1390,7 +1393,7 @@
 			<li>SK_MissilelaunchersII</li>
 		</researchPrerequisites>
 		<designationCategory>Security</designationCategory>
-		<specialDisplayRadius>50</specialDisplayRadius>
+		<specialDisplayRadius>35</specialDisplayRadius>
 		<building>
 			<turretGunDef>Gun_MissileSystem</turretGunDef>
 			<turretTopDrawSize>4</turretTopDrawSize>
@@ -1446,7 +1449,7 @@
 			<li>SK_MissilelaunchersIII</li>
 		</researchPrerequisites>
 		<designationCategory>Security</designationCategory>
-		<specialDisplayRadius>50</specialDisplayRadius>
+		<specialDisplayRadius>35</specialDisplayRadius>
 		<building>
 			<turretGunDef>Gun_RL</turretGunDef>
 			<turretTopDrawSize>4</turretTopDrawSize>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Heavy.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Heavy.xml
@@ -67,7 +67,7 @@
 				<defaultProjectile>Stone_Ball</defaultProjectile>
 				<warmupTime>2.60</warmupTime>
 				<minRange>20</minRange>
-				<range>90</range>
+				<range>130</range>
 				<!--<forcedMissRadius>4</forcedMissRadius>-->
 				<circularError>1.2</circularError>
 				<burstShotCount>1</burstShotCount>
@@ -76,7 +76,7 @@
 				<targetParams>
 					<canTargetLocations>true</canTargetLocations>
 				</targetParams>
-				<indirectFirePenalty>0.2</indirectFirePenalty>
+				<indirectFirePenalty>0.1</indirectFirePenalty>
 			</li>
 		</verbs>
 		<comps>
@@ -319,8 +319,8 @@
 				<defaultProjectile>Bullet_155mmHowitzerShell_HE</defaultProjectile>
 				<!--<forcedMissRadius>5</forcedMissRadius>-->
 				<circularError>1.5</circularError>
-				<minRange>38</minRange>
-				<range>250</range>
+				<minRange>32</minRange>
+				<range>320</range>
 				<warmupTime>2.40</warmupTime>
 				<soundCast>155mm</soundCast>
 				<targetParams>
@@ -328,7 +328,7 @@
 				</targetParams>
 				<soundCastTail>GunTail_Heavy</soundCastTail>
 				<muzzleFlashScale>21</muzzleFlashScale>
-				<indirectFirePenalty>0.2</indirectFirePenalty>
+				<indirectFirePenalty>0.15</indirectFirePenalty>
 			</li>
 		</verbs>
 		<comps>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Launchers.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Launchers.xml
@@ -134,8 +134,8 @@
 				<defaultProjectile>Bullet_130mmRocketMissile</defaultProjectile>
 				<!--<forcedMissRadius>7</forcedMissRadius>-->
 				<circularError>1.75</circularError>
-				<minRange>50</minRange>
-				<range>290</range>
+				<minRange>35</minRange>
+				<range>370</range>
 				<warmupTime>2.80</warmupTime>
 				<burstShotCount>2</burstShotCount>
 				<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
@@ -144,7 +144,7 @@
 				</targetParams>
 				<soundCast>130mmRocket</soundCast>
 				<muzzleFlashScale>16</muzzleFlashScale>
-				<indirectFirePenalty>0.2</indirectFirePenalty>
+				<indirectFirePenalty>0.15</indirectFirePenalty>
 			</li>
 		</verbs>
 		<comps>
@@ -188,8 +188,8 @@
 				<defaultProjectile>Bullet_130mmRocketMissile</defaultProjectile>
 				<!--<forcedMissRadius>6</forcedMissRadius>-->
 				<circularError>1.6</circularError>
-				<minRange>50</minRange>
-				<range>290</range>
+				<minRange>35</minRange>
+				<range>370</range>
 				<warmupTime>3.00</warmupTime>
 				<ticksBetweenBurstShots>20</ticksBetweenBurstShots>
 				<burstShotCount>3</burstShotCount>
@@ -198,7 +198,7 @@
 				</targetParams>
 				<soundCast>130mmRocket</soundCast>
 				<muzzleFlashScale>16</muzzleFlashScale>
-				<indirectFirePenalty>0.2</indirectFirePenalty>
+				<indirectFirePenalty>0.15</indirectFirePenalty>
 			</li>
 		</verbs>
 		<comps>


### PR DESCRIPTION
Artillery is useless for the most part right now, it costs a lot and is bad at the only thing it can do - long range siege damage. I offer some changes that will make artillery a bit less realistic, but at least decent at what it is supposed to be good at.
- Range of all artillery was increased by about factor 1.5, this is mostly to reduce long range penalty to accuracy. 
- Undirect fire penalty was also reduced by 25%, shooting without pointer pawn should be a bit less terrible (and in all honesty the concept of pointer-pawn doesn't fit at all into current gameplay)
- All artillery projectiles now fly faster

Since every shot with artillery is pretty expensive, I hope these small changes will make having 2-3 artillery pieces a viable option and not a luxury burden that only works in rare situations

----------------
Артиллерия теперь стреляет дальше, точнее и снаряды летят быстрее. Надеюсь этих изменений будет достаточно чтобы сделать артиллерию юзабельным оружием, а не дорогим куском железа с очень ситуативным использованием. Стрелять без наводчика всё ещё плохо, но теперь это не так заметно, можно запустить пару снарядов в надвигающийся рейд и теперь с гораздо большей вероятностью они попадут.