### PR TITLE
Some quest rewards tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/AmmoBases.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/AmmoBases.xml
@@ -42,6 +42,9 @@
 		<cookOffSound>Shot_AssaultRifle</cookOffSound>
 		<cookOffTailSound>GunTail_Medium</cookOffTailSound>
 		<techLevel>Industrial</techLevel>
+		<thingSetMakerTags>
+			<li>HSKRewardAmmo</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="SmallAmmoBase" ParentName="AmmoBase" Abstract="True">

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons.xml
@@ -85,6 +85,9 @@
 		<smeltProducts>
 			<Plasteel>10</Plasteel>
 		</smeltProducts>
+		<thingSetMakerTags>
+			<li>RewardStandardMidFreq</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 

--- a/Mods/Core_SK/Patches/ThingSetMakerDefs/ThingSetMakers_RewardPatches.xml
+++ b/Mods/Core_SK/Patches/ThingSetMakerDefs/ThingSetMakers_RewardPatches.xml
@@ -1,0 +1,39 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationSequence">
+		<success>Normal</success>
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingSetMakerDef[defName = "Reward_ItemsStandard"]/root/options/li[2]/thingSetMaker/options/li[2]/thingSetMaker/fixedParams/filter/thingDefs</xpath>
+				<value>
+					<thingDefs>
+						<li>CupronickelAlloy</li>
+					</thingDefs>
+				</value>
+			</li>
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingSetMakerDef[defName = "Reward_ItemsStandard"]/root/options/li[1]/thingSetMaker/options</xpath>
+				<value>
+					<li>
+						<weight>1.5</weight>
+						<thingSetMaker Class="ThingSetMaker_MarketValue">
+							<fixedParams>
+								<allowNonStackableDuplicates>False</allowNonStackableDuplicates>
+								<filter>
+									<thingSetMakerTagsToAllow>
+										<li>HSKRewardAmmo</li>
+									</thingSetMakerTagsToAllow>
+								</filter>
+							</fixedParams>
+						</thingSetMaker>
+					</li>
+				</value>
+			</li>
+
+		</operations>
+	</Operation>
+
+</Patch>
+


### PR DESCRIPTION
1 replaced steel to melchior (cuz steel use plasteel def, but steel has very low cost. Melchior have high cost and not so strong properties (almost like steel but better a bit);
2 added non high-tech weapon to quest reward pull;
3 added ammo to quest reward pull.

1 заменил сталь на мельхиор в наградах за выполнение квестов (сталь использует def пластали, но при этом стоит намного меньше (пласталь в ваниле стоит 9, а сталь - 2). Мельхиор дороже (8) и при этом не сильно лучше стали. Должно избавить от 15к+ стали в наградах);
2 добавлено невысокотехнологичное оружие в награды квестов;
3 добавлены патроны в награды квестов.