### PR TITLE
minor revision of hygiene categories and their translation

### DIFF
--- a/Mods/Dubs-Bad-Hygiene/Defs/DesignationSubCategoryDefs/SubCategories_dubs.xml
+++ b/Mods/Dubs-Bad-Hygiene/Defs/DesignationSubCategoryDefs/SubCategories_dubs.xml
@@ -82,23 +82,25 @@
 		<defNames>
 			<li>sewagePipeStuff</li>
 			<li>airPipe</li>
+			<li>plumbingValve</li>
 		</defNames>
 		<designationCategory>Hygiene</designationCategory>
 	</ArchitectSense.DesignationSubCategoryDef>	
 
 	<ArchitectSense.DesignationSubCategoryDef>
-		<defName>SubCategory_PumpHeads</defName>
-		<label>Pump wells</label>
-		<description>Wells that pumps suck water.</description>
+		<defName>SubCategory_WaterWells</defName>
+		<label>Water wells</label>
+		<description>Wells give access to groundwater.</description>
 		<defNames>
+			<li>PrimitiveWell</li>
 			<li>WaterWellInlet</li>
 			<li>DeepWaterWellInlet</li>
 		</defNames>
 		<designationCategory>Hygiene</designationCategory>
 	</ArchitectSense.DesignationSubCategoryDef>		
 	
-<!--	<ArchitectSense.DesignationSubCategoryDef>
-		<defName>SubCategory_Pumps</defName>
+	<ArchitectSense.DesignationSubCategoryDef>
+		<defName>SubCategory_HygienePumps</defName>
 		<label>Water Pumps</label>
 		<description>Pumps.</description>
 		<defNames>
@@ -107,7 +109,7 @@
 			<li>PumpingStation</li>			
 		</defNames>
 		<designationCategory>Hygiene</designationCategory>
-	</ArchitectSense.DesignationSubCategoryDef>	-->
+	</ArchitectSense.DesignationSubCategoryDef>	
 
 	<ArchitectSense.DesignationSubCategoryDef>
 		<defName>SubCategory_Sewage</defName>
@@ -147,11 +149,10 @@
 	</ArchitectSense.DesignationSubCategoryDef>	
 	
 	<ArchitectSense.DesignationSubCategoryDef>
-		<defName>SubCategory_Misc</defName>
+		<defName>SubCategory_HygieneMisc</defName>
 		<label>Misc</label>
 		<description>Buildings that dont fit other areas.</description>
 		<defNames>
-			<li>PrimitiveWell</li>
 			<li>WashingMachine</li>
 			<li>BurnPit</li>
 			<li>KitchenSink</li>

--- a/Mods/Dubs-Bad-Hygiene/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Dubs-Bad-Hygiene/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
@@ -1,0 +1,49 @@
+<?xml version="1.0" encoding="utf-8"?>
+<LanguageData>
+
+  <SubCategory_Sprinkler.label>Разбрызгиватели</SubCategory_Sprinkler.label>
+  <SubCategory_Sprinkler.description>Разбрызгиватели.</SubCategory_Sprinkler.description>
+
+  <SubCategory_Airconditon.label>Кондиционеры</SubCategory_Airconditon.label>
+  <SubCategory_Airconditon.description>Оборудование для охлаждения помещений и создания морозильных камер.</SubCategory_Airconditon.description>
+
+  <SubCategory_CeilingFan.label>Вентиляторы</SubCategory_CeilingFan.label>
+  <SubCategory_CeilingFan.description>Вентиляторы для охлаждения помещений.</SubCategory_CeilingFan.description>
+
+  <SubCategory_radiator.label>Радиаторы</SubCategory_radiator.label>
+  <SubCategory_radiator.description>Оборудование для нагрева помещений.</SubCategory_radiator.description>
+
+  <SubCategory_Watertanks.label>Резервуары</SubCategory_Watertanks.label>
+  <SubCategory_Watertanks.description>Резервуары для хранения воды.</SubCategory_Watertanks.description>
+
+  <SubCategory_Waterheaters.label>Нагреватели</SubCategory_Waterheaters.label>
+  <SubCategory_Waterheaters.description>Оборудование для нагрева воды.</SubCategory_Waterheaters.description>
+
+  <SubCategory_Pipes.label>Трубы</SubCategory_Pipes.label>
+  <SubCategory_Pipes.description>Изделия для распределения теплоносителя.</SubCategory_Pipes.description>
+
+  <SubCategory_WaterWells.label>Водяные скважины</SubCategory_WaterWells.label>
+  <SubCategory_WaterWells.description>Оборудование для доступа к подземным водам.</SubCategory_WaterWells.description>
+
+  <SubCategory_HygienePumps.label>Насосы</SubCategory_HygienePumps.label>
+  <SubCategory_HygienePumps.description>Оборудование для перекачки воды.</SubCategory_HygienePumps.description>
+
+  <SubCategory_Sewage.label>Канализация</SubCategory_Sewage.label>
+  <SubCategory_Sewage.description>Оборудование для очистки и удаления сточных вод.</SubCategory_Sewage.description>
+
+  <SubCategory_Pools.label>Бассейны</SubCategory_Pools.label>
+  <SubCategory_Pools.description>Бассейны и джакузи.</SubCategory_Pools.description>
+
+  <SubCategory_Toilets.label>Туалеты</SubCategory_Toilets.label>
+  <SubCategory_Toilets.description>Cанитарно-технические приспособления для избавления от отходов жизнедеятельности.</SubCategory_Toilets.description>
+
+  <SubCategory_HygieneMisc.label>Разное</SubCategory_HygieneMisc.label>
+  <SubCategory_HygieneMisc.description>Разное.</SubCategory_HygieneMisc.description>
+
+  <SubCategory_Tubs.label>Ванны</SubCategory_Tubs.label>
+  <SubCategory_Tubs.description>Приспособления для поддержания чистоты тела.</SubCategory_Tubs.description>
+
+  <SubCategory_Showers.label>Души</SubCategory_Showers.label>
+  <SubCategory_Showers.description>Приспособления для поддержания чистоты тела. Быстрее, чем прием ванны.</SubCategory_Showers.description>
+
+</LanguageData>

--- a/Mods/Dubs-Bad-Hygiene/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Dubs-Bad-Hygiene/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
@@ -20,7 +20,7 @@
   <SubCategory_Waterheaters.description>Оборудование для нагрева воды.</SubCategory_Waterheaters.description>
 
   <SubCategory_Pipes.label>Трубы</SubCategory_Pipes.label>
-  <SubCategory_Pipes.description>Изделия для распределения теплоносителя.</SubCategory_Pipes.description>
+  <SubCategory_Pipes.description>Изделия для распределения воды и соединения кондиционерных блоков.</SubCategory_Pipes.description>
 
   <SubCategory_WaterWells.label>Водяные скважины</SubCategory_WaterWells.label>
   <SubCategory_WaterWells.description>Оборудование для доступа к подземным водам.</SubCategory_WaterWells.description>


### PR DESCRIPTION
Renamed categories, conflicted with existing ones.

Переименованы категории, для устранения конфликта с уже существующими.
"Showers" перевел как "души". Выглядит странно, но кажется это допустимо.
https://ru.wiktionary.org/wiki/%D0%B4%D1%83%D1%88#%D0%B4%D1%83%D1%88_I