### PR TITLE
Some ratkins raids tweaks & fixes

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
+++ b/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
@@ -215,7 +215,7 @@
 
 	<FactionDef ParentName="RatkinFactionBase">
 		<defName>Rakinia</defName>
-		<earliestRaidDays>120</earliestRaidDays>
+		<earliestRaidDays>135</earliestRaidDays>
 		<label>ratkin kingdom</label>
 		<description>Ratkin War Kingdom. It is a invasive xenophobic species that lives visible to human beings and want to kill them all.</description>
 		<colorSpectrum>
@@ -229,7 +229,7 @@
 
 	<FactionDef ParentName="RatkinFactionBase">
 		<defName>Rakiniville</defName>
-		<earliestRaidDays>120</earliestRaidDays>
+		<earliestRaidDays>135</earliestRaidDays>
 		<label>ratkin kingdom</label>
 		<description>랫킨 왕국입니다. 인간들 눈에 띄지 않도록 숨어서 살고 있으며 농경생활을 위주로 생활하는 비 침략적인 종족입니다.</description>
 		<colorSpectrum>

--- a/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
+++ b/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
@@ -10,7 +10,7 @@
 		<requiredCountAtGameStart>1</requiredCountAtGameStart>
 		<canMakeRandomly>true</canMakeRandomly>
 		<leaderTitle>prime executor</leaderTitle>
-		<earliestRaidDays>120</earliestRaidDays>
+		<earliestRaidDays>135</earliestRaidDays>
 
 		<factionNameMaker>NamerFaction_RatkinKingdom</factionNameMaker>
 		<settlementNameMaker>NamerSettlement_RatkinKingdom</settlementNameMaker>
@@ -47,12 +47,12 @@
 		<allowedArrivalTemperatureRange>-40~45</allowedArrivalTemperatureRange>
 		<raidCommonalityFromPointsCurve>
 			<points>
-				<li>(250, 0.1)</li>
-				<li>(1000, 0.2)</li>
-				<li>(2000, 0.4)</li>
-				<li>(3000, 0.6)</li>
-				<li>(4000, 0.7)</li>
-				<li>(5000, 0.6)</li>
+				<li>(1000, 0.1)</li>
+				<li>(2000, 0.2)</li>
+				<li>(3000, 0.3)</li>
+				<li>(4000, 0.5)</li>
+				<li>(5000, 0.7)</li>
+				<li>(6000, 0.6)</li>
 				<li>(7500, 0.5)</li>
 				<li>(10000, 0.4)</li>
 			</points>
@@ -60,12 +60,12 @@
 		<maxPawnCostPerTotalPointsCurve>
 			<points>
 				<li>(0, 160)</li>
-				<li>(1000, 215)</li>
-				<li>(2000, 265)</li>
-				<li>(3000, 290)</li>
-				<li>(5000, 325)</li>
-				<li>(7500, 350)</li>
-				<li>(12500, 375)</li>
+				<li>(3000, 215)</li>
+				<li>(4000, 265)</li>
+				<li>(5000, 290)</li>
+				<li>(7500, 325)</li>
+				<li>(10000, 350)</li>
+				<li>(13000, 375)</li>
 				<li>(100000, 10000)</li>
 			</points>
 		</maxPawnCostPerTotalPointsCurve>
@@ -79,8 +79,20 @@
 				</disallowedStrategies>
 				<options>
 					<RatkinPettyThief>45</RatkinPettyThief>
+					<RatkinMurderer>5</RatkinMurderer>
 					<RatkinCombatant>3</RatkinCombatant>
-					<RatkinDemonMan>4</RatkinDemonMan>
+					<RatkinDemonMan>2</RatkinDemonMan>
+				</options>
+			</li>
+			<li>
+				<!-- Ratkin Murderers-->
+				<kindDef>Combat</kindDef>
+				<commonality>90</commonality>
+				<disallowedStrategies>
+					<li>Siege</li>
+				</disallowedStrategies>
+				<options>
+					<RatkinMurderer>10</RatkinMurderer>
 				</options>
 			</li>
 			<li>

--- a/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
+++ b/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
@@ -700,7 +700,8 @@
 			</categories>
 			</li>
 		</backstoryFiltersOverride>
-		<techHediffsChance>0.5</techHediffsChance>
+		<techHediffsChance>0.25</techHediffsChance>
+		<techHediffsMaxAmount>1</techHediffsMaxAmount>
 		<techHediffsTags>
 			<li>Advanced</li>
 		</techHediffsTags>

--- a/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
+++ b/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
@@ -5,6 +5,7 @@
 		<canBeSapper>true</canBeSapper>
 		<baseRecruitDifficulty>0.40</baseRecruitDifficulty>
 		<race>Ratkin</race>
