### PR TITLE
Fix plantprocessing bench draw size. It was so big

### DIFF
--- a/Mods/SeedsPlease/Defs/ThingDefs/Buildings_Production.xml
+++ b/Mods/SeedsPlease/Defs/ThingDefs/Buildings_Production.xml
@@ -45,7 +45,7 @@
       <texPath>Things/Building/seedextractor</texPath>
       <graphicClass>Graphic_Multi</graphicClass>
       <shaderType>CutoutComplex</shaderType>
-      <drawSize>(3.4,1.3)</drawSize>
+      <drawSize>(3,1)</drawSize>
       <damageData>
         <cornerTL>Damage/Corner</cornerTL>
         <cornerTR>Damage/Corner</cornerTR>


### PR DESCRIPTION
Поправил отрисовку у стола агронома. Зачем-то был растянут и выглядел слишком крупно (и даже немного мыльно).