### PR TITLE
Fix ironman/low pain tolerance and tough traits conflict.

### DIFF
--- a/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
+++ b/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
@@ -327,7 +327,6 @@
 			<li>Wimp</li>
 			<li>Dodging</li>
 			<li>Hardened</li>
-			<li>Tough</li>
 			<li>Weak</li>
 			<li>Strong</li>
 			<li>Nimble</li>


### PR DESCRIPTION
Ironman/low pain tolerance have conflict with tough trait, but tough have not conflict. Fixed.

Поправил конфликт между чертами характера "Необычная стойкость"/"Непереносимость боли" и "Живучесть". У первых двух в списке конфликтных есть "Живучесть", а у "Живучести" в списке конфликтов нет первых.