### PR TITLE
Fix barricade rus translation (duplicate)

### DIFF
--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Defences_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Defences_SK.xml
@@ -4,10 +4,10 @@
 
 	<chevalDeFrise.label>Рогатка</chevalDeFrise.label>
 	<chevalDeFrise.description>Рогатка — лёгкое оборонительное заграждение, конструкция из перекрещенных и скреплённых (связанных) между собою деревянных бруса и кольев (обычно заострённых).</chevalDeFrise.description>
-
+<!-- 
 	<Barricade.label>Бойница</Barricade.label>
 	<Barricade.description>Узкое отверстие в оборонительных стенах. Служит для ведения огня из укрытия по заданному направлению.</Barricade.description>
-
+ -->
 	<Embrasure.label>Амбразура</Embrasure.label>
 	<Embrasure.description>Отличное средство защиты. Позволяет создавать огневые точки и бункеры, откуда можно вести огонь.</Embrasure.description>
 

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Defences_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Defences_SK.xml
@@ -4,10 +4,7 @@
 
 	<chevalDeFrise.label>Рогатка</chevalDeFrise.label>
 	<chevalDeFrise.description>Рогатка — лёгкое оборонительное заграждение, конструкция из перекрещенных и скреплённых (связанных) между собою деревянных бруса и кольев (обычно заострённых).</chevalDeFrise.description>
-<!-- 
-	<Barricade.label>Бойница</Barricade.label>
-	<Barricade.description>Узкое отверстие в оборонительных стенах. Служит для ведения огня из укрытия по заданному направлению.</Barricade.description>
- -->
+
 	<Embrasure.label>Амбразура</Embrasure.label>
 	<Embrasure.description>Отличное средство защиты. Позволяет создавать огневые точки и бункеры, откуда можно вести огонь.</Embrasure.description>
 


### PR DESCRIPTION
Дублировался + некорректное описание и название. В CoreTranslation уже есть и оно корректное.