### PR TITLE
Apparel's component type cost fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
@@ -104,7 +104,7 @@
 		</stuffCategories>
 		<costStuffCount>16</costStuffCount>
 		<costList>
-			<ComponentAdvanced>3</ComponentAdvanced>
+			<ComponentIndustrial>3</ComponentIndustrial>
 			<Compaste>12</Compaste>
 		</costList>
 		<statBases>
@@ -256,7 +256,7 @@
 		</stuffCategories>
 		<costStuffCount>20</costStuffCount>
 		<costList>
-			<ComponentAdvanced>6</ComponentAdvanced>
+			<ComponentIndustrial>6</ComponentIndustrial>
 			<Compaste>15</Compaste>
 		</costList>
 		<statBases>
@@ -338,7 +338,7 @@
 		</stuffCategories>
 		<costStuffCount>25</costStuffCount>
 		<costList>
-			<ComponentAdvanced>5</ComponentAdvanced>
+			<ComponentIndustrial>5</ComponentIndustrial>
 			<Compaste>18</Compaste>
 			<Hexcell>1</Hexcell>
 		</costList>
@@ -591,7 +591,7 @@
 		</stuffCategories>
 		<costStuffCount>35</costStuffCount>
 		<costList>
-			<ComponentAdvanced>2</ComponentAdvanced>
+			<ComponentIndustrial>2</ComponentIndustrial>
 			<Compaste>15</Compaste>
 		</costList>
 		<statBases>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
@@ -340,7 +340,6 @@
 		<costList>
 			<ComponentIndustrial>5</ComponentIndustrial>
 			<Compaste>18</Compaste>
-			<Hexcell>1</Hexcell>
 		</costList>
 		<statBases>
 			<WorkToMake>9000</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Industrial.xml
@@ -14,7 +14,7 @@
 		</stuffCategories>
 		<costStuffCount>95</costStuffCount>
 		<costList>
-			<ComponentAdvanced>7</ComponentAdvanced>
+			<ComponentIndustrial>7</ComponentIndustrial>
 			<SyntheticFibers>10</SyntheticFibers>
 		</costList>
 		<statBases>
@@ -114,7 +114,7 @@
 		</stuffCategories>
 		<costStuffCount>65</costStuffCount>
 		<costList>
-			<ComponentAdvanced>7</ComponentAdvanced>
+			<ComponentIndustrial>7</ComponentIndustrial>
 			<Compaste>18</Compaste>
 			<SyntheticFibers>8</SyntheticFibers>
 			<MedicineUltratech>5</MedicineUltratech>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Medieval.xml
@@ -93,7 +93,7 @@
 		</stuffCategories>
 		<costStuffCount>95</costStuffCount>
 		<costList>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentMedieval>3</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>7000</WorkToMake>
@@ -176,7 +176,7 @@
 		</stuffCategories>
 		<costStuffCount>95</costStuffCount>
 		<costList>
-			<ComponentIndustrial>6</ComponentIndustrial>
+			<ComponentMedieval>6</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>8000</WorkToMake>
@@ -341,7 +341,7 @@
 		</stuffCategories>
 		<costStuffCount>95</costStuffCount>
 		<costList>
-			<ComponentIndustrial>4</ComponentIndustrial>
+			<ComponentMedieval>4</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>7000</WorkToMake>
@@ -552,7 +552,7 @@
 		</stuffCategories>
 		<costStuffCount>95</costStuffCount>
 		<costList>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentMedieval>3</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>6500</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
@@ -14,7 +14,7 @@
 		</stuffCategories>
 		<costStuffCount>15</costStuffCount>
 		<costList>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentMedieval>3</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>2000</WorkToMake>
@@ -213,7 +213,7 @@
 		</stuffCategories>
 		<costStuffCount>20</costStuffCount>
 		<costList>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentMedieval>3</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>4000</WorkToMake>
@@ -275,7 +275,7 @@
 		</stuffCategories>
 		<costStuffCount>25</costStuffCount>
 		<costList>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentMedieval>3</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>2500</WorkToMake>
@@ -346,7 +346,7 @@
 		</stuffCategories>
 		<costStuffCount>20</costStuffCount>
 		<costList>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentMedieval>3</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>2500</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Feral.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Feral.xml
@@ -15,7 +15,7 @@
 			<li>Leathery</li>
 		</stuffCategories>
 		<costList>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentMedieval>5</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>5000</WorkToMake>
@@ -90,7 +90,7 @@
 			<li>Leathery</li>
 		</stuffCategories>
 		<costList>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentMedieval>5</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>5000</WorkToMake>
@@ -164,7 +164,7 @@
 			<li>Leathery</li>
 		</stuffCategories>
 		<costList>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentMedieval>5</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>5000</WorkToMake>
@@ -366,7 +366,7 @@
 		</stuffCategories>
 		<costStuffCount>55</costStuffCount>
 		<costList>
