### PR TITLE
Fix Janissary royalty patch

### DIFF
--- a/Mods/Core_SK/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds.xml
+++ b/Mods/Core_SK/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds.xml
@@ -234,15 +234,20 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[@Name="JanissaryBase"]/weaponMoney</xpath>
 				<value>
-					<weaponMoney>2500~3000</weaponMoney>
+					<weaponMoney>2000~4000</weaponMoney>
 				</value>
 			</li>
-			<li Class="PatchOperationAdd">
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[@Name="JanissaryBase"]/weaponTags</xpath>
 				<value>
-					<li>SNIP4</li>
-					<li>ASN2</li>
-					<li>ASN3</li>
+					<weaponTags>
+						<li>SNIP4</li>
+						<li>SNIP3</li>
+						<li>ASN2</li>
+						<li>ASN3</li>
+						<li>RF4</li>
+						<li>SMG3</li>
+					</weaponTags>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">


### PR DESCRIPTION
1 correcting weapon money (ASN2 and ASN3 tags have weapon with cost higher than 3000);
2 base IndustrialGunAdvanced and SpacerGun weapon tag don't work with HSK (no weapons with this tag), but SniperRifle works -> Janissaries have only sniper rifles (in vanilla Janissaries also use other guns). Correcting tags.

1 скорректировал стоимость оружия у янычар (в состав тегов ASN2 и ASN3 входит только оружие со стоимостью более 3000);
2 базовые оружейные теги IndustrialGunAdvanced и SpacerGun не встречаются среди оружия ХСК, но тег SniperRifle встречается у всех снайперских винтовок из-за чего янычары приходят только со снайперками (в ванили у них большее разнообразие оружия). Корректировка тегов.