### PR TITLE
Food changes pt.2 1/2

### DIFF
--- a/Mods/Core_SK/Defs/HediffDefs/Meal/Hediffs_Meals.xml
+++ b/Mods/Core_SK/Defs/HediffDefs/Meal/Hediffs_Meals.xml
@@ -2,6 +2,60 @@
 <Defs>
 
 	<HediffDef>
+		<defName>HadCornbreadMuffin</defName>
+		<label>ate cornbread muffin</label>
+		<description>Ate sweet muffin. Sugary boost.</description>
+		<initialSeverity>1</initialSeverity>
+		<hediffClass>HediffWithComps</hediffClass>
+		<isBad>false</isBad>
+		<comps>
+			<li Class="HediffCompProperties_SeverityPerDay">
+				<severityPerDay>-0.7</severityPerDay>
+			</li>
+		</comps>
+		<stages>
+			<li>
+				<minSeverity>0</minSeverity>
+				<capMods>
+					<li>
+						<capacity>Moving</capacity>
+						<offset>0.1</offset>
+					</li>
+				</capMods>
+			</li>
+		</stages>
+	</HediffDef>
+
+	<HediffDef>
+		<defName>HadPizza</defName>
+		<label>ate pizza</label>
+		<description>Ate delicious pizza with so many ingredients, I feel my bones become stronger.</description>
+		<initialSeverity>1</initialSeverity>
+		<hediffClass>HediffWithComps</hediffClass>
+		<isBad>false</isBad>
+		<comps>
+			<li Class="HediffCompProperties_SeverityPerDay">
+				<severityPerDay>-0.7</severityPerDay>
+			</li>
+		</comps>
+		<stages>
+			<li>
+				<minSeverity>0</minSeverity>
+				<painFactor>0.9</painFactor>
+				<capMods>
+					<li>
+						<capacity>Consciousness</capacity>
+						<offset>0.15</offset>
+					</li>
+				</capMods>
+				<statOffsets>
+					<IncomingDamageFactor>-0.1</IncomingDamageFactor>				
+				</statOffsets>
+			</li>
+		</stages>
+	</HediffDef>
+
+	<HediffDef>
 		<defName>HadIceCream</defName>
 		<label>ate ice cream</label>
 		<description>It so delicious! And cold!</description>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Bakery.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Bakery.xml
@@ -4,63 +4,8 @@
 	<RecipeDef>
 		<defName>MakePizza</defName>
 		<label>bake pizza</label>
-		<description>Bakes a pizza from flour, cheese and tomatoes. Scrumptious! Produces 2.</description>
+		<description>Bakes a pizza from many ingredients. Scrumptious! Produces 3.</description>
 		<jobString>Baking pizza.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<workAmount>1000</workAmount>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Flour</li>
-					</thingDefs>
-				</filter>
-				<count>0.2</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Cheese</li>
-					</thingDefs>
-				</filter>
-				<count>0.2</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>RawTomatoes</li>
-					</thingDefs>
-				</filter>
-				<count>0.3</count>
-			</li>
-		</ingredients>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>Flour</li>
-				<li>Cheese</li>
-				<li>RawTomatoes</li>
-			</thingDefs>
-		</fixedIngredientFilter>
-		<products>
-			<Pizza>2</Pizza>
-		</products>
-		<skillRequirements>
-			<Cooking>7</Cooking>
-		</skillRequirements>
-		<workSkill>Cooking</workSkill>
-	</RecipeDef>
-
-
-	<RecipeDef>
-		<defName>MakePieBlueberry</defName>
-		<label>bake berry pies</label>
-		<description>Bake tasty berry pies. Produces 4.</description>
-		<jobString>Baking berry pies.</jobString>
 		<workSpeedStat>CookSpeed</workSpeedStat>
 		<effectWorking>Cook</effectWorking>
 		<workAmount>1500</workAmount>
@@ -75,31 +20,116 @@
 						<li>Flour</li>
 					</thingDefs>
 				</filter>
+				<count>0.1</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Meat_Muffalo</li>
+						<li>MetalCannedMeat_prime</li>
+					</thingDefs>
+				</filter>
+				<count>0.4</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Cheese</li>
+						<li>AgedCheese</li>
+					</thingDefs>
+				</filter>
 				<count>0.3</count>
 			</li>
 			<li>
 				<filter>
 					<thingDefs>
-						<li>RawBerries</li>
-						<li>Rawgrape</li>
+						<li>RawTomatoes</li>
 					</thingDefs>
 				</filter>
