### PR TITLE
Moved ground-penetrating scanner research research prerequisites

### DIFF
--- a/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Tech.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Tech.xml
@@ -972,7 +972,7 @@
 				<!-- <defName>SK_MiningII</defName>-->
 				<defName>DeepDrilling</defName>
 				<label>Geology</label>
-				<description>Opens the construction of a mining, drilling rig and ground penetraing scanner.</description>
+				<description>Opens the construction of a mining & drilling rigs and ground penetraing scanner.</description>
 				<baseCost>850</baseCost>
 				<techLevel>Industrial</techLevel>
 				<tab>Main</tab>

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Tech.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Tech.xml
@@ -972,7 +972,7 @@
 				<!-- <defName>SK_MiningII</defName>-->
 				<defName>DeepDrilling</defName>
 				<label>Geology</label>
-				<description>Opens the construction of a mining and drilling rig.</description>
+				<description>Opens the construction of a mining, drilling rig and ground penetraing scanner.</description>
 				<baseCost>850</baseCost>
 				<techLevel>Industrial</techLevel>
 				<tab>Main</tab>
@@ -1058,7 +1058,7 @@
 					<!-- <defName>SK_MiningIII</defName>-->
 					<defName>GroundPenetratingScanner</defName>
 					<label>Geophysics</label>
-					<description>Unlocks the construction of an advanced mining station and ground penetraing scanner.</description>
+					<description>Unlocks the construction of an advanced mining station.</description>
 					<baseCost>1200</baseCost>
 					<techLevel>Industrial</techLevel>
 					<tab>Main</tab>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_SK.xml
@@ -1949,7 +1949,7 @@
 		</placeWorkers>
 		<defaultPlacingRot>South</defaultPlacingRot>
 		<researchPrerequisites>
-			<li>GroundPenetratingScanner</li>
+			<li>DeepDrilling</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
 	</ThingDef>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ResearchProjectDef/ResearchProjects_Tech.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ResearchProjectDef/ResearchProjects_Tech.xml
@@ -124,10 +124,10 @@
 		<SK_Quarry.description>Новые исследования в горнодобывающей области позволят построить карьер - огромную яму для добычи скрытых ресурсов.</SK_Quarry.description> 
 
 			<DeepDrilling.label>Геология</DeepDrilling.label> 
-			<DeepDrilling.description>Открывает постройку добывающей и буровой установки.</DeepDrilling.description> 
+			<DeepDrilling.description>Открывает постройку добывающей и буровой установки, а также глубинного сканера.</DeepDrilling.description> 
 
 				<GroundPenetratingScanner.label>Геофизика</GroundPenetratingScanner.label> 
-				<GroundPenetratingScanner.description>Открывает постройку продвинутой добывающей установки и глубинного сканера.</GroundPenetratingScanner.description>
+				<GroundPenetratingScanner.description>Открывает постройку продвинутой добывающей установки.</GroundPenetratingScanner.description>
 	
 				<OilDrilling.label>Нефтедобыча</OilDrilling.label> 
 				<OilDrilling.description>Открывает возможность добычи нефти и связанные с нефтедобычей строения.</OilDrilling.description>


### PR DESCRIPTION
Moved ground-penetrating scanner research research prerequisites (Geophysics -> Geology):
- before:

![image](https://user-images.githubusercontent.com/62516232/97604459-55312000-1a2f-11eb-84f2-c513ed7158ec.png)

- after:

![image](https://user-images.githubusercontent.com/62516232/97604500-624e0f00-1a2f-11eb-9b22-ade76c0b97b0.png)

Cuz drill and mine extractor can't work without scanner.

Сдвинул требования исследований для глубинного сканера (Геофизика -> Геология).
См. скриншоты выше.
Связано с тем, что бур и добывающая установка без него работать не могут (т.к. залежи генерируются этим сканером).