### PR TITLE
Fix bio refinery idle power consumption (didn't work)

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
@@ -1655,6 +1655,7 @@
 			<ElectronicComponents>5</ElectronicComponents>
 			<Mechanism>8</Mechanism>
 		</costList>
+		<tickerType>Normal</tickerType>
 		<comps>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>


### PR DESCRIPTION
Исправил перегонщик норбалов в топливо. Во время простоя потреблял столько же энергии, сколько и во время работы.