-				<count>0.5</count>
+				<count>0.4</count>
 			</li>
 			<li>
 				<filter>
 					<thingDefs>
-						<li>Sugar</li>
+						<li>RawShimmershroom</li>
+						<li>RawGlowbulb</li>
+						<li>Rawmushroom</li>
 					</thingDefs>
 				</filter>
-				<count>0.15</count>
+				<count>0.4</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>RawBerries</li>
-				<li>Rawgrape</li>
-				<li>Sugar</li>
+				<li>Flour</li>
+				<li>Cheese</li>
+				<li>AgedCheese</li>
+				<li>RawTomatoes</li>
+				<li>RawShimmershroom</li>
+				<li>RawGlowbulb</li>
+				<li>Rawmushroom</li>
+				<li>Meat_Muffalo</li>
+				<li>MetalCannedMeat_prime</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>Flour</li>
+				<li>Cheese</li>
+				<li>AgedCheese</li>
+				<li>RawTomatoes</li>
+				<li>RawShimmershroom</li>
+				<li>RawGlowbulb</li>
+				<li>Rawmushroom</li>
+				<li>Meat_Muffalo</li>
+				<li>MetalCannedMeat_prime</li>
+			</thingDefs>
+		</defaultIngredientFilter>
+		<products>
+			<Pizza>3</Pizza>
+		</products>
+		<skillRequirements>
+			<Cooking>15</Cooking>
+		</skillRequirements>
+		<workSkill>Cooking</workSkill>
+	</RecipeDef>
+
+
+	<RecipeDef>
+		<defName>MakePieBlueberry</defName>
+		<label>bake fruit pies</label>
+		<description>Bake tasty fruit pies. Produces 2.</description>
+		<jobString>Baking fruit pies.</jobString>
+		<workSpeedStat>CookSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<workAmount>1200</workAmount>
+		<soundWorking>Recipe_CookMeal</soundWorking>
+		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Flour</li>
+					</thingDefs>
+				</filter>
+				<count>0.08</count>
+			</li>
+			<li>
+				<filter>
+					<categories>
+						<li>FruitFoodRaw</li>
+					</categories>
+				</filter>
+				<count>0.4</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<categories>
+				<li>FruitFoodRaw</li>
+			</categories>
+			<thingDefs>
 				<li>Flour</li>
 			</thingDefs>
 			<specialFiltersToDisallow>
@@ -107,7 +137,7 @@
 			</specialFiltersToDisallow>
 		</fixedIngredientFilter>
 		<products>
-			<PieBlueberry>4</PieBlueberry>
+			<PieBlueberry>2</PieBlueberry>
 		</products>
 		<skillRequirements>
 			<Cooking>8</Cooking>
@@ -305,6 +335,9 @@
 		<products>
 			<Cornbread>2</Cornbread>
 		</products>
+		<skillRequirements>
+			<Cooking>2</Cooking>
+		</skillRequirements>
 		<workSkill>Cooking</workSkill>
 	</RecipeDef>
 
@@ -316,7 +349,7 @@
 		<workSpeedStat>CookSpeed</workSpeedStat>
 		<effectWorking>Cook</effectWorking>
 		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<workAmount>1500</workAmount>
+		<workAmount>1200</workAmount>
 		<soundWorking>Recipe_CookMeal</soundWorking>          
 		<ingredients>
 			<li>
@@ -335,11 +368,20 @@
 				</filter>
 				<count>6</count>
 			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Sugar</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
 		</ingredients>
 		<fixedIngredientFilter>
 			<thingDefs>
 				<li>Flour</li>
 				<li>Cornmeal</li>
+				<li>Sugar</li>
 			</thingDefs>
 			<specialFiltersToDisallow>
 				<li>AllowRotten</li>
@@ -348,6 +390,9 @@
 		<products>
 			<Cornbreadmuffin>3</Cornbreadmuffin>
 		</products>
+		<skillRequirements>
+			<Cooking>7</Cooking>
+		</skillRequirements>
 		<workSkill>Cooking</workSkill>
 	</RecipeDef>
 

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Bakery.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Bakery.xml
@@ -13,9 +13,9 @@
 			<DeteriorationRate>10</DeteriorationRate>
 			<MarketValue>15</MarketValue>
 			<WorkToMake>600</WorkToMake>
-			<Bulk>0.5</Bulk>
-			<Mass>0.4</Mass>
-			<Nutrition>0.35</Nutrition>
+			<Bulk>1</Bulk>
+			<Mass>1</Mass>
+			<Nutrition>0.7</Nutrition>
 		</statBases>
 		<ingestible>
 			<preferability>MealSimple</preferability>
