### PR TITLE
14.5x114 mm caliber param correction

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -121,7 +121,7 @@
 		<defName>Bullet_145x114mm_HE</defName>
 		<label>14.5x114mm bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>37</damageAmountBase>
+			<damageAmountBase>35</damageAmountBase>
 			<!-- <armorPenetrationBase>1.16</armorPenetrationBase>-->
 			<armorPenetrationSharp>22</armorPenetrationSharp>
 			<armorPenetrationBlunt>570</armorPenetrationBlunt>
@@ -138,7 +138,7 @@
 		<defName>Bullet_145x114mm_Incendiary</defName>
 		<label>14.5x114mm bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>38</damageAmountBase>
+			<damageAmountBase>36</damageAmountBase>
 			<!-- <armorPenetrationBase>0.99</armorPenetrationBase> -->
 			<armorPenetrationSharp>33</armorPenetrationSharp>
 			<armorPenetrationBlunt>570</armorPenetrationBlunt>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -58,7 +58,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>4.25</MarketValue>
+			<MarketValue>4</MarketValue>
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_145x114mm_FMJ</cookOffProjectile>
@@ -72,7 +72,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>8.0</MarketValue>
+			<MarketValue>7</MarketValue>
 		</statBases>
 		<ammoClass>ExplosiveAP</ammoClass>
 		<cookOffProjectile>Bullet_145x114mm_HE</cookOffProjectile>
@@ -86,7 +86,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>7.5</MarketValue>
+			<MarketValue>6</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
 		<cookOffProjectile>Bullet_145x114mm_Incendiary</cookOffProjectile>
@@ -110,10 +110,10 @@
 		<defName>Bullet_145x114mm_FMJ</defName>
 		<label>14.5x114mm bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>48</damageAmountBase>
+			<damageAmountBase>46</damageAmountBase>
 			<!-- <armorPenetrationBase>0.99</armorPenetrationBase> -->
-			<armorPenetrationSharp>24</armorPenetrationSharp>
-			<armorPenetrationBlunt>634</armorPenetrationBlunt>
+			<armorPenetrationSharp>22</armorPenetrationSharp>
+			<armorPenetrationBlunt>570</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -121,14 +121,14 @@
 		<defName>Bullet_145x114mm_HE</defName>
 		<label>14.5x114mm bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>45</damageAmountBase>
+			<damageAmountBase>37</damageAmountBase>
 			<!-- <armorPenetrationBase>1.16</armorPenetrationBase>-->
-			<armorPenetrationSharp>24</armorPenetrationSharp>
-			<armorPenetrationBlunt>634</armorPenetrationBlunt>
+			<armorPenetrationSharp>22</armorPenetrationSharp>
+			<armorPenetrationBlunt>570</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>32</amount>
+					<amount>30</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -140,12 +140,12 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>38</damageAmountBase>
 			<!-- <armorPenetrationBase>0.99</armorPenetrationBase> -->
-			<armorPenetrationSharp>36</armorPenetrationSharp>
-			<armorPenetrationBlunt>634</armorPenetrationBlunt>			
+			<armorPenetrationSharp>33</armorPenetrationSharp>
+			<armorPenetrationBlunt>570</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>21</amount>
+					<amount>16</amount>
 				</li>
 			</secondaryDamage>
 			<ai_IsIncendiary>true</ai_IsIncendiary>


### PR DESCRIPTION
I created some comparison why-table and noticed the following:
![image](https://user-images.githubusercontent.com/62516232/93708056-ae628580-fb4c-11ea-89f0-4d54ab37f544.png)
1 14.5x114 mm and 20x102 mm have same RHA penetration;
2 14.5 mm AP-I have more flame dmg than .50 bmg and 20x102 mm calibers;
3 14.5 & 20 mm HE have same (almost) damage;
4 14.5 mm HE and AP-I have different bullet dmg (45 and 38). .50 bmg (28 and 28) & 20 mm (46 and 45) have similar (or almost);
5 14.5 and 20 mm calibers are generally very similar, although their bullet energy differs radically (30-32 kJ versus 49-53 kJ). 12.7 mm (.50 bmg) has about 18-20 kJ. 14.5 should be closer to 12.7 mm, not 20 mm.
I suggest correcting this a bit.

Создал небольшую сравнительную why-таблицу и заметил следующее (см. таблицу выше):
1 14.5х114 мм и 20х102 мм имеют одинаковое бронепробитие в БКГ;
2 14.5 мм бронебойно-зажигательные патроны (далее просто AP-I) имеют больший вторичный урон, чем .50 bmg и 20х102 мм;
3 14.5 и 20 мм бронебойно-фугасные патроны (далее просто HE) имеют почти одинаковый урон (что странно, ведь калибры разные);
4 14.5 мм HE и AP-I патроны имеют сильно различный урон (45 и 38 соотв.) У .50 bmg урон одинаковый (28 и 28). У 20 мм почти одинаковый (46 и 45);
5 14.5 и 20 мм калибры в игре очень похожи в целом, хотя их реальная энергия пули кардинально отличается (30-32 кДж против 49-53 кДж). 12.7 мм (.50 bmg) имеет около 18-20 кДж. 14.5 мм должен быть ближе к 12.7 мм, а не 20 мм как это есть сейчас.
Предлагаю немного откорректировать это.
P.S. кто-то очень любит 14.5 мм, судя по параметрам HE патронов =).