### PR TITLE
Some neolithic ammo & pain giver tweaks & fixes

### DIFF
--- a/Mods/CombatExtended/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
+++ b/Mods/CombatExtended/Patches/Core/HediffDefs/Hediffs_Local_Injuries.xml
@@ -138,6 +138,13 @@
 	  <value>Cut</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="Cut"]/injuryProps/painPerSeverity</xpath>
+		<value>
+			<painPerSeverity>0.02</painPerSeverity>
+  		</value>
+	</Operation>
+
 	<!-- Scratch -->
 
 	<Operation Class="PatchOperationReplace">
@@ -171,6 +178,13 @@
   	<xpath>Defs/HediffDef[defName="Bite"]</xpath>
     <attribute>Name</attribute>
     <value>HediffBite</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/HediffDef[defName="Bite"]/injuryProps/painPerSeverity</xpath>
+		<value>
+			<painPerSeverity>0.015</painPerSeverity>
+		</value>
 	</Operation>
 
 	<!-- Stab -->

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrows.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrows.xml
@@ -127,8 +127,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
 			<!-- <armorPenetrationBase>0.24</armorPenetrationBase> -->
-			<armorPenetrationSharp>2.2</armorPenetrationSharp>
-			<armorPenetrationBlunt>3.520</armorPenetrationBlunt>
+			<armorPenetrationSharp>2.4</armorPenetrationSharp>
+			<armorPenetrationBlunt>3.84</armorPenetrationBlunt>
 			<preExplosionSpawnChance>0.333</preExplosionSpawnChance> <!-- 14.99 arrows per resource -->			
 			<preExplosionSpawnThingDef>Ammo_Arrow_Stone</preExplosionSpawnThingDef>
 		</projectile>
@@ -140,8 +140,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
 			<!-- <armorPenetrationBase>0.3</armorPenetrationBase> -->
-			<armorPenetrationSharp>2.7</armorPenetrationSharp>
-			<armorPenetrationBlunt>3.760</armorPenetrationBlunt>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationBlunt>4.2</armorPenetrationBlunt>
 			<preExplosionSpawnChance>0.666</preExplosionSpawnChance> <!-- 29.94 arrows per resource -->			
 			<preExplosionSpawnThingDef>Ammo_Arrow_Steel</preExplosionSpawnThingDef>
 		</projectile>
@@ -155,7 +155,7 @@
 			<damageAmountBase>1</damageAmountBase>
 			<!-- <armorPenetrationBase>0.25</armorPenetrationBase> -->
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
-			<armorPenetrationBlunt>3.3</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.84</armorPenetrationBlunt>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>
 			<preExplosionSpawnThingDef>Ammo_Arrow_Poison</preExplosionSpawnThingDef>			
 			<secondaryDamage>
@@ -174,7 +174,7 @@
 			<damageAmountBase>12</damageAmountBase>
 			<!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
 			<armorPenetrationSharp>2</armorPenetrationSharp>
-			<armorPenetrationBlunt>3.760</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.2</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
@@ -115,8 +115,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
 			<!-- <armorPenetrationBase>0.37</armorPenetrationBase> -->			
-			<armorPenetrationBlunt>5.240</armorPenetrationBlunt>
-			<armorPenetrationSharp>3.35</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.8</armorPenetrationBlunt>
+			<armorPenetrationSharp>3.7</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_Bolt_Metallic</preExplosionSpawnThingDef>
 		</projectile>
@@ -129,7 +129,7 @@
 			<damageDef>ArrowVenom</damageDef>
 			<damageAmountBase>1</damageAmountBase>
 			<!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
-			<armorPenetrationBlunt>5.240</armorPenetrationBlunt>
+			<armorPenetrationBlunt>5.8</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.1</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_Bolt_Poison</preExplosionSpawnThingDef>			
@@ -148,7 +148,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>15</damageAmountBase>
 			<!-- <armorPenetrationBase>0.35</armorPenetrationBase> -->
-			<armorPenetrationBlunt>5.6</armorPenetrationBlunt>
+			<armorPenetrationBlunt>6.2</armorPenetrationBlunt>
 			<armorPenetrationSharp>2.72</armorPenetrationSharp>
 			<secondaryDamage>
 				<li>

--- a/Mods/Core_SK/Defs/HediffDefs/HediffDefs_ResistPain.xml
+++ b/Mods/Core_SK/Defs/HediffDefs/HediffDefs_ResistPain.xml
@@ -57,7 +57,7 @@
 		<description>Real berserker</description>
 		<stages>
 			<li>
-				<painFactor>0.67</painFactor>
+				<painFactor>0.75</painFactor>
 			</li>
 		</stages>
 	</HediffDef>


### PR DESCRIPTION
1 light arrow & bolt armor penetration correction;
2 returned berserk state passive pain factor to 75%;
3 added missed cut & bite painPerSeverity CE patch.

1 небольшая корректировка бронепробития стрел и болтов;
2 откатил изменения пассивки норбалов до предыдущего состояния (=75%);
3 добавил отсутствующие патчи на накопление боли от порезов и укусов (странно, что СЕ не пропатчили эти типы урона, раны от них оставляют намного меньше боли, чем от остальных атак).