### PR TITLE
Rimatomic apparels armor rating correction to CE

### DIFF
--- a/Mods/Rimatomics_SK/Defs/ThingDefs_Misc/RadSuits.xml
+++ b/Mods/Rimatomics_SK/Defs/ThingDefs_Misc/RadSuits.xml
@@ -119,9 +119,10 @@
 		<statBases>
 			<WorkToMake>15000</WorkToMake>
 			<Mass>1.24</Mass>
-			<ArmorRating_Sharp>0.09</ArmorRating_Sharp>
-			<ArmorRating_Blunt>0.09</ArmorRating_Blunt>
-			<ArmorRating_Heat>0.27</ArmorRating_Heat>
+			<ArmorRating_Sharp>1.2</ArmorRating_Sharp>
+			<ArmorRating_Blunt>2.4</ArmorRating_Blunt>
+			<ArmorRating_Heat>0.027</ArmorRating_Heat>
+			<StuffEffectMultiplierArmor>1.43</StuffEffectMultiplierArmor>
 			<Insulation_Cold>15</Insulation_Cold>
 			<EquipDelay>3.5</EquipDelay>
 		</statBases>
@@ -142,7 +143,10 @@
 			<MaxHitPoints>90</MaxHitPoints>
 			<WorkToMake>24000</WorkToMake>
 			<Mass>3.8</Mass>
-			<ArmorRating_Heat>0.23</ArmorRating_Heat>
+			<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
+			<ArmorRating_Blunt>3</ArmorRating_Blunt>
+			<ArmorRating_Heat>0.023</ArmorRating_Heat>
+			<StuffEffectMultiplierArmor>1.79</StuffEffectMultiplierArmor>
 			<Insulation_Cold>15</Insulation_Cold>
 			<EquipDelay>4.5</EquipDelay>
 		</statBases>
@@ -192,9 +196,11 @@
 			<Mass>1.6</Mass>
 			<Bulk>3</Bulk>
 			<EquipDelay>2.8</EquipDelay>
-			<ArmorRating_Heat>0.3</ArmorRating_Heat>
+			<ArmorRating_Sharp>2</ArmorRating_Sharp>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
+			<ArmorRating_Heat>0.03</ArmorRating_Heat>
 			<Insulation_Cold>8</Insulation_Cold>
-			<StuffEffectMultiplierArmor>0.43</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>5.73</StuffEffectMultiplierArmor>
 			<StuffEffectMultiplierInsulation_Cold>0.25</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>0.25</StuffEffectMultiplierInsulation_Heat>
 		</statBases>
@@ -246,10 +252,12 @@
 			<Mass>4</Mass>
 			<Bulk>3.5</Bulk>
 			<EquipDelay>22</EquipDelay>
-			<ArmorRating_Heat>0.23</ArmorRating_Heat>
+			<ArmorRating_Sharp>2.5</ArmorRating_Sharp>
+			<ArmorRating_Blunt>5</ArmorRating_Blunt>
+			<ArmorRating_Heat>0.023</ArmorRating_Heat>
 			<Insulation_Cold>25</Insulation_Cold>
 			<Insulation_Heat>6</Insulation_Heat>
-			<StuffEffectMultiplierArmor>0.58</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>7.73</StuffEffectMultiplierArmor>
 			<StuffEffectMultiplierInsulation_Cold>1</StuffEffectMultiplierInsulation_Cold>
 			<StuffEffectMultiplierInsulation_Heat>1</StuffEffectMultiplierInsulation_Heat>
 		</statBases>


### PR DESCRIPTION
Rimatomic apparels armor rating correction to CE.

Скорректировал показатели брони одежды из риматомикса под СЕ.