+		<itemQuality>Normal</itemQuality>
 		<minGenerationAge>16</minGenerationAge>
 		<maxGenerationAge>35</maxGenerationAge>
 		<defaultFactionType>Rakinia</defaultFactionType>
@@ -278,7 +279,6 @@
 		<label>ratkin soldier</label>
 		<combatPower>240</combatPower>
 		<isFighter>true</isFighter>
-		<itemQuality>Normal</itemQuality>
 		<backstoryFiltersOverride>
 			<li>
 			<categories>
@@ -320,7 +320,6 @@
 		<baseRecruitDifficulty>0.70</baseRecruitDifficulty>
 		<combatPower>215</combatPower>
 		<isFighter>true</isFighter>
-		<itemQuality>Good</itemQuality>
 		<minGenerationAge>26</minGenerationAge>
 		<backstoryFiltersOverride>
 			<li>
@@ -383,7 +382,6 @@
 		<baseRecruitDifficulty>0.75</baseRecruitDifficulty>
 		<combatPower>160</combatPower>
 		<isFighter>true</isFighter>
-		<itemQuality>Normal</itemQuality>
 		<minGenerationAge>24</minGenerationAge>
 		<backstoryFiltersOverride>
 			<li>
@@ -398,7 +396,7 @@
 		</apparelRequired>
 		<gearHealthRange>
 			<min>0.7</min>
-			<max>2</max>
+			<max>1</max>
 		</gearHealthRange>
 		<apparelMoney>
 			<min>6500</min>
@@ -429,7 +427,6 @@
 		<baseRecruitDifficulty>0.85</baseRecruitDifficulty>
 		<combatPower>220</combatPower>
 		<isFighter>true</isFighter>
-		<itemQuality>Good</itemQuality>
 		<minGenerationAge>27</minGenerationAge>
 		<backstoryFiltersOverride>
 			<li>
@@ -444,8 +441,8 @@
 			<li>RK_HeavyShield</li>
 		</apparelRequired>
 		<gearHealthRange>
-			<min>0.7</min>
-			<max>2</max>
+			<min>0.8</min>
+			<max>1</max>
 		</gearHealthRange>
 		<apparelMoney>
 			<min>6500</min>
@@ -477,7 +474,7 @@
 		<combatPower>235</combatPower>
 		<isFighter>true</isFighter>
 		<factionLeader>true</factionLeader>
-		<itemQuality>Excellent</itemQuality>
+		<itemQuality>Good</itemQuality>
 		<minGenerationAge>21</minGenerationAge>
 		<backstoryFiltersOverride>
 			<li>
@@ -494,8 +491,8 @@
 			<li>RK_HeavyShield</li>
 		</apparelRequired>
 		<gearHealthRange>
-			<min>1</min>
-			<max>3</max>
+			<min>0.9</min>
+			<max>1</max>
 		</gearHealthRange>
 		<apparelMoney>
 			<min>6500</min>
@@ -529,7 +526,6 @@
 		<baseRecruitDifficulty>0.83</baseRecruitDifficulty>
 		<combatPower>375</combatPower>
 		<isFighter>true</isFighter>
-		<itemQuality>Good</itemQuality>
 		<gearHealthRange>
 			<min>1.0</min>
 			<max>2.0</max>
@@ -591,7 +587,7 @@
 		<baseRecruitDifficulty>0.83</baseRecruitDifficulty>
 		<isFighter>true</isFighter>
 		<gearHealthRange>
-			<min>0.8</min>
+			<min>0.7</min>
 			<max>1</max>
 		</gearHealthRange>
 		<backstoryFiltersOverride>
@@ -659,6 +655,7 @@
 		<label>ratkin petty thief</label>
 		<combatPower>100</combatPower>
 		<isFighter>true</isFighter>
+		<itemQuality>Poor</itemQuality>
 		<backstoryFiltersOverride>
 			<li>
 			<categories>

--- a/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
@@ -476,7 +476,7 @@
 			<ToxicSensitivity>0.8</ToxicSensitivity>
 			<SmokeSensitivity>0.8</SmokeSensitivity>
 			<EatingSpeed>1.2</EatingSpeed>
-			<MeatAmount>35</MeatAmount>
+			<MeatAmount>60</MeatAmount>
 			<LeatherAmount>30</LeatherAmount>
 			<!-- 전투 -->
 			<MeleeDodgeChance>1.15</MeleeDodgeChance>

--- a/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
@@ -560,7 +560,7 @@
 			<intelligence>Humanlike</intelligence>
 			<makesFootprints>true</makesFootprints>
 			<lifeExpectancy>70</lifeExpectancy>
