### PR TITLE
Fix stuff count type cost of totem crafting

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Exotic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Exotic.xml
@@ -386,8 +386,8 @@
 		<stuffCategories>
 			<li>WoodLogs</li>
 		</stuffCategories>
+		<costStuffCount>110</costStuffCount>
 		<costList>
-			<WoodLog>110</WoodLog>
 			<ComponentMedieval>15</ComponentMedieval>
 		</costList>
 		<designationCategory>Joy</designationCategory>


### PR DESCRIPTION
Поправил крафт тотема. Теперь при разборе будет выпадать не дерево, а материал тотема.