@@ -33,7 +33,7 @@
 	<ThingDef ParentName="SK_MealBase">
 		<defName>Pizza</defName>
 		<label>pizza</label>
-		<description>Pizza in 30 minutes or less! \n\nFood Effects: Consciousness and Metabolism.</description>
+		<description>Masterfully made pizza with many different ingredients. \n\nLowers pain\nImproves consciousness\nReduces incoming damage</description>
 		<graphicData>
 			<texPath>Things/Item/Meal/Meal_Pizza</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -44,18 +44,18 @@
 			<WorkToMake>500</WorkToMake>
 			<Bulk>1.5</Bulk>
 			<Mass>1.2</Mass>
-			<Nutrition>1</Nutrition>
+			<Nutrition>0.9</Nutrition>
 		</statBases>
 		<ingestible>
 			<preferability>MealLavish</preferability>
-			<joy>0.1</joy>
+			<joy>0.2</joy>
 			<ingestEffect>EatVegetarian</ingestEffect>
 			<ingestSound>Meal_Eat</ingestSound>
 			<joyKind>Gluttonous</joyKind>
 			<outcomeDoers>
 				<li Class="IngestionOutcomeDoer_GiveHediff">
-					<hediffDef>HedPizza</hediffDef>
-					<severity>0.25</severity>
+					<hediffDef>HadPizza</hediffDef>
+					<severity>0.6</severity>
 				</li>
 			</outcomeDoers>
 		</ingestible>
@@ -136,8 +136,8 @@
 
 	<ThingDef ParentName="SweetMealBase">
 		<defName>PieBlueberry</defName>
-		<label>Berry pie</label>
-		<description>A delicious berry pie.</description>
+		<label>Fruit pie</label>
+		<description>A delicious pie with fruits or berries.</description>
 		<graphicData>
 			<texPath>Things/Item/Meal/Meal_PieBlueberry</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -148,7 +148,7 @@
 			<MaxHitPoints>50</MaxHitPoints>
 			<Flammability>1.0</Flammability>
 			<DeteriorationRate>10</DeteriorationRate>
-			<Nutrition>0.6</Nutrition>
+			<Nutrition>0.9</Nutrition>
 		</statBases>
 		<tickerType>Rare</tickerType>
 		<socialPropernessMatters>true</socialPropernessMatters>
@@ -160,8 +160,9 @@
 			</li>
 		</comps>
 		<ingestible>
+			<tasteThought>AtePie</tasteThought>
 			<preferability>MealFine</preferability>
-			<joy>0.4</joy>
+			<joy>0.2</joy>
 			<ingestEffect>EatVegetarian</ingestEffect>
 			<ingestSound>Meal_Eat</ingestSound>
 			<joyKind>Gluttonous</joyKind>
@@ -227,12 +228,6 @@
 			<preferability>MealSimple</preferability>
 			<ingestEffect>EatVegetarian</ingestEffect>
 			<ingestSound>Meal_Eat</ingestSound>
-			<outcomeDoers>
-				<li Class="IngestionOutcomeDoer_GiveHediff">
-					<hediffDef>HedSweetbun</hediffDef>
-					<severity>0.25</severity>
-				</li>
-			</outcomeDoers>
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
@@ -245,25 +240,26 @@
 	<ThingDef ParentName="SK_MealBase">
 		<defName>Cornbreadmuffin</defName>
 		<label>Cornbread Muffin</label>
-		<description>A very simple baked muffin made from corn meal.</description>
+		<description>A very simple baked muffin made from corn meal. \n\nImproves moving</description>
 		<graphicData>
 			<texPath>Things/Item/Meal/cornbreadmuffin</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>15</MarketValue>
+			<MarketValue>20</MarketValue>
 			<WorkToMake>500</WorkToMake>
 			<Nutrition>0.6</Nutrition>
 		</statBases>
 		<ingestible>
+			<tasteThought>AteFineMeal</tasteThought>
 			<preferability>MealSimple</preferability>
 			<ingestEffect>EatVegetarian</ingestEffect>
 			<ingestSound>Meal_Eat</ingestSound>
 			<outcomeDoers>
 				<li Class="IngestionOutcomeDoer_GiveHediff">
-					<hediffDef>HedSweetbun</hediffDef>
-					<severity>0.25</severity>
+					<hediffDef>HadCornbreadMuffin</hediffDef>
+					<severity>0.6</severity>
 				</li>
 			</outcomeDoers>
 		</ingestible>

