### PR TITLE
Additional recipes for Matter Converter

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Matter.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Matter.xml
@@ -474,5 +474,75 @@
 	<workSkill>Crafting</workSkill>
     	<workSkillLearnFactor>0.8</workSkillLearnFactor>
   </RecipeDef>
+	
+	  <!-- Paraffins -->
+    <RecipeDef>
+    <defName>ConvertToParaffins</defName>
+    <label>Convert to paraffins</label>
+    <description>Convert inorganic matter into paraffins. Produces 10.</description>
+    <jobString>Converting matter into paraffins.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>1200</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Paraffins>10</Paraffins>
+    </products>
+		<skillRequirements>
+			<Crafting>15</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+  </RecipeDef>
+  
+    	<!-- Sulphates -->
+    <RecipeDef>
+    <defName>ConvertToSulphates</defName>
+    <label>Convert to sulphates</label>
+    <description>Convert inorganic matter into sulphates. Produces 10.</description>
+    <jobString>Converting matter into sulphates.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>1200</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>5</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Sulphates>10</Sulphates>
+    </products>
+		<skillRequirements>
+			<Crafting>15</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+  </RecipeDef>
   
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
@@ -812,6 +812,8 @@
 			<!-- from matter -->
 			<li>ConvertToSteel</li>
 			<li>ConvertToPolymers</li>
+			<li>ConvertToParaffins</li>
+			<li>ConvertToSulphates</li>
 			<li>ConvertToCopper</li>
 			<li>ConvertToAluminium</li>
 			<li>ConvertToGold</li>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Matter.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Matter.xml
@@ -45,5 +45,13 @@
 	<ConvertToPolymers.label>Конвертировать материю в полимеры</ConvertToPolymers.label>
 	<ConvertToPolymers.description>Конвертировать материю в полимеры.</ConvertToPolymers.description>
 	<ConvertToPolymers.jobString>Конвертирует материю в полимеры.</ConvertToPolymers.jobString>
+	
+	<ConvertToParaffins.label>Конвертировать материю в парафин</ConvertToParaffins.label>
+	<ConvertToParaffins.description>Конвертировать материю в парафин. Производится 10 шт.</ConvertToParaffins.description>
+	<ConvertToParaffins.jobString>Конвертирует материю в парафин.</ConvertToParaffins.jobString>
+
+	<ConvertToSulphates.label>Конвертировать материю в сульфаты</ConvertToSulphates.label>
+	<ConvertToSulphates.description>Конвертировать материю в сульфаты. Производится 10 шт.</ConvertToSulphates.description>
+	<ConvertToSulphates.jobString>Конвертирует материю в сульфаты.</ConvertToSulphates.jobString>
 
 </LanguageData>


### PR DESCRIPTION
Добавляет в Конвертер материи рецепты на преобразование материи в парафин и сульфаты в дополнение к существующему рецепту на преобразование материи в полимеры. Позволяет на поздних этапах игры перейти к получению нефтепродуктов из материи.

Adds to the Matter Converter recipes for converting matter to paraffin and sulfates in addition to the existing recipe for converting matter to polymers. Allows in the late game to go to the production of oil products from matter.