### PR TITLE
Some grenade recipes tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Recipes_HandGrenades.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Recipes_HandGrenades.xml
@@ -27,7 +27,7 @@
       <li>
         <filter>
           <thingDefs>
-            <li>ComponentAdvanced</li>
+            <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
         <count>4</count>
@@ -41,7 +41,7 @@
       <thingDefs>
         <li>Powder</li>
         <li>FSX</li>
-        <li>ComponentAdvanced</li>
+        <li>ComponentIndustrial</li>
       </thingDefs>
     </fixedIngredientFilter>
     <products>
@@ -65,9 +65,9 @@
       </li>
       <li>
         <filter>
-          <thingDefs>
-            <li>Cloth</li>
-          </thingDefs>
+          <categories>
+            <li>BTextiles</li>
+          </categories>
         </filter>
         <count>30</count>
       </li>
@@ -82,6 +82,9 @@
       </li>
     </ingredients>
     <fixedIngredientFilter>
+      <categories>
+        <li>BTextiles</li>
+      </categories>
       <thingDefs>
         <li>Glass</li>
         <li>Napalm</li>
@@ -110,10 +113,18 @@
       <li>
         <filter>
           <thingDefs>
-            <li>ComponentAdvanced</li>
+            <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
-        <count>14</count>
+        <count>7</count>
+      </li>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>ElectronicComponents</li>
+          </thingDefs>
+        </filter>
+        <count>4</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
@@ -122,7 +133,8 @@
         <li>USLDBar</li>
       </categories>
       <thingDefs>
-        <li>ComponentAdvanced</li>
+        <li>ComponentIndustrial</li>
+		<li>ElectronicComponents</li>
       </thingDefs>
     </fixedIngredientFilter>
     <products>
@@ -155,7 +167,7 @@
       <li>
         <filter>
           <thingDefs>
-            <li>ComponentAdvanced</li>
+            <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
         <count>4</count>
@@ -168,7 +180,7 @@
       </categories>
       <thingDefs>
         <li>Powder</li>
-        <li>ComponentAdvanced</li>
+        <li>ComponentIndustrial</li>
       </thingDefs>
     </fixedIngredientFilter>
     <products>
@@ -190,10 +202,10 @@
       <li>
         <filter>
           <thingDefs>
-            <li>WoodLog</li>
+            <li>ComponentMedieval</li>
           </thingDefs>
         </filter>
-        <count>20</count>
+        <count>15</count>
       </li>
       <li>
         <filter>
@@ -205,18 +217,20 @@
       </li>
       <li>
         <filter>
-          <thingDefs>
-            <li>Cloth</li>
-          </thingDefs>
+          <categories>
+            <li>BTextiles</li>
+          </categories>
         </filter>
         <count>30</count>
       </li>
     </ingredients>
     <fixedIngredientFilter>
+      <categories>
+        <li>BTextiles</li>
+      </categories>
       <thingDefs>
-        <li>WoodLog</li>
+        <li>ComponentMedieval</li>
         <li>FSX</li>
-        <li>Cloth</li>
       </thingDefs>
     </fixedIngredientFilter>
     <products>
@@ -249,7 +263,7 @@
       <li>
         <filter>
           <thingDefs>
-            <li>ComponentAdvanced</li>
+            <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
         <count>10</count>
@@ -262,7 +276,7 @@
         <li>Chemical</li>
       </categories>
       <thingDefs>
-        <li>ComponentAdvanced</li>
+        <li>ComponentIndustrial</li>
       </thingDefs>
     </fixedIngredientFilter>
     <products>
@@ -304,7 +318,7 @@
       <li>
         <filter>
           <thingDefs>
-            <li>ComponentAdvanced</li>
+            <li>ComponentIndustrial</li>
           </thingDefs>
         </filter>
         <count>4</count>
@@ -319,7 +333,7 @@
       <thingDefs>
         <li>Powder</li>
         <li>FSX</li>
-        <li>ComponentAdvanced</li>
+        <li>ComponentIndustrial</li>
       </thingDefs>
     </fixedIngredientFilter>
     <products>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
@@ -154,7 +154,9 @@
 			</li>
 		</comps>
 		<smeltProducts>
