### PR TITLE
Stop vanilla worktab faction column override by hospitality

### DIFF
--- a/Mods/Hospitality/Defs/MainTab/PawnColumnDefs/PawnColumns.xml
+++ b/Mods/Hospitality/Defs/MainTab/PawnColumnDefs/PawnColumns.xml
@@ -13,7 +13,7 @@
   </PawnColumnDef>
 
   <PawnColumnDef>
-    <defName>Faction</defName>
+    <defName>Faction_Hospitality</defName>
     <workerClass>Hospitality.MainTab.PawnColumnWorker_Faction</workerClass>
     <sortable>true</sortable>
     <label>faction</label>

--- a/Mods/Hospitality/Defs/MainTab/PawnTableDefs/PawnTables.xml
+++ b/Mods/Hospitality/Defs/MainTab/PawnTableDefs/PawnTables.xml
@@ -7,7 +7,7 @@
     <columns>
       <li>GuestRelationship</li>
       <li>LabelCustom</li>
-	  <li>Faction</li>
+	  <li>Faction_Hospitality</li>
       <li>GapTiny</li>
 	  <li>AccommodationArea</li>
 	  <li>ShoppingArea</li>


### PR DESCRIPTION
Hospitality column always shows player faction name. That useless. Vanilla shows temporary quest factions.