-			<leatherDef>Leather_Light</leatherDef>
+			<leatherDef>Leather_Human</leatherDef>
 			<useMeatFrom>Human</useMeatFrom>
 			<nameCategory>HumanStandard</nameCategory>
 			<hasGenders>true</hasGenders>

--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
@@ -1221,9 +1221,9 @@
 			<Mass>2.5</Mass>
             <Insulation_Cold>6</Insulation_Cold>
             <Insulation_Heat>4</Insulation_Heat>
-			<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
-			<ArmorRating_Sharp>4.0</ArmorRating_Sharp>
-			<ArmorRating_Blunt>8.0</ArmorRating_Blunt>
+			<StuffEffectMultiplierArmor>1.25</StuffEffectMultiplierArmor>
+			<ArmorRating_Sharp>3.0</ArmorRating_Sharp>
+			<ArmorRating_Blunt>6.0</ArmorRating_Blunt>
 			<ArmorRating_Heat>0.08</ArmorRating_Heat>
 			<StuffEffectMultiplierInsulation_Cold>0.58</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>0.42</StuffEffectMultiplierInsulation_Heat>
@@ -2309,7 +2309,7 @@
 			<StuffEffectMultiplierArmor>0.8</StuffEffectMultiplierArmor>
 			<StuffEffectMultiplierInsulation_Cold>0.1</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>0.1</StuffEffectMultiplierInsulation_Heat>
-			<ArmorRating_Sharp>7.0</ArmorRating_Sharp>
+			<ArmorRating_Sharp>6.5</ArmorRating_Sharp>
 			<ArmorRating_Blunt>8.4</ArmorRating_Blunt>
 			<Flammability>0.0</Flammability>
 			<EquipDelay>7</EquipDelay>
@@ -2622,13 +2622,13 @@
 		<costStuffCount>30</costStuffCount>
 		<techLevel>Medieval</techLevel>
 		<statBases>
-			<MaxHitPoints>120</MaxHitPoints>
+			<MaxHitPoints>100</MaxHitPoints>
 			<WorkToMake>12500</WorkToMake>
 			<Mass>3</Mass>
 			<Bulk>2.5</Bulk>
 			<WornBulk>1.5</WornBulk>
 			<ArmorRating_Sharp>2.8</ArmorRating_Sharp>
-			<ArmorRating_Blunt>5.6</ArmorRating_Blunt>
+			<ArmorRating_Blunt>4.6</ArmorRating_Blunt>
 			<ArmorRating_Heat>0.1</ArmorRating_Heat>
 			<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
 			<Flammability>0.8</Flammability>
@@ -2716,7 +2716,7 @@
 		</stuffCategories>
 		<techLevel>Medieval</techLevel>
 		<statBases>
-			<MaxHitPoints>240</MaxHitPoints>
+			<MaxHitPoints>200</MaxHitPoints>
 			<WorkToMake>35000</WorkToMake>
 			<Mass>7</Mass>
 			<Bulk>8</Bulk>
@@ -2725,7 +2725,7 @@
 			<StuffEffectMultiplierInsulation_Cold>0.01</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>0.01</StuffEffectMultiplierInsulation_Heat>
 			<ArmorRating_Sharp>3.4</ArmorRating_Sharp>
-			<ArmorRating_Blunt>9.1</ArmorRating_Blunt>
+			<ArmorRating_Blunt>8.1</ArmorRating_Blunt>
 			<Flammability>0.3</Flammability>
 			<EquipDelay>2</EquipDelay>
 		</statBases>


### PR DESCRIPTION
1 increased earliest raid days from 120 to 135;
2 more powerful pawns will appear later;
3 added new early raid type - ratkin murders:

![image](https://user-images.githubusercontent.com/62516232/95023235-53c14180-0695-11eb-8af5-75a3d3eeb1ab.png)

4 some item quality & gears heals range tweaks & fixes;
5 light correction medieval ratkins armor & shield armor rating value;
6 fix meat amount & leather type by ratkin corpses butchering.

1 увеличил количество дней со старта колонии, после которых рейды раткинов могут начать приходить с 120 до 135;
2 самые мощные пешки раткинов будут появляться несколько позже (в зависимости от стоимости колонии);
3 добавил новый тип ранних рейдов раткинов (см. картинку выше);
4 некоторые правки качества предметов и прочности у пешек при их спавне. Местами были выше нормального значения;
5 немного скорректировал значения брони у средневековой брони и щитов раткинов;
6 скорректировал количество мяса и тип кожи при разделке трупов раткинов (было в 3 раза меньше мяса, чем от разделки других рас + кожа была не человеческая, а легкая (Как она там оказалась?)).