### PR TITLE
Some mask hediff fixes

### DIFF
--- a/Mods/CombatExtended/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Mods/CombatExtended/Defs/HediffDefs/Hediffs_CE.xml
@@ -11,7 +11,7 @@
     <label>mask</label>
 	<description>Wearing a gas mask</description>
     <makesSickThought>false</makesSickThought>
-    <scenarioCanAdd>false</scenarioCanAdd>
+    <scenarioCanAdd>true</scenarioCanAdd>
     <stages>
       <li>
         <label>wearing</label>
@@ -42,7 +42,7 @@
     <label>light mask</label>
 	<description>Wearing a gas mask</description>
     <makesSickThought>false</makesSickThought>
-    <scenarioCanAdd>false</scenarioCanAdd>
+    <scenarioCanAdd>true</scenarioCanAdd>
     <stages>
       <li>
         <label>wearing</label>
@@ -73,7 +73,7 @@
     <label>spacer helmet</label>
 	<description>Wearing a spacer helmet</description>
     <makesSickThought>false</makesSickThought>
-    <scenarioCanAdd>false</scenarioCanAdd>
+    <scenarioCanAdd>true</scenarioCanAdd>
     <stages>
       <li>
         <label>wearing</label>


### PR DESCRIPTION
It should help to prevent spawn pawn with mask hediff without any mask or other hats with PC (PrepareCarefully) randomizer

Небольшая правка хедиффа от масок. В редакторе мода PC будет возможность его добавить/убрать. При использовании рандомайзера этого мода, хедифф маски сохраняется, даже если пешка уже без шлема, но убрать его все равно никак нельзя.