### PR TITLE
Fix bug when spacer pawn can't wear spacer items

### DIFF
--- a/Mods/ArcaneTechnology_SK/Patches/Pawn/Pawns.xml
+++ b/Mods/ArcaneTechnology_SK/Patches/Pawn/Pawns.xml
@@ -33,7 +33,7 @@
 			<xpath>Defs/PawnKindDef[@Name="AsariBase" or @Name="SK_BasePlayerPawnKindAsari" or @Name="AsariVillagerBase" or defName="AsariHunterPlayer"]</xpath>
 			<value>
 				<li Class="DArcaneTechnology.PawnKindExtension">
-					<pawnKindTechLevel>Spacer</pawnKindTechLevel>
+					<pawnKindTechLevel>Ultra</pawnKindTechLevel>
 				</li>				
 			</value>
 		</match>
@@ -47,7 +47,7 @@
 			<xpath>Defs/PawnKindDef[defName="RatkinSubject" or defName="RatkinEliteSoldier" or defName="RatkinDemonMan"]</xpath>
 			<value>
 				<li Class="DArcaneTechnology.PawnKindExtension">
-					<pawnKindTechLevel>Spacer</pawnKindTechLevel>
+					<pawnKindTechLevel>Ultra</pawnKindTechLevel>
 				</li>				
 			</value>
 		</match>


### PR DESCRIPTION
Fixed a bug when spacer pawn couldn't wear spacer items. On default Arcane Technology params if you want to wear spacer item you need (spacer+1) tech level (= Ultra).

![image](https://user-images.githubusercontent.com/62516232/98897999-77667b80-24ce-11eb-9e62-88de198af521.png)

Исправлен баг, когда высокотехнологические (далее просто spacer) пешки не могли носить spacer предметы. В настройках по умолчанию мода Arcane Technology пешка будет носить spacer предметы только в случае, если её технологический уровень будет на единицу выше (т.е. spacer+1=ultra).