### PR TITLE
HP ammo craft rethinking

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
@@ -259,18 +259,21 @@
 				<filter>
 					<categories>
 						<li>SLDBar</li>
-						<li>USLDBar</li>
+						<li>HeavyBar</li>
 					</categories>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
 				</filter>
-				<count>6</count>
+				<count>3</count>
 			</li>
 			<li>
 				<filter>
 					<thingDefs>
-						<li>Carbon</li>
+						<li>HeavyBar</li>
 					</thingDefs>
 				</filter>
-				<count>3</count>
+				<count>5</count>
 			</li>
 			<li>
 				<filter>
@@ -284,10 +287,10 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>SLDBar</li>
-				<li>USLDBar</li>
+				<li>HeavyBar</li>
 			</categories>
 			<thingDefs>
-				<li>Carbon</li>
+				<li>Plastic</li>
 				<li>Powder</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
@@ -269,9 +269,9 @@
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
+					<categories>
 						<li>HeavyBar</li>
-					</thingDefs>
+					</categories>
 				</filter>
 				<count>5</count>
 			</li>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
@@ -256,18 +256,21 @@
 				<filter>
 					<categories>
 						<li>SLDBar</li>
-						<li>USLDBar</li>
+						<li>HeavyBar</li>
 					</categories>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
 				</filter>
-				<count>6</count>
+				<count>3</count>
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>Carbon</li>
-					</thingDefs>
+					<categories>
+						<li>HeavyBar</li>
+					</categories>
 				</filter>
-				<count>2</count>
+				<count>4</count>
 			</li>
 			<li>
 				<filter>
@@ -281,10 +284,10 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>SLDBar</li>
-				<li>USLDBar</li>
+				<li>HeavyBar</li>
 			</categories>
 			<thingDefs>
-				<li>Carbon</li>
+				<li>Plastic</li>
 				<li>Powder</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/303British.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/303British.xml
@@ -256,18 +256,21 @@
 				<filter>
 					<categories>
 						<li>SLDBar</li>
-						<li>USLDBar</li>
+						<li>HeavyBar</li>
 					</categories>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
 				</filter>
-				<count>11</count>
+				<count>5</count>
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>Carbon</li>
-					</thingDefs>
+					<categories>
+						<li>HeavyBar</li>
+					</categories>
 				</filter>
-				<count>3</count>
+				<count>6</count>
 			</li>
 			<li>
 				<filter>
@@ -281,10 +284,10 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>SLDBar</li>
-				<li>USLDBar</li>
+				<li>HeavyBar</li>
 			</categories>
 			<thingDefs>
-				<li>Carbon</li>
+				<li>Plastic</li>
 				<li>Powder</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/303British.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/303British.xml
@@ -270,7 +270,7 @@
 						<li>HeavyBar</li>
 					</categories>
 				</filter>
-				<count>6</count>
+				<count>8</count>
 			</li>
 			<li>
 				<filter>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/556x45mmNATO.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/556x45mmNATO.xml
@@ -257,18 +257,21 @@
 				<filter>
 					<categories>
 						<li>SLDBar</li>
-						<li>USLDBar</li>
+						<li>HeavyBar</li>
 					</categories>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
 				</filter>
-				<count>6</count>
+				<count>4</count>
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>Carbon</li>
-					</thingDefs>
+					<categories>
+						<li>HeavyBar</li>
+					</categories>
 				</filter>
-				<count>2</count>
+				<count>5</count>
 			</li>
 			<li>
 				<filter>
@@ -282,10 +285,10 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>SLDBar</li>
-				<li>USLDBar</li>
+				<li>HeavyBar</li>
 			</categories>
 			<thingDefs>
-				<li>Carbon</li>
+				<li>Plastic</li>
 				<li>Powder</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x39mmSoviet.xml
@@ -268,18 +268,21 @@
 				<filter>
 					<categories>
 						<li>SLDBar</li>
-						<li>USLDBar</li>
+						<li>HeavyBar</li>
 					</categories>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>5</count>
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>Carbon</li>
-					</thingDefs>
+					<categories>
+						<li>HeavyBar</li>
+					</categories>
 				</filter>
-				<count>4</count>
+				<count>7</count>
 			</li>
 			<li>
 				<filter>
@@ -293,10 +296,10 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>SLDBar</li>
-				<li>USLDBar</li>
+				<li>HeavyBar</li>
 			</categories>
 			<thingDefs>
-				<li>Carbon</li>
+				<li>Plastic</li>
 				<li>Powder</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x51mmNATO.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x51mmNATO.xml
@@ -259,18 +259,21 @@
 				<filter>
 					<categories>
 						<li>SLDBar</li>
-						<li>USLDBar</li>
+						<li>HeavyBar</li>
 					</categories>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
 				</filter>
-				<count>14</count>
+				<count>6</count>
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>Carbon</li>
-					</thingDefs>
+					<categories>
+						<li>HeavyBar</li>
+					</categories>
 				</filter>