-			<Weapon_Parts>1</Weapon_Parts>
+			<Plasteel>4</Plasteel>
+			<Powder>2</Powder>
+			<ComponentIndustrial>1</ComponentIndustrial>
 		</smeltProducts>
 	</ThingDef>
 
@@ -251,7 +253,9 @@
 			</li>
 		</comps>
 		<smeltProducts>
-			<ComponentIndustrial>1</ComponentIndustrial>
+			<Bronze>3</Bronze>
+			<ComponentMedieval>2</ComponentMedieval>
+			<FSX>1</FSX>
 		</smeltProducts>
 	</ThingDef>
 	<!-- MOLOTOV -->
@@ -336,8 +340,9 @@
 			</li>
 		</comps>
 		<smeltProducts>
-			<Glass>1</Glass>
-			<Chemfuel>1</Chemfuel>
+			<Glass>3</Glass>
+			<Cloth>3</Cloth>
+			<Napalm>1</Napalm>
 		</smeltProducts>
 	</ThingDef>
 	<!-- EMP -->
@@ -417,7 +422,9 @@
 			</li>
 		</comps>
 		<smeltProducts>
-			<Weapon_Parts>1</Weapon_Parts>
+			<Plasteel>5</Plasteel>
+			<ComponentIndustrial>2</ComponentIndustrial>
+			<ElectronicComponents>1</ElectronicComponents>
 		</smeltProducts>
 	</ThingDef>
 
@@ -495,7 +502,9 @@
 			</li>
 		</comps>
 		<smeltProducts>
-			<Weapon_Parts>1</Weapon_Parts>
+			<Plasteel>3</Plasteel>
+			<Powder>1</Powder>
+			<ComponentIndustrial>1</ComponentIndustrial>
 		</smeltProducts>
 	</ThingDef>
 
@@ -849,6 +858,11 @@
 				<explosionRadius>1.5</explosionRadius>
 			</li>
 		</comps>
+		<smeltProducts>
+			<Cloth>3</Cloth>
+			<ComponentMedieval>2</ComponentMedieval>
+			<FSX>1</FSX>
+		</smeltProducts>
 	</ThingDef>
 
 
@@ -925,6 +939,11 @@
 				<preExplosionSpawnChance>1</preExplosionSpawnChance>
 			</li>
 		</comps>
+		<smeltProducts>
+			<Plasteel>5</Plasteel>
+			<Plastic>2</Plastic>
+			<ComponentIndustrial>2</ComponentIndustrial>
+		</smeltProducts>
 	</ThingDef>
 
 	<!-- ==================== Firefoam grenade ========================== -->
@@ -1000,6 +1019,12 @@
 				<postExplosionSpawnThingCount>3</postExplosionSpawnThingCount>
 			</li>
 		</comps>
+		<smeltProducts>
+			<Plasteel>4</Plasteel>
+			<Plastic>1</Plastic>
+			<Powder>1</Powder>
+			<ComponentIndustrial>1</ComponentIndustrial>
+		</smeltProducts>
 	</ThingDef>	
 
 </Defs>

--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
@@ -197,7 +197,7 @@
 		<label>summer dress</label>
 		<description>여름용 흰 드레스입니다. 통풍이 잘되어 체온을 빠르게 식혀줍니다.</description>
 		<graphicData>
-			<texPath>Apparel/RK_SummerDressbk</texPath>
+			<texPath>Apparel/RK_SummerDress</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>


### PR DESCRIPTION
1 corrected grenade recipes craft (replace advanced component to industrial);
2 corrected grenades smelt products (some grenades hadn't products, like smoke, stick and foam);
3 fix ratkin summer dress incorrect icon texture path.

1 скорректированы рецепты крафта гранат (в основном сверхпрочные продвинутые компоненты заменены на индустриальные);
2 скорректирован дроп после переплавки гранат (из дымовой, пенной гранат и гранаты на палке вообще ничего не выпадало; дроп от переплавки теперь чуть более разнообразный (например, от переплавки молота тора и гранаты на палке можно получить немного взрывчатого экстракта);
3 поправлен некорректный путь к текстуре иконки летнего платья раткинов.