### PR TITLE
Fix ratkins head position

### DIFF
--- a/Mods/RatkinRaceHSKFaces/Defs/BodyAnimDef_Ratkin_Thin.xml
+++ b/Mods/RatkinRaceHSKFaces/Defs/BodyAnimDef_Ratkin_Thin.xml
@@ -29,6 +29,10 @@
         <z>0</z>
       </li>
     </hipOffsets>
+    <headOffset>
+        <x>0</x>
+        <y>-0.09</y>
+    </headOffset>
     <offCenterX>-0.001709405</offCenterX>
     <shoulderOffsets>
       <li>


### PR DESCRIPTION
Fix ratkins head position:
![image](https://user-images.githubusercontent.com/62516232/97179062-3413c980-17ba-11eb-9cfa-52d151b99144.png)
Исправил положение головы раткинов. Это было слабо заметно, но она немного отходила от их тела.