### PR TITLE
Some ammo dmg & penetration tweaks & fixes

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
@@ -112,7 +112,7 @@
 			<damageAmountBase>13</damageAmountBase>
 			<!-- <armorPenetrationBase>0.34</armorPenetrationBase> -->
 			<armorPenetrationSharp>5.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
+			<armorPenetrationBlunt>12.3</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -120,10 +120,10 @@
 		<defName>Bullet_45ACP_AP</defName>
 		<label>.45 ACP bullet (AP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>8</damageAmountBase>
+			<damageAmountBase>10</damageAmountBase>
 			<!-- <armorPenetrationBase>0.46</armorPenetrationBase> -->
 			<armorPenetrationSharp>8.1</armorPenetrationSharp>
-			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
+			<armorPenetrationBlunt>12.3</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -133,8 +133,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>16</damageAmountBase>
 			<!-- <armorPenetrationBase>0.32</armorPenetrationBase> -->
-			<armorPenetrationSharp>3.4</armorPenetrationSharp>
-			<armorPenetrationBlunt>10.860</armorPenetrationBlunt>
+			<armorPenetrationSharp>4.5</armorPenetrationSharp>
+			<armorPenetrationBlunt>12.3</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
@@ -112,7 +112,7 @@
 			<damageAmountBase>13</damageAmountBase>
 			<!-- <armorPenetrationBase>0.34</armorPenetrationBase> -->
 			<armorPenetrationSharp>5.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>12.3</armorPenetrationBlunt>
+			<armorPenetrationBlunt>12</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -123,7 +123,7 @@
 			<damageAmountBase>10</damageAmountBase>
 			<!-- <armorPenetrationBase>0.46</armorPenetrationBase> -->
 			<armorPenetrationSharp>8.1</armorPenetrationSharp>
-			<armorPenetrationBlunt>12.3</armorPenetrationBlunt>
+			<armorPenetrationBlunt>12</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -134,7 +134,7 @@
 			<damageAmountBase>16</damageAmountBase>
 			<!-- <armorPenetrationBase>0.32</armorPenetrationBase> -->
 			<armorPenetrationSharp>4.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>12.3</armorPenetrationBlunt>
+			<armorPenetrationBlunt>12</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
@@ -133,7 +133,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
 			<!-- <armorPenetrationBase>0.30</armorPenetrationBase> -->
-			<armorPenetrationSharp>3.75</armorPenetrationSharp>
+			<armorPenetrationSharp>4.7</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.66</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
@@ -133,7 +133,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
 			<!-- <armorPenetrationBase>0.30</armorPenetrationBase> -->
-			<armorPenetrationSharp>4.7</armorPenetrationSharp>
+			<armorPenetrationSharp>4.8</armorPenetrationSharp>
 			<armorPenetrationBlunt>10.66</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/303British.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/303British.xml
@@ -133,7 +133,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>27</damageAmountBase>
 			<!-- <armorPenetrationBase>0.54</armorPenetrationBase> -->
-			<armorPenetrationSharp>6.7</armorPenetrationSharp>
+			<armorPenetrationSharp>7.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>62.540</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/556x45mmNATO.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/556x45mmNATO.xml
@@ -134,7 +134,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>24</damageAmountBase>
 			<!-- <armorPenetrationBase>0.50</armorPenetrationBase> -->
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>6.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>36.18</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x39mmSoviet.xml
@@ -145,7 +145,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>26</damageAmountBase>
 			<!-- <armorPenetrationBase>0.49</armorPenetrationBase> -->
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>6.25</armorPenetrationSharp>
 			<armorPenetrationBlunt>43.08</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x51mmNATO.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x51mmNATO.xml
@@ -133,7 +133,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>28</damageAmountBase>
 			<!-- <armorPenetrationBase>0.58</armorPenetrationBase> -->
-			<armorPenetrationSharp>7.5</armorPenetrationSharp>
+			<armorPenetrationSharp>8.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>66.72</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Pistols/7.62x25mmTT.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Pistols/7.62x25mmTT.xml
@@ -149,7 +149,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>15</damageAmountBase>
 			<!-- <armorPenetrationBase>0.31</armorPenetrationBase> -->
-			<armorPenetrationSharp>4.25</armorPenetrationSharp>
+			<armorPenetrationSharp>5</armorPenetrationSharp>
 			<armorPenetrationBlunt>11.67</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/545x39mmSoviet.xml
@@ -134,7 +134,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>23</damageAmountBase>
 			<!-- <armorPenetrationBase>0.48</armorPenetrationBase> -->
-			<armorPenetrationSharp>6</armorPenetrationSharp>
+			<armorPenetrationSharp>6.4</armorPenetrationSharp>
 			<armorPenetrationBlunt>34.8</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>

--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/762x54mmR.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/762x54mmR.xml
@@ -133,7 +133,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>29</damageAmountBase>
 			<!-- <armorPenetrationBase>0.60</armorPenetrationBase> -->
-			<armorPenetrationSharp>7.7</armorPenetrationSharp>
+			<armorPenetrationSharp>8.75</armorPenetrationSharp>
 			<armorPenetrationBlunt>68.9</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>


### PR DESCRIPTION
I created some why-table and noticed the following:

![image](https://user-images.githubusercontent.com/62516232/95012001-7c721880-064e-11eb-9ce9-16d08acbde7d.png)

1 .45 ACP FMJ and HP ammo have 2 more dmg than 9x19 mm FMJ and HP but have some lesser RHA armor penetration. .45 ACP AP and 9x19 mm AP ammo have similar dmg, but .45 ACP stil have lesser RHA penetration than 9x19 mm. It's strange I think;

2 parameters of the HP ammo lower than that of the FMJ and AP version (HP lose more % of the RHA penetration than it's receive % of damage) (it's very noticeable in pistol ammo);

3 some pistol HP ammo have worse dmg/RHApenetration param than metallic bolts (why?);

4 .45 ACP as the heaviest pistol bullet should have little more MPa penetration than other I think.

I suggest increasing the armor penetration of all HP ammo a little bit.

[rus]
Решил создать why-таблицу (см. выше) и заметил следующее:

1 .45 ACP FMJ и HP патроны наносят на две единицы больше урона, чем 9x19 мм FMJ и HP, но при этом имеют несколько меньшее БКГ бронепробитие. .45 ACP AP и 9x19 мм AP патроны наносят одинаковый урон, но при этом .45 ACP все ещё имеет меньшее бронепробитие. Странно (по идее у .45 ACP урон должен быть несколько более высоким, чем у 9x19 мм);

2 параметры всех HP патронов в целом хуже, чем у FMJ и AP версий (HP патроны теряют больший % в бронепробитии, чем приобретают в виде дополнительного урона. Особенно это заметно у пистолетов);

3 некоторые пистолетные HP патроны слабее металлических болтов (ват?);

4 .45 ACP как самый тяжелый из пистолетных патронов, на мой взгляд, должен иметь несколько большее МПа бронепробитие.

Предлагаю немного увеличить бронепробитие всех HP-патронов.