### PR TITLE
Ratkin pawns & apparels tweaks & fixes

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
+++ b/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
@@ -140,6 +140,14 @@
 				</options>
 			</li>
 			<li>
+				<kindDef>Combat</kindDef>
+				<commonality>15</commonality>
+				<options>
+					<RatkinEliteSoldier>10</RatkinEliteSoldier>
+					<RatkinDemonMan>3</RatkinDemonMan>
+				</options>
+			</li>
+			<li>
 				<kindDef>Peaceful</kindDef>
 				<options>
 					<RatkinNoble>10</RatkinNoble>

--- a/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
+++ b/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
@@ -548,9 +548,6 @@
 		<apparelRequired>
 			<li>RK_BattleSuit</li>
 			<li>RK_Mask</li>
-			<li>MedievalTimes_Boots_Techno</li>
-			<li>Apparello_CalmingLove</li>
-			<li>Apparel_TacVest</li>
 		</apparelRequired>
 		<weaponMoney>
 			<min>3500</min>
@@ -558,7 +555,6 @@
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_4TierWeapon</li>
-			<li>RK_HT_RF</li>
 		</weaponTags>
 		<apparelTags>
 			<li>RK_EliteSoldier</li>
@@ -613,8 +609,6 @@
 			<li>Apparel_SmokepopBelt</li>
 			<li>RK_HeadBand</li>
 			<li>RK_BattleSuit</li>
-			<li>Apparello_CalmingLove</li>
-			<li>MedievalTimes_Boots_Techno</li>
 		</apparelRequired>
 		<apparelTags>
 			<li>RK_Demoman</li>

--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
@@ -2083,8 +2083,8 @@
 			<EnergyShieldRechargeRate>0.1</EnergyShieldRechargeRate>
 			<EnergyShieldEnergyMax>1</EnergyShieldEnergyMax>
 			<Mass>5</Mass>
-            <Insulation_Cold>10</Insulation_Cold>
-            <Insulation_Heat>10</Insulation_Heat>
+            <Insulation_Cold>30</Insulation_Cold>
+            <Insulation_Heat>20</Insulation_Heat>
 			<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 			<StuffEffectMultiplierInsulation_Cold>0.57</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>0.57</StuffEffectMultiplierInsulation_Heat>
@@ -2105,8 +2105,8 @@
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>			
 			<PainShockThreshold>0.1</PainShockThreshold>
 			<Flammability>-0.25</Flammability>
-			<GermResistance>0.10</GermResistance>
-			<GermContainment>0.10</GermContainment>
+			<GermResistance>0.2</GermResistance>
+			<GermContainment>0.2</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
 			<bodyPartGroups>
@@ -2115,6 +2115,8 @@
 				<li>Shoulders</li>
 				<li>Arms</li>
 				<li>Legs</li>
+				<li>Hands</li>
+				<li>Feet</li>
 			</bodyPartGroups>
 			<defaultOutfitTags>
 				<li>Soldier</li>
@@ -2205,6 +2207,11 @@
 				<li>RoyalCombatGear</li>
 			</tags>
 		</apparel>
+        	<modExtensions>
+            		<li Class="CombatExtended.ApparelHediffExtension">
+                		<hediff>WearingSpacerHelmet</hediff>
+            		</li>
+        	</modExtensions>
 		<tradeability>Sellable</tradeability>
 	</ThingDef>
 


### PR DESCRIPTION
1 added high-tech only ratkin raid type (late game only);
2 delete gloves & boots from ratkin high-tech pawns (sometimes there was an red error when spawning). Battle suit now cover hands and feet. Also correcting insulation & germ param of it;
3 added wearing spacer helmet to ratkin mask;
4 removed redundant weapon tag.

1 добавил рейд раткинов, состоящий только из высокотехнологичных пешек (для лейта);
2 удалил перчатки и ботинки у высокотехнологичных пешек раткинов (из-за них иногда возникала красная ошибка при спавне, сама пешка при этом не спавнилась). Вместо них боевой костюм раткинов теперь закрывает кисти и ступни. Скорректировал параметры изоляции и параметры распространения микробов в связи с этими изменениями;
3 добавил маске раткинов эффект космического шлема (т.к. сам шлем делается из высокотехнологичных материалов);
4 удалил лишний тег оружия у раткинов.