-			<ComponentIndustrial>6</ComponentIndustrial>
+			<ComponentMedieval>6</ComponentMedieval>
 		</costList>
 		<graphicData>
 			<texPath>Things/Apparel/Plate_Crude/Plate_Crude</texPath>
@@ -436,7 +436,7 @@
 		</stuffCategories>
 		<costStuffCount>65</costStuffCount>
 		<costList>
-			<ComponentIndustrial>8</ComponentIndustrial>
+			<ComponentMedieval>8</ComponentMedieval>
 		</costList>
 		<graphicData>
 			<texPath>Things/Apparel/Plate_Improved/Plate_Improved</texPath>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Medieval.xml
@@ -15,7 +15,7 @@
 		</stuffCategories>
 		<costStuffCount>65</costStuffCount>
 		<costList>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentMedieval>5</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>9000</WorkToMake>
@@ -359,7 +359,7 @@
 		</stuffCategories>
 		<costStuffCount>80</costStuffCount>
 		<costList>
-			<ComponentIndustrial>6</ComponentIndustrial>
+			<ComponentMedieval>6</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>9000</WorkToMake>
@@ -444,7 +444,7 @@
 		</stuffCategories>
 		<costStuffCount>80</costStuffCount>
 		<costList>
-			<ComponentIndustrial>10</ComponentIndustrial>
+			<ComponentMedieval>10</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>9500</WorkToMake>
@@ -530,7 +530,7 @@
 		</stuffCategories>
 		<costStuffCount>125</costStuffCount>
 		<costList>
-			<ComponentIndustrial>8</ComponentIndustrial>
+			<ComponentMedieval>8</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>10000</WorkToMake>
@@ -616,7 +616,7 @@
 		</stuffCategories>
 		<costStuffCount>115</costStuffCount>
 		<costList>
-			<ComponentIndustrial>11</ComponentIndustrial>
+			<ComponentMedieval>11</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>11000</WorkToMake>
@@ -706,7 +706,7 @@
 		</stuffCategories>
 		<costStuffCount>100</costStuffCount>
 		<costList>
-			<ComponentIndustrial>7</ComponentIndustrial>
+			<ComponentMedieval>7</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>9500</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Gloves.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Gloves.xml
@@ -85,7 +85,7 @@
 		</stuffCategories>
 		<costStuffCount>18</costStuffCount>
 		<costList>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<ComponentMedieval>2</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>2500</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Medieval.xml
@@ -88,7 +88,7 @@
 		</stuffCategories>
 		<costStuffCount>35</costStuffCount>
 		<costList>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentMedieval>3</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>6000</WorkToMake>
@@ -159,7 +159,7 @@
 		</stuffCategories>
 		<costStuffCount>25</costStuffCount>
 		<costList>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<ComponentMedieval>2</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>6500</WorkToMake>
@@ -227,7 +227,7 @@
 		</stuffCategories>
 		<costStuffCount>25</costStuffCount>
 		<costList>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<ComponentMedieval>2</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>5000</WorkToMake>
@@ -294,7 +294,7 @@
 		</stuffCategories>
 		<costStuffCount>40</costStuffCount>
 		<costList>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentMedieval>5</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>5000</WorkToMake>
@@ -433,7 +433,7 @@
 		</stuffCategories>
 		<costStuffCount>35</costStuffCount>
 		<costList>
-			<ComponentIndustrial>4</ComponentIndustrial>
+			<ComponentMedieval>4</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>6500</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Medieval.xml
@@ -15,7 +15,7 @@
 		</stuffCategories>
 		<costStuffCount>40</costStuffCount>
 		<costList>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentMedieval>5</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>4000</WorkToMake>
@@ -91,7 +91,7 @@
 		</stuffCategories>
 		<costStuffCount>35</costStuffCount>
 		<costList>
-			<ComponentIndustrial>4</ComponentIndustrial>
+			<ComponentMedieval>4</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>4000</WorkToMake>
@@ -165,7 +165,7 @@
 		</stuffCategories>
 		<costStuffCount>35</costStuffCount>
 		<costList>
-			<ComponentIndustrial>4</ComponentIndustrial>
+			<ComponentMedieval>4</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>4000</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Outlander.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Outlander.xml
@@ -395,7 +395,7 @@
 		</stuffCategories>
 		<costStuffCount>35</costStuffCount>
 		<costList>
-			<ComponentMedieval>2</ComponentMedieval>
+			<ComponentIndustrial>2</ComponentIndustrial>
 			<Compaste>10</Compaste>
 		</costList>
 		<statBases>
@@ -685,7 +685,7 @@
 		</stuffCategories>
 		<costStuffCount>45</costStuffCount>
 		<costList>
-			<ComponentMedieval>5</ComponentMedieval>
+			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<statBases>
 			<WorkToMake>4500</WorkToMake>
