### PR TITLE
Some mechanoinds tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
@@ -448,8 +448,8 @@
 		<statBases>
 			<Mass>20</Mass>
 			<MoveSpeed>6.2</MoveSpeed>
-			<ArmorRating_Blunt>1</ArmorRating_Blunt>
-			<ArmorRating_Sharp>1</ArmorRating_Sharp>
+			<ArmorRating_Blunt>2.25</ArmorRating_Blunt>
+			<ArmorRating_Sharp>1.5</ArmorRating_Sharp>
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
 			<MeleeCritChance>0.05</MeleeCritChance>
 			<MeleeParryChance>0.15</MeleeParryChance>

--- a/Mods/Core_SK/Royalty/Patches/ThingDefs_Buildings/Patches2.xml
+++ b/Mods/Core_SK/Royalty/Patches/ThingDefs_Buildings/Patches2.xml
@@ -217,4 +217,34 @@
 		</operations>
 	</Operation>
 
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName = "MechDropBeacon"]/comps/li[@Class= "CompProperties_PawnSpawnOnWakeup"]</xpath>
+				<value>
+					<li Class="CompProperties_PawnSpawnOnWakeup">
+						<points>800~1300</points>
+						<dropInPods>True</dropInPods>
+						<pawnSpawnRadius>10~30</pawnSpawnRadius>
+						<spawnEffecter>MechDropBeaconActivated</spawnEffecter>
+						<activatedMessageKey>MessageMechanoidsReinforcementsDrop</activatedMessageKey>
+						<spawnablePawnKinds>
+							<li>Mech_Scyther</li>
+							<li>Mech_HGScyther</li>
+							<li>Mech_Lancer</li>
+							<li>Mech_SniperLancer</li>
+							<li>Mech_Centipede</li>
+							<li>Mech_CentipedeInferno</li>
+							<li>Mech_Pikeman</li>
+							<li>Mech_Crawler</li>
+						</spawnablePawnKinds>
+						<lordJob>LordJob_MechanoidsDefend</lordJob>
+						<shouldJoinParentLord>True</shouldJoinParentLord>
+					</li>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
1 Patched Mechanoid drop beacon (cluster). It didn't spawn mechanoids.
2 Crawler had lesser armor rating than simple clothes apparels. Light boost.

1 маяки кластера механоидов не вызывали подкрепление при срабатывании. Исправлено;
2 механические крабы имели слишком низкую броню (меньше, чем обычная одежда из текстиля). Немного увеличена.