### PR TITLE
Decreased quarry natural priority. Now pawns will mine ore deposits first, not quarry mining

### DIFF
--- a/Mods/Core_SK/Defs/WorkTypeDefs/WorkTypes_SK.xml
+++ b/Mods/Core_SK/Defs/WorkTypeDefs/WorkTypes_SK.xml
@@ -8,7 +8,7 @@
 		<gerundLabel>mining</gerundLabel>
 		<description>Collecting resources, digging and drilling in a quarry.</description>
 		<verb>Mine</verb>
-		<naturalPriority>650</naturalPriority>
+		<naturalPriority>550</naturalPriority>
 		<requireCapableColonist>true</requireCapableColonist>
 		<relevantSkills>
 			<li>Mining</li>


### PR DESCRIPTION
Предлагаю уменьшить приоритет работы в карьере. Пешки в первую очередь будут копать обычные залежи ресурсов и только потом работать в карьере.