### PR TITLE
Fixes

### DIFF
--- a/Mods/Core_SK/Defs/BiomeDefs/Biomes_Archipelago.xml
+++ b/Mods/Core_SK/Defs/BiomeDefs/Biomes_Archipelago.xml
@@ -1088,7 +1088,7 @@
 			<Plant_HealrootWild>0.06</Plant_HealrootWild>
 			<Plant_Rhododendron>0.05</Plant_Rhododendron>
 			<Plant_TallGrass>6.8</Plant_TallGrass>
-			<Plant_GiantLeaf>0.25</Plant_GiantLeaf>
+			<Plant_GiantLeaf>0.15</Plant_GiantLeaf>
 			<Plant_Daylily>0.4</Plant_Daylily>
 			<Plant_WhiteRose>0.25</Plant_WhiteRose>
 			<Plant_Crocus>0.4</Plant_Crocus>
@@ -1289,7 +1289,7 @@
 			<Plant_Sugarcane>0.6</Plant_Sugarcane>
 			<Plant_TreeCocoa>0.04</Plant_TreeCocoa>
 			<Plant_HealrootWild>0.06</Plant_HealrootWild>
-			<Plant_GiantLeaf>0.3</Plant_GiantLeaf>
+			<Plant_GiantLeaf>0.2</Plant_GiantLeaf>
 			<Plant_Fern>3.5</Plant_Fern>
 			<Plant_Bromeliad>0.5</Plant_Bromeliad>
 			<Plant_Hosta>0.5</Plant_Hosta>

--- a/Mods/Core_SK/Defs/BiomeDefs/Biomes_Warm.xml
+++ b/Mods/Core_SK/Defs/BiomeDefs/Biomes_Warm.xml
@@ -153,7 +153,7 @@
 			<Plant_HealrootWild>0.06</Plant_HealrootWild>
 			<Plant_Rhododendron>0.05</Plant_Rhododendron>
 			<Plant_TallGrass>6.8</Plant_TallGrass>
-			<Plant_GiantLeaf>0.25</Plant_GiantLeaf>
+			<Plant_GiantLeaf>0.15</Plant_GiantLeaf>
 			<Plant_Daylily>0.4</Plant_Daylily>
 			<Plant_WhiteRose>0.25</Plant_WhiteRose>
 			<Plant_Crocus>0.4</Plant_Crocus>
@@ -384,7 +384,7 @@
 			<Plant_Sugarcane>0.6</Plant_Sugarcane>
 			<Plant_TreeCocoa>0.04</Plant_TreeCocoa>
 			<Plant_HealrootWild>0.06</Plant_HealrootWild>
-			<Plant_GiantLeaf>0.3</Plant_GiantLeaf>
+			<Plant_GiantLeaf>0.2</Plant_GiantLeaf>
 			<Plant_Fern>3.7</Plant_Fern>
 			<Plant_Bromeliad>0.5</Plant_Bromeliad>
 			<Plant_Hosta>0.5</Plant_Hosta>

--- a/Mods/Core_SK/Defs/ThingDefs/Events_Meteors.xml
+++ b/Mods/Core_SK/Defs/ThingDefs/Events_Meteors.xml
@@ -14,6 +14,7 @@
 		<mineable>true</mineable>
 		<rotatable>false</rotatable>
 		<building>
+			<deconstructible>false</deconstructible>
 			<claimable>false</claimable>
 			<isResourceRock>true</isResourceRock>
 			<mineableNonMinedEfficiency>0.8</mineableNonMinedEfficiency>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Caveplants.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Caveplants.xml
@@ -89,7 +89,8 @@
 			<MaxHitPoints>100</MaxHitPoints>
 			<MarketValue>5.5</MarketValue>
 			<Flammability>1.0</Flammability>
-			<MedicalPotency>0.5</MedicalPotency>
+			<MedicalPotency>0.35</MedicalPotency>
+			<MedicalQualityMax>0.60</MedicalQualityMax>
 			<DeteriorationRate>10</DeteriorationRate>
 			<Mass>0.04</Mass>
 			<Bulk>0.05</Bulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Caveplants.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Caveplants.xml
@@ -89,8 +89,8 @@
 			<MaxHitPoints>100</MaxHitPoints>
 			<MarketValue>5.5</MarketValue>
 			<Flammability>1.0</Flammability>
-			<MedicalPotency>0.35</MedicalPotency>
-			<MedicalQualityMax>0.60</MedicalQualityMax>
+			<MedicalPotency>0.45</MedicalPotency>
+			<MedicalQualityMax>0.70</MedicalQualityMax>
 			<DeteriorationRate>10</DeteriorationRate>
 			<Mass>0.04</Mass>
 			<Bulk>0.05</Bulk>


### PR DESCRIPTION
- Removed "deconstruct" option from meteors. No more new players deconstructing valuable meteors
- Slightly reduces spawn rate of huge edible leaves, there were too many of them
- Reduced medical potency of gleamcaps to be in row with raw herbal medicine 0.6 -> 0.35

------------------

- Убрал возможность разобрать метеорит без получения дропа
- Немного уменьшил частоту спавна больших съедобных листьев (раньше они были несъедобными)
- Уменьшил медицинскую силу ножек сатанинского гриба чтобы соответствовала мощности лекарственных трав 0.6 -> 0.35 (у лекарственных трав 0.3)