### PR TITLE
Some raids tweaks & fixes

### DIFF
--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Mech.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Mech.xml
@@ -53,6 +53,7 @@
 					<Mech_Crawler>85</Mech_Crawler>
 					<Mech_Lancer>70</Mech_Lancer>
 					<Mech_Scyther>60</Mech_Scyther>
+					<Mech_Pikeman>51</Mech_Pikeman>
 					<Mech_Centipede>50</Mech_Centipede>
 					<Mech_HGScyther>45</Mech_HGScyther>
 					<Mech_SniperLancer>41</Mech_SniperLancer>
@@ -76,6 +77,7 @@
 				<options>
 					<Mech_Lancer>70</Mech_Lancer>
 					<Mech_Scyther>60</Mech_Scyther>
+					<Mech_Pikeman>55</Mech_Pikeman>
 					<Mech_HGScyther>50</Mech_HGScyther>
 					<Mech_SniperLancer>40</Mech_SniperLancer>
 				</options>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Norbal.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Norbal.xml
@@ -28,7 +28,7 @@
 				<li>(0,100)</li>
 				<li>(500, 130)</li>
 				<li>(1000, 180)</li>
-				<li>(3000, 200)</li>
+				<li>(3000, 190)</li>
 				<li>(100000, 10000)</li>
 			</points>
 		</maxPawnCostPerTotalPointsCurve>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Norbal.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Norbal.xml
@@ -27,7 +27,8 @@
 			<points>
 				<li>(0,100)</li>
 				<li>(500, 130)</li>
-				<li>(1000, 190)</li>
+				<li>(1000, 180)</li>
+				<li>(3000, 200)</li>
 				<li>(100000, 10000)</li>
 			</points>
 		</maxPawnCostPerTotalPointsCurve>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Pirate.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Pirate.xml
@@ -117,7 +117,7 @@
 				</disallowedStrategies>
 				<options>
 					<Thrasher>10</Thrasher>
-					<Mercenary_Slasher>10</Mercenary_Slasher>
+					<Mercenary_Slasher>9</Mercenary_Slasher>
 					<PirateBoss>5</PirateBoss>
 				</options>
 			</li>

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Mercenary.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Mercenary.xml
@@ -246,7 +246,7 @@
 	<!-- Slasher -->
 	<PawnKindDef ParentName="SK_MercenaryBase" Name="MercenarySlasherBase" Abstract="True">
 		<label>Mercenary Slasher</label>
-		<combatPower>155</combatPower>
+		<combatPower>170</combatPower>
 		<race>Human</race>
 		<canBeSapper>true</canBeSapper>
 		<apparelRequired>

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Norbals.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Norbals.xml
@@ -271,6 +271,7 @@
 			<li>Norbalboots</li>
 			<li>WoodenShield</li>
 			<li>MedievalShield</li>
+			<li>NorbsonalShield</li>
 		</apparelTags>
 		<apparelMoney>
 			<min>2500</min>
@@ -296,6 +297,7 @@
 			<li>Norbal</li>
 			<li>NorbalKingly</li>
 			<li>Norbalboots</li>
+			<li>NorbsonalShield</li>
 		</apparelTags>
 		<apparelRequired>
 			<li>MedievalArmor_Gambeson</li>


### PR DESCRIPTION
1 added pikeman pawn to mechanoid raids;
2 light combat power cost boost to Mercenary Slasher (~ 10%, cuz this pawn has very strong guardian power shield);
3 light mercenary slasher amount to pirates melee only raid fixes (~ 10% reduced);
4 added norbal guardian shield to some high tier norbal melee pawns;
5 norbal raids curve correction (cuz (4)).

1 добавил драгуна в обычные рейды механоидов;
2 немного увеличил стоимость пешки "наёмник-вышибала", (~ 10%, т.к. приходит с сильным для своей стоимости силовым щитом);
3 немного уменьшил вес пешки "наёмник-вышибала" в мили-рейдах пиратов (~ 10%);
4 добавил силовой щит норбалов некоторым самым сильным пешкам ближнего боя;
5 в связи с пунктом (4) немного откорректировал кривую силы рейда норбалов (чтобы пешки с силовыми щитами не приходили слишком рано).