### PR TITLE
Disables screen shake while mining (part 2)

### DIFF
--- a/Mods/Core_SK/Patches/Minerals_Patch.xml
+++ b/Mods/Core_SK/Patches/Minerals_Patch.xml
@@ -11,4 +11,16 @@
         </value>
     </match>
   </Operation>
+
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Minerals</li>
+    </mods>
+    <match Class ="PatchOperationAdd">
+        <xpath>Defs/ThingDef[@Name="DynamicMineralBase"]/building</xpath>
+        <value>
+          <destroyShakeAmount>0</destroyShakeAmount>
+        </value>
+    </match>
+  </Operation>
 </Patch>


### PR DESCRIPTION
Disables screen shake for dynamic minerals (sulphur, salt, etc) when mined