### PR TITLE
Vulcanize rubber recipe light expansion

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Petrochemistry.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Petrochemistry.xml
@@ -100,6 +100,8 @@
 				<filter>
 					<thingDefs>
 						<li>Sulphates</li>
+						<li>Sulfur</li>
+						<li>Ash</li>
 					</thingDefs>
 				</filter>
 				<count>3</count>
@@ -112,6 +114,8 @@
 			<thingDefs>
 				<li>RawCaoutchouc</li>
 				<li>Sulphates</li>
+				<li>Sulfur</li>
+				<li>Ash</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<skillRequirements>
@@ -119,6 +123,7 @@
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
 		<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<researchPrerequisite>BiofuelRefining</researchPrerequisite>
 	</RecipeDef>
 
 	<RecipeDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -1867,7 +1867,7 @@
 	<ThingDef ParentName="BuildingFueled">
 		<defName>Kiln</defName>
 		<label>kiln</label>
-		<description>An improvised kiln used to produce clay bricks, burning apparel and used as crematorium. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff. After researching chemistry, rubber vulcanization is available.</description>
+		<description>An improvised kiln used to produce clay bricks, burning apparel and used as crematorium. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff. After researching chemistry it allow to make rubber from raw caoutchouc.</description>
 		<graphicData>
 			<texPath>Things/Building/Production/NeolithicProduction/Kiln</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -1867,7 +1867,7 @@
 	<ThingDef ParentName="BuildingFueled">
 		<defName>Kiln</defName>
 		<label>kiln</label>
-		<description>An improvised kiln used to produce clay bricks, burning apparel and used as crematorium. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff.</description>
+		<description>An improvised kiln used to produce clay bricks, burning apparel and used as crematorium. Can be fueled by Kindling, Coal, Charcoal, Peat and wooden stuff. After researching chemistry, rubber vulcanization is available.</description>
 		<graphicData>
 			<texPath>Things/Building/Production/NeolithicProduction/Kiln</texPath>
 			<graphicClass>Graphic_Multi</graphicClass>
@@ -1905,6 +1905,7 @@
 			<li>BurnApparel</li>
 			<li>BurnDrugs</li>
 			<li>BurnThings</li>
+			<li>VulcanizeRubber</li>
 		</recipes>
 		<building>
 			<uninstallWork>1850</uninstallWork>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Production.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Production.xml
@@ -5,7 +5,7 @@
 	<UniversalFermenter.description>Бочка для получения пива из сусла путём брожения.</UniversalFermenter.description>
 
 	<Kiln.label>Горн</Kiln.label>
-	<Kiln.description>Улучшенный горн позволяет обжигать глиняные кирпичи, сжигать одежду, а ещё его можно использовать как крематорий.</Kiln.description>
+	<Kiln.description>Горн позволяет обжигать глиняные кирпичи, сжигать одежду, а ещё его можно использовать как крематорий. После изучения химии доступна вулканизация каучука.</Kiln.description>
 
 	<LeatherworkerTable.label>Верстак кожевника</LeatherworkerTable.label>
 	<LeatherworkerTable.description>Верстак для производства кожаной одежды из обрезков кожи.</LeatherworkerTable.description>


### PR DESCRIPTION
I propose to slightly expand the possibilities of creating rubber from raw сaoutchouc, allowing to use this recipe before the discovery of oil. Reasons:
1) vulcanization recipe is almost never used by anyone due to its late availability and low efficiency;
2) there are some useful buildings in the game that require only rubber from other oil products for their construction, but access to their construction opens much earlier than the petrochemical industry itself (for example, a small tool cabinet).
3) growing hevea trees is quite problematic and it grows only in the tropics, so this expansion will not have a serious impact on the balance but at the same time it will bring a little variety to the game.

Sulfur or sulfur-containing substances (including ash) can be used as an analog of sulfates for vulcanization.

Предлагаю немного расширить возможности создания резины из каучука, позволив использовать рецепт до открытия нефти. Причины следующие:
1) на данный момент рецепт вулканизации почти никем не используется ввиду его поздней доступности и низкой эффективности;
2) в игре присутствуют некоторые полезные постройки, которые для своего строительства требуют только резину из нефтепродуктов, но доступ к их строительству открывается намного раньше самой нефтехимии (например, малый шкаф инструментов).
3) выращивать гевею достаточно проблематично, да и растет она изначально только в тропиках, так что данное расширение не окажет серьезного влияния на баланс, но при этом внесет небольшое разнообразие в игру.

В качестве аналога сульфатов для вулканизации можно использовать серу или другие серосодержащие вещества (в том числе и пепел).