--- a/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Cultivated_Manufacture.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Cultivated_Manufacture.xml
@@ -207,14 +207,14 @@
 	<ThingDef ParentName="SK_DeciduousPlantDef">
 		<defName>Plantwheat</defName>
 		<label>Wheat Grass</label>
-		<description>Wheat Grass is a cereal grain that produces Wheat. Wheat can be milled from the Butcher Table into Flour, which can be baked into Bread Leaves from the Electric Oven.</description>
+		<description>Wheat Grass is a cereal grain that produces Wheat. Wheat can be milled into Flour, which can be baked into Bread Leaves from the Oven.</description>
 		<graphicData>
 			<texPath>Things/Plant/PlantWheat_Harvest</texPath>
 			<graphicClass>Graphic_Random</graphicClass>
 		</graphicData>
 		<plant>
-			<wildClusterWeight>55</wildClusterWeight>
-			<wildClusterRadius>5</wildClusterRadius>
+			<wildClusterWeight>70</wildClusterWeight>
+			<wildClusterRadius>6</wildClusterRadius>
 			<maxMeshCount>4</maxMeshCount>
 			<sowMinSkill>4</sowMinSkill>
 			<sowResearchPrerequisites>
@@ -226,7 +226,7 @@
 			</sowTags>
 			<immatureGraphicPath>Things/Plant/PlantWheat</immatureGraphicPath>
 			<harvestedThingDef>Rawwheat</harvestedThingDef>
-			<harvestYield>12</harvestYield>
+			<harvestYield>18</harvestYield>
 			<topWindExposure>0.1</topWindExposure>
 			<growDays>5.2</growDays>
 			<fertilitySensitivity>1.4</fertilitySensitivity>

--- a/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Cultivated_Vegetables.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Cultivated_Vegetables.xml
@@ -94,7 +94,7 @@
 			<harvestedThingDef>RawRice</harvestedThingDef>
 			
 			<harvestTag>Standard</harvestTag>
-			<harvestYield>12</harvestYield>
+			<harvestYield>16</harvestYield>
 			<topWindExposure>0.1</topWindExposure>
 			<growDays>4.6</growDays>
 			<fertilitySensitivity>1</fertilitySensitivity>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_CookingSupplies.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_CookingSupplies.xml
@@ -79,7 +79,7 @@
 		</stuffProps>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>25</daysToRotStart>
+				<daysToRotStart>60</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>

--- a/Mods/Core_SK/Defs/ThoughtDefs/Thoughts_Memory_Special.xml
+++ b/Mods/Core_SK/Defs/ThoughtDefs/Thoughts_Memory_Special.xml
@@ -3,7 +3,7 @@
 
     <ThoughtDef>
         <defName>ObservedAurora</defName>
-        <durationDays>1</durationDays>
+        <durationDays>4</durationDays>
         <stackLimit>1</stackLimit>
         <stages>
             <li>

--- a/Mods/Core_SK/Defs/TraitDefs/Expanded Traits.xml
+++ b/Mods/Core_SK/Defs/TraitDefs/Expanded Traits.xml
@@ -226,7 +226,7 @@
 				<label>religious</label>
 				<description>{PAWN_nameDef} has found faith and peace of mind in {PAWN_possessive} religion and is more prepared for what may come than others.</description>
 				<statOffsets>
-					<MentalBreakThreshold>0.05</MentalBreakThreshold>
+					<MentalBreakThreshold>-0.05</MentalBreakThreshold>
 				</statOffsets>
 			</li>
 		</degreeDatas>
@@ -245,7 +245,7 @@
 				<label>fanatic</label>
 				<description>{PAWN_nameDef} has found religon and is prepared to do what ever is required to make others accept its truth.</description>
 				<statOffsets>
-					<MentalBreakThreshold>0.03</MentalBreakThreshold>
+					<MentalBreakThreshold>-0.03</MentalBreakThreshold>
 				</statOffsets>
 				<skillGains>
 					<li>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/HediffDef/Hediffs_Food.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/HediffDef/Hediffs_Food.xml
@@ -1,5 +1,11 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
+	<HadCornbreadMuffin.label>Съел печёную вкусняшку</HadCornbreadMuffin.label>
+	<HadCornbreadMuffin.description>Вкуснятина.</HadCornbreadMuffin.description>
+
+	<HadPizza.label>Съел пиццу</HadPizza.label>
+	<HadPizza.description>Съел пиццу с кучей различных ингредиентов. Кажется мои кости становятся крепче...</HadPizza.description>
+
 	<HadMisoSoup.label>Съел мисо суп</HadMisoSoup.label>
 	<HadMisoSoup.description>Съел чрезвычайно полезное блюдо. Я чувствую, как сила здорового питания течет по моим венам...</HadMisoSoup.description>
 

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
@@ -164,9 +164,9 @@
 	<MakeFruitDrink.description>Приготовить фруктовый напиток сделанный из свежевыжатых фруктов..</MakeFruitDrink.description>
 	<MakeFruitDrink.jobString>Готовит фруктовый напиток</MakeFruitDrink.jobString>
 
