### PR TITLE
Some tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
@@ -384,7 +384,7 @@
 			<BiosyntheticMaterial>4</BiosyntheticMaterial>
 			<SyntheticFibers>10</SyntheticFibers>
 			<Carbon>8</Carbon>
-			<Hexcell>2</Hexcell>
+			<ComponentSpacer>2</ComponentSpacer>
 		</costList>
 		<statBases>
 			<WorkToMake>18000</WorkToMake>

--- a/Mods/Core_SK/Royalty/Patches/ResearchProjectDefs/ResearchProjectsPatches.xml
+++ b/Mods/Core_SK/Royalty/Patches/ResearchProjectDefs/ResearchProjectsPatches.xml
@@ -1,0 +1,34 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ResearchProjectDef[@Name="BaseBodyPartEmpire_TierA"]/techprintMarketValue</xpath>
+				<value>
+					<techprintMarketValue>2000</techprintMarketValue>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ResearchProjectDef[@Name="BaseBodyPartEmpire_TierB"]/techprintMarketValue</xpath>
+				<value>
+					<techprintMarketValue>4000</techprintMarketValue>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ResearchProjectDef[defName="CataphractArmor"]/techprintMarketValue</xpath>
+				<value>
+					<techprintMarketValue>6000</techprintMarketValue>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ResearchProjectDef[defName="JumpPack"]/techprintMarketValue</xpath>
+				<value>
+					<techprintMarketValue>4000</techprintMarketValue>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>

--- a/Mods/SurvivalToolsLite/Patches/ImplantsPatches.xml
+++ b/Mods/SurvivalToolsLite/Patches/ImplantsPatches.xml
@@ -1,0 +1,16 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/HediffDef[defName="DrillArm"]/stages/li/statOffsets</xpath>
+				<value>
+					<DiggingSpeed>1.6</DiggingSpeed>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
1 Replaced hexcell in cryptopod bodysuit reciple to spacer component.
2 Added survivle tools patch to drill arm.
3 Correcting royalty techprints market value.

1 заменен модуль питания на высокотехнологичный компонент у крипто комбинезона (что делал модуль питания в обычном комбинезоне? причем у других такого даже близко нет);
2 руке-буру добавлен патч для мода Survival tools lite;
3 скорректирована рыночная стоимость чертежей роялти (увеличена в 2 раза).
