### PR TITLE
Golden latrine

### DIFF
--- a/Mods/Dubs-Bad-Hygiene/Defs/ThingDefs_Buildings/BuildingsB_Hygiene.xml
+++ b/Mods/Dubs-Bad-Hygiene/Defs/ThingDefs_Buildings/BuildingsB_Hygiene.xml
@@ -128,8 +128,10 @@
     <fillPercent>0.15</fillPercent>
     <stuffCategories>
       <li>Metallic</li>
+      <li>Precious</li>
       <li>Woody</li>
       <li>Stony</li>
+      <li>Bricks</li>
     </stuffCategories>
     <costStuffCount>15</costStuffCount>
     <leaveResourcesWhenKilled>true</leaveResourcesWhenKilled>


### PR DESCRIPTION
added some missed latrine stuff categories (Precious + Bricks).

добавлены две пропущенные категории у выгребной ямы (драгоценные металлы и глиняные кирпичи) (гальюн из золота!).