### PR TITLE
Corrected costs, rewards and threat points of Quests pt.1 - Building Monument Quests & some rare leather commonality fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Stuff_Leather.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Stuff_Leather.xml
@@ -784,7 +784,7 @@
 		</statBases>
 		<stuffProps>
 			<color>(223,203,231)</color>
-			<commonality>0.0025</commonality>
+			<commonality>0.0075</commonality>
 			<statFactors>
 				<MaxHitPoints>2.0</MaxHitPoints>
 				<Beauty>6</Beauty>
@@ -821,7 +821,7 @@
 		</statBases>
 		<stuffProps>
 			<color>(179,54,20)</color>
-			<commonality>0.0025</commonality>
+			<commonality>0.0075</commonality>
 			<statFactors>
 				<MaxHitPoints>2.0</MaxHitPoints>
 				<Flammability>0</Flammability>
@@ -863,7 +863,7 @@
 		</statBases>
 		<stuffProps>
 			<color>(89,123,6)</color>
-			<commonality>0.0025</commonality>
+			<commonality>0.0075</commonality>
 			<statFactors>
 				<MaxHitPoints>2.0</MaxHitPoints>
 				<Beauty>4</Beauty>
@@ -900,7 +900,7 @@
 		</statBases>
 		<stuffProps>
 			<color>(82,109,99)</color>
-			<commonality>0.0025</commonality>
+			<commonality>0.0075</commonality>
 			<statFactors>
 				<MaxHitPoints>2.0</MaxHitPoints>
 				<Beauty>3</Beauty>
@@ -937,7 +937,7 @@
 		</statBases>
 		<stuffProps>
 			<color>(61,68,76)</color>
-			<commonality>0.0025</commonality>
+			<commonality>0.0075</commonality>
 			<statFactors>
 				<MaxHitPoints>2.0</MaxHitPoints>
 				<Beauty>5</Beauty>

--- a/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
+++ b/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
@@ -1,0 +1,29 @@
+﻿<Patch>
+
+	<!-- Monument Quests -->
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/QuestScriptDef[defName = "BuildMonumentWorker"]/root/nodes/li[@Class= "QuestNode_GetMonumentSketch"]/pointsPerArea</xpath>
+				<value>
+					<pointsPerArea>15.0</pointsPerArea>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/QuestScriptDef[defName = "BuildMonumentWorker"]/root/nodes/li[12]/node/nodes/li[@Class= "QuestNode_Signal"]/node/nodes/li[@Class= "QuestNode_SetAndRestore"]/value</xpath>
+				<value>
+					<value>$($pointsOriginal * 0.7)</value>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/QuestScriptDef[defName = "Decree_BuildMonument"]/root/nodes/li[@Class= "QuestNode_GetMonumentSketch"]/pointsPerArea</xpath>
+				<value>
+					<pointsPerArea>20.8</pointsPerArea>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+
+</Patch>

--- a/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
+++ b/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
@@ -7,19 +7,19 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/QuestScriptDef[defName = "BuildMonumentWorker"]/root/nodes/li[@Class= "QuestNode_GetMonumentSketch"]/pointsPerArea</xpath>
 				<value>
-					<pointsPerArea>15.0</pointsPerArea> <!-- was 6.0 -->
+					<pointsPerArea>15.0</pointsPerArea> <!-- vanilla value is 6.0 -->
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/QuestScriptDef[defName = "BuildMonumentWorker"]/root/nodes/li[12]/node/nodes/li[@Class= "QuestNode_Signal"]/node/nodes/li[@Class= "QuestNode_SetAndRestore"]/value</xpath>
 				<value>
-					<value>$($pointsOriginal * 0.7)</value> <!-- was 1.75 -->
+					<value>$($pointsOriginal * 0.7)</value> <!-- vanilla value is 1.75 -->
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/QuestScriptDef[defName = "Decree_BuildMonument"]/root/nodes/li[@Class= "QuestNode_GetMonumentSketch"]/pointsPerArea</xpath>
 				<value>
-					<pointsPerArea>20.8</pointsPerArea> <!-- was 8.3 -->
+					<pointsPerArea>20.8</pointsPerArea> <!-- vanilla value is 8.3 -->
 				</value>
 			</li>
 		</operations>

--- a/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
+++ b/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
@@ -7,19 +7,19 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/QuestScriptDef[defName = "BuildMonumentWorker"]/root/nodes/li[@Class= "QuestNode_GetMonumentSketch"]/pointsPerArea</xpath>
 				<value>
-					<pointsPerArea>15.0</pointsPerArea>
+					<pointsPerArea>15.0</pointsPerArea> <!-- was 6.0 -->
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/QuestScriptDef[defName = "BuildMonumentWorker"]/root/nodes/li[12]/node/nodes/li[@Class= "QuestNode_Signal"]/node/nodes/li[@Class= "QuestNode_SetAndRestore"]/value</xpath>
 				<value>
-					<value>$($pointsOriginal * 0.7)</value>
+					<value>$($pointsOriginal * 0.7)</value> <!-- was 1.75 -->
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/QuestScriptDef[defName = "Decree_BuildMonument"]/root/nodes/li[@Class= "QuestNode_GetMonumentSketch"]/pointsPerArea</xpath>
 				<value>
-					<pointsPerArea>20.8</pointsPerArea>
+					<pointsPerArea>20.8</pointsPerArea> <!-- was 8.3 -->
 				</value>
 			</li>
 		</operations>


### PR DESCRIPTION
1 Corrected costs, rewards and threat points of Building Monument Quests (~2.5 fold lesser) (very large monuments and very large rewards/threat. Fixed);
2 Lightly increased chance to spawn apparel from some rare leather (I have never seen dragon or thrumbo skin clothing).

1 Скорректировал размеры монумента, награды за выполнение задания и силу угроз (стало примерно в 2.5 раза меньше) (слишком большие постройки/награды/силы рейдов для текущей стоимости. Поправил);
2 Немного увеличил частоту появления одежды из редких шкур (драконьей, Трумбо и т.д. Не припомню, чтобы хоть раз видел одежду из них).