-				<count>4</count>
+				<count>11</count>
 			</li>
 			<li>
 				<filter>
@@ -284,10 +287,10 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>SLDBar</li>
-				<li>USLDBar</li>
+				<li>HeavyBar</li>
 			</categories>
 			<thingDefs>
-				<li>Carbon</li>
+				<li>Plastic</li>
 				<li>Powder</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Pistols/7.62x25mmTT.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Pistols/7.62x25mmTT.xml
@@ -288,18 +288,21 @@
 				<filter>
 					<categories>
 						<li>SLDBar</li>
-						<li>USLDBar</li>
+						<li>HeavyBar</li>
 					</categories>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
 				</filter>
-				<count>6</count>
+				<count>2</count>
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>Carbon</li>
-					</thingDefs>
+					<categories>
+						<li>HeavyBar</li>
+					</categories>
 				</filter>
-				<count>3</count>
+				<count>6</count>
 			</li>
 			<li>
 				<filter>
@@ -313,10 +316,10 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>SLDBar</li>
-				<li>USLDBar</li>
+				<li>HeavyBar</li>
 			</categories>
 			<thingDefs>
-				<li>Carbon</li>
+				<li>Plastic</li>
 				<li>Powder</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/545x39mmSoviet.xml
@@ -257,18 +257,21 @@
 				<filter>
 					<categories>
 						<li>SLDBar</li>
-						<li>USLDBar</li>
+						<li>HeavyBar</li>
 					</categories>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>4</count>
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>Carbon</li>
-					</thingDefs>
+					<categories>
+						<li>HeavyBar</li>
+					</categories>
 				</filter>
-				<count>2</count>
+				<count>4</count>
 			</li>
 			<li>
 				<filter>
@@ -282,10 +285,10 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>SLDBar</li>
-				<li>USLDBar</li>
+				<li>HeavyBar</li>
 			</categories>
 			<thingDefs>
-				<li>Carbon</li>
+				<li>Plastic</li>
 				<li>Powder</li>
 			</thingDefs>
 		</fixedIngredientFilter>

--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/762x54mmR.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/762x54mmR.xml
@@ -256,18 +256,21 @@
 				<filter>
 					<categories>
 						<li>SLDBar</li>
-						<li>USLDBar</li>
+						<li>HeavyBar</li>
 					</categories>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
 				</filter>
-				<count>15</count>
+				<count>7</count>
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>Carbon</li>
-					</thingDefs>
+					<categories>
+						<li>HeavyBar</li>
+					</categories>
 				</filter>
-				<count>4</count>
+				<count>11</count>
 			</li>
 			<li>
 				<filter>
@@ -281,10 +284,10 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>SLDBar</li>
-				<li>USLDBar</li>
+				<li>HeavyBar</li>
 			</categories>
 			<thingDefs>
-				<li>Carbon</li>
+				<li>Plastic</li>
 				<li>Powder</li>
 			</thingDefs>
 		</fixedIngredientFilter>


### PR DESCRIPTION
The following issues are currently observed with HP ammo:

1 HP ammo require carbon for crafting. By the time it's becomes possible to create this, their effectiveness tends to zero (cuz enemies with strong armor appear starting (like mechanoids));
2 to create HP ammo, lead or other heavy materials are not required at all, but at the same time it is possible to use ultra-solid bars when creating them. I think this is very strange cuz HP ammo cuz HP ammo and FMJ ammo have not so much differents. 
Main differents - no/not full metal jacket & hollow point.

I propose to rethinking the recipes by adding the ability to create several types of HP ammunition in one recipe:
- no/not full metal jacket version (heavy bars/solid bars + heavy bars + powder);
- polymer-tipped bullets version (plastic + heavy bars + powder).

This will make them more usable I hope.

Переосмысление рецепта создания HP боеприпасов.
На данный момент мы имеем следующие проблемы с созданием HP боеприпасов:

1 HP боеприпасы требуют карбон для создания. К тому времени, когда карбон становится доступен для создания, эффективность таких боеприпасов стремится к нулю (начинают появляться враги с прочной броней (например, механоиды));
2 для создания HP боеприпасов по неизвестным причинам вовсе не требуется свинец или какой-либо другой тяжелый сплав, но при этом их можно создавать из сверхпрочных сплавов (что полностью противоречит принципу их действия). Это очень странной на мой взгляд, т.к. HP боеприпасы отличаются от FMJ в основном отсутствием/наличием неполной оболочки и наличием полости.

Предлагаю пересмотреть рецепт создания, добавив возможность создавать следующие версии HP патронов в пределах одного рецепта:
- версия с отсутствием/наличием неполной оболочки (тяжелые сплавы/прочные сплавы + тяжелые сплавы + порох);
- версия с полимерными наконечниками (пластик + тяжелые сплавы + порох).

Это должно сделать их менее бесполезными.