@@ -760,7 +760,7 @@
 		</stuffCategories>
 		<costStuffCount>40</costStuffCount>
 		<costList>
-			<ComponentMedieval>5</ComponentMedieval>
+			<ComponentIndustrial>5</ComponentIndustrial>
 		</costList>
 		<statBases>
 			<WorkToMake>4500</WorkToMake>
@@ -1059,7 +1059,7 @@
 		</stuffCategories>
 		<costStuffCount>35</costStuffCount>
 		<costList>
-			<ComponentMedieval>3</ComponentMedieval>
+			<ComponentIndustrial>3</ComponentIndustrial>
 		</costList>
 		<statBases>
 			<WorkToMake>3500</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
@@ -79,7 +79,7 @@
 		</stuffCategories>
 		<costStuffCount>40</costStuffCount>
 		<costList>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentMedieval>3</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>4500</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Mask.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Mask.xml
@@ -83,7 +83,7 @@
 		<generateCommonality>1</generateCommonality>
 		<costList>
 			<Cloth>25</Cloth>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<ComponentMedieval>2</ComponentMedieval>
 			<MedicineHerbal>1</MedicineHerbal>
 		</costList>
 		<apparel>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Medieval.xml
@@ -14,7 +14,7 @@
 		</stuffCategories>
 		<costStuffCount>95</costStuffCount>
 		<costList>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<ComponentMedieval>2</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>4000</WorkToMake>
@@ -81,7 +81,7 @@
 		</stuffCategories>
 		<costStuffCount>95</costStuffCount>
 		<costList>
-			<ComponentIndustrial>6</ComponentIndustrial>
+			<ComponentMedieval>6</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>5500</WorkToMake>
@@ -561,7 +561,7 @@
 		</stuffCategories>
 		<costStuffCount>110</costStuffCount>
 		<costList>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<ComponentMedieval>2</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>5000</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_SlaveOutfit.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_SlaveOutfit.xml
@@ -280,7 +280,7 @@
 		</stuffCategories>
 		<costStuffCount>70</costStuffCount>
 		<costList>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<ComponentMedieval>2</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>7500</WorkToMake>
@@ -352,7 +352,7 @@
 		</stuffCategories>
 		<costStuffCount>75</costStuffCount>
 		<costList>
-			<ComponentIndustrial>3</ComponentIndustrial>
+			<ComponentMedieval>3</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>8500</WorkToMake>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Special.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Special.xml
@@ -78,7 +78,7 @@
 		<costStuffCount>25</costStuffCount>
 		<costList>
 			<LeadBar>5</LeadBar>
-			<ComponentAdvanced>5</ComponentAdvanced>
+			<ComponentIndustrial>5</ComponentIndustrial>
 			<Rubber>15</Rubber>
 			<Paraffins>5</Paraffins>
 		</costList>
@@ -156,7 +156,7 @@
 		<costStuffCount>40</costStuffCount>
 		<costList>
 			<LeadBar>15</LeadBar>
-			<ComponentAdvanced>8</ComponentAdvanced>
+			<ComponentIndustrial>8</ComponentIndustrial>
 			<Rubber>40</Rubber>
 			<Paraffins>5</Paraffins>
 		</costList>
@@ -234,7 +234,7 @@
 		</stuffCategories>
 		<costStuffCount>60</costStuffCount>
 		<costList>
-			<ComponentAdvanced>8</ComponentAdvanced>
+			<ComponentIndustrial>8</ComponentIndustrial>
 			<Rubber>12</Rubber>
 		</costList>
 		<statBases>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
@@ -235,7 +235,7 @@
 		</stuffCategories>
 		<costStuffCount>75</costStuffCount>
 		<costList>
-			<ComponentIndustrial>2</ComponentIndustrial>
+			<ComponentMedieval>2</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>5000</WorkToMake>
@@ -390,7 +390,7 @@
 		</stuffCategories>
 		<costStuffCount>85</costStuffCount>
 		<costList>
-			<ComponentIndustrial>5</ComponentIndustrial>
+			<ComponentMedieval>5</ComponentMedieval>
 		</costList>
 		<statBases>
 			<WorkToMake>6000</WorkToMake>


### PR DESCRIPTION
1 some medieval & neolitic apparels now requires primitive components instead of (industrial) components;
2 some industrial apparels required advanced & medieval components instead of (industrial) components. Fixed;
3 remove hexcell requirements from marine storm mask (it's not spacer armor).

1 некоторая одежда средневековья и неолита теперь требует примитивные компоненты вместо индустриальных компонентов;
2 часть индустриальной одежды требовала продвинутые и примитивные компоненты вместо индустриальных. Исправил;
3 убрал из крафта маски штурмовика модуль питания (это простая индустриальная маска, а не хай-тек броня).