### PR TITLE
Fishing tweaks & fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Building_FishingPier.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Building_FishingPier.xml
@@ -52,7 +52,6 @@
 		<defName>FishingPierSpawnerOnMud</defName>
 		<label>fishing pier (on mud)</label>
 		<description>A simple and solid fishing pier. Keeps your feet dry while fishing. Can be built over mud be requires more time and building materials.</description>
-		<terrainAffordanceNeeded>Undefined</terrainAffordanceNeeded>
 		<costList>
 			<WoodPlank>160</WoodPlank>
 			<ComponentIndustrial>8</ComponentIndustrial>
@@ -78,7 +77,6 @@
 				<rect>(0.05,1,5,1)</rect>
 			</damageData>
 		</graphicData>
-		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
 		<altitudeLayer>Building</altitudeLayer>
 		<stuffCategories>
 			<li>Woody</li>

--- a/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Races_Animal_Fish.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Races_Animal_Fish.xml
@@ -187,7 +187,9 @@
 		<commonality>0.2</commonality>
 		<naturalBiomes>
 			<li>TemperateForest</li>
+			<li>TemperateSwamp</li>
 			<li>TropicalRainforest</li>
+			<li>TropicalSwamp</li>
 			<li>AridShrubland</li>
 			<li>DesertArchipelago</li>
 			<li>DesertArchipelago_Fresh</li>
@@ -474,8 +476,11 @@
 		<breedingDurationInDays>2</breedingDurationInDays>
 		<naturalBiomes>
 			<li>BorealForest</li>
+			<li>ColdBog</li>
 			<li>TemperateForest</li>
+			<li>TemperateSwamp</li>
 			<li>TropicalRainforest</li>
+			<li>TropicalSwamp</li>
 			<li>AridShrubland</li>
 			<li>BorealArchipelago</li>
 			<li>BorealArchipelago_Fresh</li>


### PR DESCRIPTION
1 fixed inability to build a swamp pier in swamps (Undefined terrainAffordanceNeeded param & deleted duplicates of this);
2 fixed inability to fish in swamp biomes. There was not a single fish. Added a couple. 
Mashgon – A medium shellfish often found in the swamps and marshes. Its name comes from the local tribespeople calling it "marsh dragon"... Marsh dragon who cannot be found in march & swamp of swamp biomes... how ironic.

1 исправил невозможность построить пирс для болот на болотах (требовал поверхность типа Undefined. Также удалил дубликаты требования к поверхности. У базы пирсов они уже были прописаны).
2 исправил невозможность рыбачить во всех болотных биомах. Там не были ни одной рыбки. Добавил парочку.
В описании Машгона сказано, что некоторые племена прозвали его "болотным драконом"... Болотный дракон, который не обитает в болотах болотных биомов... как иронично, однако.