### PR TITLE
Fix unworking numbers mod with android scenarios (apparelStuffFilter red error)

### DIFF
--- a/Mods/Androids/Defs/FactionDefs/Factions_Androids.xml
+++ b/Mods/Androids/Defs/FactionDefs/Factions_Androids.xml
@@ -26,8 +26,15 @@
 			<li>Urban</li>
 		</hairTags>
 		<apparelStuffFilter>
+			<categories>
+				<li>Leathers</li>
+			</categories>
 			<thingDefs>
+				<li>Plasteel</li>
 				<li>Synthread</li>
+				<li>FerrosiliconAlloy</li>
+				<li>CupronickelAlloy</li>
+				<li>SteelBar</li>
 			</thingDefs>
 		</apparelStuffFilter>
 	</FactionDef>


### PR DESCRIPTION
https://discord.com/channels/272340793174392832/283226662970195969/758655495472152597

Исправление неработоспособности мода "Цифры" на сценариях андроидов (красная ошибка с отсылкой на apparelStuffFilter )