-	<MakePieBlueberry.label>Приготовить черничный пирог</MakePieBlueberry.label>
-	<MakePieBlueberry.description>Приготовить черничный пирог</MakePieBlueberry.description>
-	<MakePieBlueberry.jobString>Готовит черничный пирог</MakePieBlueberry.jobString>
+	<MakePieBlueberry.label>Приготовить фруктовый пирог</MakePieBlueberry.label>
+	<MakePieBlueberry.description>Приготовить фруктовый пирог</MakePieBlueberry.description>
+	<MakePieBlueberry.jobString>Готовит фруктовый пирог</MakePieBlueberry.jobString>
 
 	<MakeChocolate.label>Сделать шоколад</MakeChocolate.label>
 	<MakeChocolate.description>Сделать шоколад.</MakeChocolate.description>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Meals_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Meals_SK.xml
@@ -64,7 +64,7 @@
 	<GrilledCheese.description>Два ломтика хлеба с плавленым сыром, поджаренные на гриле.\n\nУлучшает метаболизм</GrilledCheese.description>
 
 	<Pizza.label>Пицца</Pizza.label>
-	<Pizza.description>Пицца за 30 минут или меньше!</Pizza.description>
+	<Pizza.description>Роскошная пицца из кучи разных ингредиентов.\n\nУлучшает сопротивляемость боли\nУлучшает движение\nУменьшает получаемый урон</Pizza.description>
 
 	<FruitYogurt.label>Фруктовый йогурт</FruitYogurt.label>
 	<FruitYogurt.description>Сладкое удовольствие из молока и фруктов.</FruitYogurt.description>
@@ -132,8 +132,8 @@
 	<cookie.label>Печенье</cookie.label>
 	<cookie.description>Свежие испеченные печенья!</cookie.description>
 
-	<PieBlueberry.label>Черничный пирог</PieBlueberry.label>
-	<PieBlueberry.description>Аппетитный ломтик ягодного пирога.</PieBlueberry.description>
+	<PieBlueberry.label>Фруктовый пирог</PieBlueberry.label>
+	<PieBlueberry.description>Аппетитный ломтик фруктового пирога.</PieBlueberry.description>
 
 	<SweetBun.label>Сладкие булочки</SweetBun.label>
 	<SweetBun.description>Нежный ролл покрытый сладкой глазурью.</SweetBun.description>
@@ -166,7 +166,7 @@
 	<Cornbread.description>Буханка хлеба, приготовленная из кукурузной муки.</Cornbread.description>
 
 	<Cornbreadmuffin.label>Кукурузная булочка</Cornbreadmuffin.label>
-	<Cornbreadmuffin.description>Хрустящая булочка из кукурузной муки.</Cornbreadmuffin.description>
+	<Cornbreadmuffin.description>Хрустящая булочка из кукурузной муки.\n\nУлучшает движение</Cornbreadmuffin.description>
 
 	<cider.label>Бутылка сидра</cider.label>
 	<cider.description>Сладкий алкогольный яблочный напиток.</cider.description>


### PR DESCRIPTION
Rebalanced half of the baked dishes, cornbread muffins are not as good now, pizza requires more ingredients but gives really nice buffs now (lowers pain, improves consiousness and **reduces incoming damage**). Baking is a lot more viable in general now.
Misc:
- increased aurora buff duration, now it actually worth waking up your pawns to see it
- for some reason religious trait increased mental break threshold despite description saying the opposite
------------------------------------------
Перебалансил половину выпечки, булочки из кукурузной муки не имеют таких больших баффов, пицца теперь требует больше ингредиентов, но даёт очень сочные баффы (снижает боль, улучшает сознание и уменьшает получаемый урон). Выпечка теперь в целом гораздо более жизнеспособный путь прокормить колонию. 
- увеличил длительность баффа от северного сияния/ авроры, теперь имеет смысл поднимать своих пешек среди ночи чтобы посмотрели и порадовались
- пофиксил трейт "религиозный", повышал порог нервного срыва, хотя описании говорит об увеличенной психической устойчивости 