### PR TITLE
Fix muscle stimulator surgery bug

### DIFF
--- a/Mods/Core_SK/Defs/BodyParts/BodyParts_Synthetic.xml
+++ b/Mods/Core_SK/Defs/BodyParts/BodyParts_Synthetic.xml
@@ -835,8 +835,12 @@
 		<defName>InstallMuscleStimulatorArms</defName>
 		<label>install muscle stimulator</label>
 		<description>Installs muscle stimulator in the arm.</description>
-		<descriptionHyperlinks><ThingDef>MuscleStimulator</ThingDef></descriptionHyperlinks>
+		<workerClass>Recipe_InstallImplant</workerClass>
+		<descriptionHyperlinks>
+			<ThingDef>MuscleStimulator</ThingDef>
+		</descriptionHyperlinks>
 		<jobString>Installing muscle stimulator.</jobString>
+		<workAmount>1500</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -846,11 +850,22 @@
 				</filter>
 				<count>1</count>
 			</li>
+			<li>
+				<filter>
+					<categories>
+						<li>Medicine</li>
+					</categories>
+				</filter>
+				<count>1</count>
+			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>MuscleStimulator</li>
 			</thingDefs>
+			<categories>
+				<li>Medicine</li>
+			</categories>
 		</fixedIngredientFilter>
 		<appliedOnFixedBodyParts>
 			<li>Shoulder</li> 
@@ -863,8 +878,12 @@
 		<defName>InstallMuscleStimulatorLegs</defName>
 		<label>install muscle stimulator</label>
 		<description>Installs muscle stimulator in the leg.</description>
-		<descriptionHyperlinks><ThingDef>MuscleStimulator</ThingDef></descriptionHyperlinks>
+		<workerClass>Recipe_InstallImplant</workerClass>
+		<descriptionHyperlinks>
+			<ThingDef>MuscleStimulator</ThingDef>
+		</descriptionHyperlinks>
 		<jobString>Installing muscle stimulator.</jobString>
+		<workAmount>1500</workAmount>
 		<ingredients>
 			<li>
 				<filter>
@@ -874,11 +893,22 @@
 				</filter>
 				<count>1</count>
 			</li>
+			<li>
+				<filter>
+					<categories>
+						<li>Medicine</li>
+					</categories>
+				</filter>
+				<count>1</count>
+			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>MuscleStimulator</li>
 			</thingDefs>
+			<categories>
+				<li>Medicine</li>
+			</categories>
 		</fixedIngredientFilter>
 		<appliedOnFixedBodyParts>
 			<li>Leg</li> 

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_ProstheticsInstall.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_ProstheticsInstall.xml
@@ -81,6 +81,14 @@
 	<InstallJoywire.description>Установить чип счастья.</InstallJoywire.description>
 	<InstallJoywire.jobString>Устанавливает чип счастья</InstallJoywire.jobString>
 
+	<InstallMuscleStimulatorArms.label>установить стимулятор мышц</InstallMuscleStimulatorArms.label>
+	<InstallMuscleStimulatorArms.description>Установить стимулятор мышц в плечо.</InstallMuscleStimulatorArms.description>
+	<InstallMuscleStimulatorArms.jobString>Устанавливает стимулятор мышц</InstallMuscleStimulatorArms.jobString>
+
+	<InstallMuscleStimulatorLegs.label>установить стимулятор мышц</InstallMuscleStimulatorLegs.label>
+	<InstallMuscleStimulatorLegs.description>Установить стимулятор мышц в бедро.</InstallMuscleStimulatorLegs.description>
+	<InstallMuscleStimulatorLegs.jobString>Устанавливает стимулятор мышц</InstallMuscleStimulatorLegs.jobString>
+
 	<InstallPainstopper.label>установить чип обезболивания</InstallPainstopper.label>
 	<InstallPainstopper.description>Установить чип обезболивания.</InstallPainstopper.description>
 	<InstallPainstopper.jobString>Устанавливает чип обезболивания</InstallPainstopper.jobString>


### PR DESCRIPTION
Patch enable existing surgery recipes for muscle stimulator.
Now you can craft, sell or buy and INSTALL them.