### PR TITLE
Some Rich Explorer starting scenario tweaks & fixes

### DIFF
--- a/Mods/Core_SK/Defs/ScenarioDefs/Scenarios_K_TheRichExplorer.xml
+++ b/Mods/Core_SK/Defs/ScenarioDefs/Scenarios_K_TheRichExplorer.xml
@@ -47,7 +47,16 @@
 				<li Class="ScenPart_StartingThing_Defined">
 					<def>StartingThing_Defined</def>
 					<thingDef>DeployableTentBig</thingDef>
-					<stuff>Cloth</stuff>
+					<stuff>Synthread</stuff>
+				</li>
+				<li Class="ScenPart_StartingThing_Defined">
+					<def>StartingThing_Defined</def>
+					<thingDef>Gun_TacticalCombatRifle</thingDef>
+				</li>
+				<li Class="ScenPart_StartingThing_Defined">
+					<def>StartingThing_Defined</def>
+					<thingDef>Ammo_556x45mmNATO_FMJ</thingDef>
+					<count>180</count>
 				</li>
 				<li Class="ScenPart_StartingAnimal">
 					<def>StartingAnimal</def>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
@@ -210,7 +210,7 @@
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Multitool</thingDef>
-		<stuff>SteelBar</stuff>
+		  <stuff>SteelBar</stuff>
             </li>
         </value>
     </Operation>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
@@ -210,7 +210,7 @@
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Multitool</thingDef>
-		<stuff>SteelBar</stuff>
+				<stuff>SteelBar</stuff>
             </li>
         </value>
     </Operation>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
@@ -210,7 +210,7 @@
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Multitool</thingDef>
-				<stuff>SteelBar</stuff>
+		<stuff>SteelBar</stuff>
             </li>
         </value>
     </Operation>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
@@ -210,6 +210,7 @@
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Multitool</thingDef>
+		<stuff>SteelBar</stuff>
             </li>
         </value>
     </Operation>


### PR DESCRIPTION
1 fixed red errors log spam from missed multitool stuff material. Added stein alloy.

**Mouse position stack is not empty. There were more calls to BeginScrollView than EndScrollView. Fixing.
Verse.Log:Error(String, Boolean)
Verse.Widgets:EnsureMousePositionStackEmpty()
Verse.Root:Verse.Root.Update_Patch1(Root)
Verse.Root_Entry:Update()**

2 added starting weapon to Rich Explorer scenario (MA5 ICWS - looks futuristic enough and does not conflict with Arcane Technology mod);

3 replaced stuff material of starting tent from cloth to synthread (high-tech start after all).

[rus]
1 исправлен спам красных ошибок из-за отсутствия материала мультитула. Добавил штейн.

2 добавил стартовое оружие в сценарий Богатого Исследователя. По умолчанию его почему-то не было. Добавил винтовку Halo Fanon MA5 - выглядит достаточно футуристично и не конфликтует с модом Arcane Technology).

3 заменил материал стартовой палатки с ткани на синткань (высокотехнологичный старт все-таки).