### PR TITLE
Some tweaks and fixes

### DIFF
--- a/Mods/AsariRace/Defs/FactionDefs/Factions_Asari.xml
+++ b/Mods/AsariRace/Defs/FactionDefs/Factions_Asari.xml
@@ -54,7 +54,7 @@
 		<hairTags>
 			<li>AsariHair</li>
 		</hairTags>
-		<startingGoodwill>-75</startingGoodwill>
+		<startingGoodwill>0</startingGoodwill>
 		<naturalColonyGoodwill>
 			<min>-50</min>
 			<max>50</max>

--- a/Mods/AsariRace/Defs/FactionDefs/Factions_Asari.xml
+++ b/Mods/AsariRace/Defs/FactionDefs/Factions_Asari.xml
@@ -54,7 +54,7 @@
 		<hairTags>
 			<li>AsariHair</li>
 		</hairTags>
-		<startingGoodwill>0</startingGoodwill>
+		<startingGoodwill>-75</startingGoodwill>
 		<naturalColonyGoodwill>
 			<min>-50</min>
 			<max>50</max>
@@ -96,7 +96,7 @@
 		<pawnGroupMakers>
 			<li>
 				<kindDef>Combat</kindDef>
-				<commonality>100</commonality>
+				<commonality>10</commonality>
 				<options>
 					<AsariEnslaver>25</AsariEnslaver>
 					<AsariHunter>20</AsariHunter>
@@ -106,7 +106,7 @@
 			</li>
 			<li>
 				<kindDef>Combat</kindDef>
-				<commonality>65</commonality>
+				<commonality>150</commonality>
 				<options>
 					<AsariCrewMember>25</AsariCrewMember>
 					<AsariCommando>20</AsariCommando>

--- a/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_Asari.xml
+++ b/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_Asari.xml
@@ -20,8 +20,8 @@
 		<invFoodDef>MealNutrientPaste</invFoodDef>
 		<apparelIgnoreSeasons>false</apparelIgnoreSeasons>
 		<apparelAllowHeadgearChance>0</apparelAllowHeadgearChance>
-		<minGenerationAge>90</minGenerationAge>
-		<maxGenerationAge>700</maxGenerationAge>
+		<minGenerationAge>300</minGenerationAge>
+		<maxGenerationAge>1200</maxGenerationAge>
 		<combatEnhancingDrugsChance>0.15</combatEnhancingDrugsChance>
 		<combatEnhancingDrugsCount>
 			<min>0</min>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Orassan.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Orassan.xml
@@ -27,7 +27,9 @@
 				<li>(1250, 170)</li>
 				<li>(6000, 170)</li>
 				<li>(6500, 210)</li>
-				<li>(7500, 320)</li>
+				<li>(7500, 310)</li>
+				<li>(11000, 330)</li>
+				<li>(12500, 360)</li>
 				<li>(100000, 10000)</li>
 			</points>
 		</maxPawnCostPerTotalPointsCurve>
@@ -75,6 +77,7 @@
 				<li>WoolAlpaca</li>
 				<li>HempCloth</li>
 				<li>WoolSheep</li>
+				<li>Synthread</li>
 				<li>CopperBar</li>
 				<li>Bronze</li>
 				<li>Plasteel</li>
@@ -84,6 +87,7 @@
 		<pawnGroupMakers>
 			<li>
 				<kindDef>Combat</kindDef>
+				<commonality>10</commonality>
 				<options>
 					<OrassanVillager>8</OrassanVillager>
 					<OrassanWindrunner>20</OrassanWindrunner>
@@ -91,6 +95,16 @@
 					<OrassanAdventurer>12</OrassanAdventurer>
 					<OrassanPredator>10</OrassanPredator>
 					<OrassanElder>3</OrassanElder>
+				</options>
+			</li>
+			<li>
+				<kindDef>Combat</kindDef>
+				<commonality>150</commonality>
+				<options>
+					<OrassanTacticalEngineer>15</OrassanTacticalEngineer>
+					<OrassanTacticalSniper>6</OrassanTacticalSniper>
+					<OrassanTacticalDemolisher>5</OrassanTacticalDemolisher>
+					<OrassanTacticalCommander>2</OrassanTacticalCommander>
 				</options>
 			</li>
 			<li>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Orion.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Orion.xml
@@ -43,7 +43,7 @@
 			<min>-40</min>
 			<max>60</max>
 		</naturalColonyGoodwill>
-		<startingGoodwill>-75</startingGoodwill>
+		<startingGoodwill>0</startingGoodwill>
 		<mustStartOneEnemy>true</mustStartOneEnemy>
 		<factionNameMaker>NamerFactionPirate</factionNameMaker>
 		<settlementNameMaker>NamerSettlementPirate</settlementNameMaker>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Orion.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Orion.xml
@@ -43,7 +43,7 @@
 			<min>-40</min>
 			<max>60</max>
 		</naturalColonyGoodwill>
-		<startingGoodwill>0</startingGoodwill>
+		<startingGoodwill>-75</startingGoodwill>
 		<mustStartOneEnemy>true</mustStartOneEnemy>
 		<factionNameMaker>NamerFactionPirate</factionNameMaker>
 		<settlementNameMaker>NamerSettlementPirate</settlementNameMaker>

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Orassan.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Orassan.xml
@@ -321,4 +321,205 @@
 			</li>
 		</modExtensions>
 	</PawnKindDef>
+
+	<!-- Tier 2 pawns -->
+	<PawnKindDef Name="OrassanTacticalBase" ParentName="OrassanVillagerBase" Abstract="True">
+		<combatPower>325</combatPower>
+		<invFoodDef>MealNutrientPaste</invFoodDef>
+		<itemQuality>Good</itemQuality>
+		<apparelIgnoreSeasons>true</apparelIgnoreSeasons>
+		<gearHealthRange>
+			<min>0.75</min>
+			<max>1.25</max>
+		</gearHealthRange>
+		<apparelColor>(235,140,65)</apparelColor>
+		<techHediffsMoney>
+			<min>2200</min>
+			<max>3600</max>
+		</techHediffsMoney>
+		<techHediffsTags>
+			<li>Advanced</li>
+		</techHediffsTags>
+		<techHediffsMaxAmount>1</techHediffsMaxAmount>
+		<techHediffsChance>0.75</techHediffsChance>
+		<apparelAllowHeadgearChance>0.6</apparelAllowHeadgearChance>
+		<disallowedTraits>
+			<li>Brawler</li>
+		</disallowedTraits>
+	</PawnKindDef>
+	<!-- Tactical Engineer -->
+	<PawnKindDef ParentName="OrassanTacticalBase">
+		<defName>OrassanTacticalEngineer</defName>
+		<label>tactical engineer</label>
+		<isFighter>true</isFighter>
+		<canBeSapper>true</canBeSapper>
+		<apparelTags>
+			<li>OrassanTacticalSuit</li>
+			<li>OrassanTacticalEngineer</li>
+		</apparelTags>
+		<apparelMoney>
+			<min>6400</min>
+			<max>8550</max>
+		</apparelMoney>
+		<weaponMoney>
+			<min>1500</min>
+			<max>2550</max>
+		</weaponMoney>
+		<weaponTags>
+			<li>SMG2</li>
+			<li>SMG3</li>
+			<li>ST1</li>
+			<li>ST2</li>
+		</weaponTags>
+		<modExtensions>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>7</min>
+					<max>8</max>
+				</primaryMagazineCount>
+				<sidearms>
+					<li>
+						<generateChance>1</generateChance>
+						<sidearmMoney>
+							<min>0</min>
+							<max>25</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>MonkeyWrenchMelee</li>
+						</weaponTags>
+					</li>
+				</sidearms>
+			</li>
+		</modExtensions>
+	</PawnKindDef>
+	<!-- Tactical Sniper -->
+	<PawnKindDef ParentName="OrassanTacticalBase">
+		<defName>OrassanTacticalSniper</defName>
+		<label>tactical sniper</label>
+		<isFighter>true</isFighter>
+		<apparelTags>
+			<li>OrassanTacticalSuit</li>
+			<li>OrassanTacticalSniper</li>
+		</apparelTags>
+		<apparelMoney>
+			<min>6800</min>
+			<max>8950</max>
+		</apparelMoney>
+		<weaponMoney>
+			<min>2400</min>
+			<max>3450</max>
+		</weaponMoney>
+		<weaponTags>
+			<li>SNIP1</li>
+			<li>SNIP2</li>
+		</weaponTags>
+		<modExtensions>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>5</min>
+					<max>7</max>
+				</primaryMagazineCount>
+				<sidearms>
+					<li>
+						<generateChance>0.75</generateChance>
+						<sidearmMoney>
+							<min>0</min>
+							<max>25</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>MidworldMelee</li>
+						</weaponTags>
+					</li>
+				</sidearms>
+			</li>
+		</modExtensions>
+	</PawnKindDef>
+	<!-- Tactical Demolisher -->
+	<PawnKindDef ParentName="OrassanTacticalBase">
+		<defName>OrassanTacticalDemolisher</defName>
+		<label>tactical demolisher</label>
+		<isFighter>true</isFighter>
+		<canBeSapper>true</canBeSapper>
+		<apparelTags>
+			<li>OrassanTacticalSuit</li>
+			<li>OrassanTacticalDemolisher</li>
+		</apparelTags>
+		<apparelMoney>
+			<min>6800</min>
+			<max>8950</max>
+		</apparelMoney>
+		<weaponMoney>
+			<min>150</min>
+			<max>350</max>
+		</weaponMoney>
+		<weaponTags>
+			<li>GrenadeTierTwo</li>
+		</weaponTags>
+		<modExtensions>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>12</min>
+					<max>20</max>
+				</primaryMagazineCount>
+				<sidearms>
+					<li>
+						<generateChance>0.75</generateChance>
+						<sidearmMoney>
+							<min>0</min>
+							<max>25</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>MidworldMelee</li>
+						</weaponTags>
+					</li>
+				</sidearms>
+			</li>
+		</modExtensions>
+	</PawnKindDef>
+	<!-- Tactical Commander -->
+	<PawnKindDef ParentName="OrassanTacticalBase">
+		<defName>OrassanTacticalCommander</defName>
+		<label>tactical commander</label>
+		<combatPower>350</combatPower>
+		<itemQuality>Normal</itemQuality>
+		<isFighter>true</isFighter>
+		<canBeSapper>true</canBeSapper>
+		<apparelTags>
+			<li>OrassanTacticalCommander</li>
+		</apparelTags>
+		<apparelMoney>
+			<min>8300</min>
+			<max>10800</max>
+		</apparelMoney>
+		<apparelAllowHeadgearChance>1</apparelAllowHeadgearChance>
+		<weaponMoney>
+			<min>3150</min>
+			<max>4000</max>
+		</weaponMoney>
+		<weaponTags>
+			<li>ASN1</li>
+		</weaponTags>
+		<modExtensions>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>6</min>
+					<max>9</max>
+				</primaryMagazineCount>
+				<sidearms>
+					<li>
+						<generateChance>0.75</generateChance>
+						<sidearmMoney>
+							<min>0</min>
+							<max>125</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>MidworldMelee</li>
+						</weaponTags>
+					</li>
+				</sidearms>
+			</li>
+		</modExtensions>
+		<techHediffsMaxAmount>3</techHediffsMaxAmount>
+		<techHediffsChance>1</techHediffsChance>
+	</PawnKindDef>
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
@@ -304,6 +304,7 @@
 				<li>Military</li>
 				<li>BrotherhoodScout</li>
 				<li>SectarianScout</li>
+				<li>OrassanTacticalSuit</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Worker</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
@@ -514,6 +514,7 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>OrassanTacticalSuit</li>
 				<li>BrotherhoodLight</li>
 				<li>BrotherhoodScout</li>
 				<li>BrotherhoodMedium</li>
@@ -665,6 +666,7 @@
 				<li>SyndicateMelee</li>
 				<li>AsariCommando</li>
 				<li>AsariPowerArmor</li>
+				<li>OrassanTacticalCommander</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Worker</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Industrial.xml
@@ -68,6 +68,7 @@
 			<tags>
 				<li>BrotherhoodMedium</li>
 				<li>SectarianMedium</li>
+				<li>OrassanTacticalSuit</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Soldier</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Spacer.xml
@@ -280,6 +280,7 @@
 			</layers>
 			<tags>
 				<li>SpacerMilitary</li>
+				<li>OrassanTacticalCommander</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Soldier</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Gloves.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Gloves.xml
@@ -471,6 +471,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>OrassanTacticalSuit</li>
 				<li>BrotherhoodUnique</li>
 				<li>BrotherhoodScout</li>
 				<li>SyndicateMedium</li>
@@ -541,6 +542,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>OrassanTacticalSniper</li>
 				<li>SyndicateMedium</li>
 				<li>OrionScout</li>
 				<li>SyndicateScout</li>
@@ -838,6 +840,7 @@
 				<li>SyndicateScout</li>
 				<li>AsariCommando</li>
 				<li>AsariPowerArmor</li>
+				<li>OrassanTacticalCommander</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Soldier</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Industrial.xml
@@ -542,6 +542,7 @@
 			<tags>
 				<li>SectarianLight</li>
 				<li>OrionLight</li>
+				<li>OrassanTacticalSuit</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Soldier</li>
@@ -624,6 +625,8 @@
 				<li>Outlander</li>
 				<li>RenegadesMedium</li>
 				<li>EmpireMedium</li>
+				<li>OrassanTacticalEngineer</li>
+				<li>OrassanTacticalDemolisher</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Worker</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Spacer.xml
@@ -366,6 +366,7 @@
 			</layers>
 			<tags>
 				<li>SpacerMilitary</li>
+				<li>OrassanTacticalCommander</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Worker</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Industrial.xml
@@ -53,6 +53,7 @@
 				<li>Military</li>
 				<li>BrotherhoodMedium</li>
 				<li>EmpireMedium</li>
+				<li>OrassanTacticalEngineer</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Soldier</li>
@@ -175,6 +176,8 @@
 			</layers>
 			<tags>
 				<li>SectarianMedium</li>
+				<li>OrassanTacticalSniper</li>
+				<li>OrassanTacticalDemolisher</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Soldier</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Kits.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Kits.xml
@@ -229,6 +229,8 @@
 				<li>BanditsLight</li>
 				<li>AsariCommando</li>
 				<li>AsariPowerArmor</li>
+				<li>OrassanTacticalSuit</li>
+				<li>OrassanTacticalCommander</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Soldier</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
@@ -426,6 +426,8 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>OrassanTacticalSuit</li>
+				<li>OrassanTacticalCommander</li>
 				<li>SyndicateMedium</li>
 				<li>SyndicateLight</li>
 				<li>OrionMedium</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Rodentlike.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Rodentlike.xml
@@ -750,7 +750,7 @@
 			<baseHealthScale>0.4</baseHealthScale>
 			<foodType>OmnivoreRoughAnimal</foodType>
 			<useMeatFrom>Elephant</useMeatFrom>
-			<leatherDef>Leather_Light</leatherDef>
+			<leatherDef>Leather_Boomanimal</leatherDef>
 			<executionRange>4</executionRange>
 			<wildness>0.75</wildness>
 			<petness>0.20</petness>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Tropical.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Tropical.xml
@@ -365,7 +365,7 @@
 			<baseHealthScale>0.65</baseHealthScale>
 			<foodType>VegetarianRoughAnimal</foodType>
 			<useMeatFrom>Elephant</useMeatFrom>
-			<leatherDef>Leather_Plain</leatherDef>
+			<leatherDef>Leather_Boomanimal</leatherDef>
 			<manhunterOnDamageChance>0</manhunterOnDamageChance>
 			<wildness>0.6</wildness>
 			<canBePredatorPrey>false</canBePredatorPrey>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
@@ -2,7 +2,6 @@
 <Defs>
 	<!-- HUMANOID BASE -->
 	<ThingDef Name="BaseHumanlikePawn" ParentName="SK_BasePawn" Abstract="True">
-		<uiIconPath>Things/Pawn/Humanlike/UI/IconHuman</uiIconPath>
 		<statBases>
 			<MarketValue>1750</MarketValue>
 			<MoveSpeed>4.85</MoveSpeed>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Stuff_Leather.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Stuff_Leather.xml
@@ -346,7 +346,7 @@
 		</graphicData>
 		<statBases>
 			<MaxHitPoints>100</MaxHitPoints>
-			<MarketValue>5</MarketValue>
+			<MarketValue>2.8</MarketValue>
 			<Flammability>1.0</Flammability>
 			<DeteriorationRate>0</DeteriorationRate>
 			<StuffPower_Armor_Blunt>1</StuffPower_Armor_Blunt>
@@ -642,6 +642,46 @@
 				<WorkToBuild>1.1</WorkToBuild>
 				<BedRestEffectiveness>0.9</BedRestEffectiveness>
 				<ImmunityGainSpeedFactor>1.35</ImmunityGainSpeedFactor>
+				<Mass>0.5</Mass>
+			</statFactors>
+		</stuffProps>
+	</ThingDef>
+
+	<ThingDef ParentName="SK_LeatherBase">
+		<defName>Leather_Boomanimal</defName>
+		<label>boomanimal leather</label>
+		<description>Lightweight leather from a boom animal like boomrat or boomalope. More flammable than other leathers.</description>
+		<statBases>
+			<MaxHitPoints>100</MaxHitPoints>
+			<MarketValue>3.5</MarketValue>
+			<Flammability>1.2</Flammability>
+			<DeteriorationRate>0</DeteriorationRate>
+			<StuffPower_Armor_Blunt>1.05</StuffPower_Armor_Blunt>
+			<StuffPower_Armor_Sharp>1.12</StuffPower_Armor_Sharp>
+			<StuffPower_Armor_Heat>0.09</StuffPower_Armor_Heat>
+			<StuffPower_Insulation_Cold>8</StuffPower_Insulation_Cold>
+			<StuffPower_Insulation_Heat>9</StuffPower_Insulation_Heat>
+			<Mass>0.01</Mass>
+			<Bulk>0.01</Bulk>	
+		</statBases>
+		<tickerType>Rare</tickerType>
+		<stackLimit>300</stackLimit>
+		<graphicData>
+			<color>(115,37,28)</color>
+		</graphicData>
+		<stuffProps>
+			<color>(115,37,28)</color>
+			<commonality>0.125</commonality>
+			<statFactors>
+				<MaxHitPoints>1.0</MaxHitPoints>
+				<Flammability>1.2</Flammability>
+				<Beauty>2</Beauty>
+				<MoveSpeed>1</MoveSpeed>
+				<MarketValue>0.8</MarketValue>
+				<WorkToMake>1.1</WorkToMake>
+				<WorkToBuild>1.1</WorkToBuild>
+				<BedRestEffectiveness>1.15</BedRestEffectiveness>
+				<ImmunityGainSpeedFactor>1.15</ImmunityGainSpeedFactor>
 				<Mass>0.5</Mass>
 			</statFactors>
 		</stuffProps>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Midworld.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Melee_Midworld.xml
@@ -233,6 +233,7 @@
 		<techLevel>Industrial</techLevel>
 		<weaponTags>
 			<li>MidworldMelee</li>
+			<li>MonkeyWrenchMelee</li>
 			<li>CE_OneHandedWeapon</li>
 		</weaponTags>
 		<equippedAngleOffset>-25</equippedAngleOffset>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/PawnKindDef/PawnKinds_Orassan.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/PawnKindDef/PawnKinds_Orassan.xml
@@ -57,4 +57,32 @@
   <OrassanPredator.labelFemale>Хищница фелинов</OrassanPredator.labelFemale>
   <OrassanPredator.labelFemalePlural>Хищницы фелинов</OrassanPredator.labelFemalePlural>
 
+  <OrassanTacticalEngineer.label>Инженер фелинов</OrassanTacticalEngineer.label>
+  <OrassanTacticalEngineer.labelPlural>Инженеры фелинов</OrassanTacticalEngineer.labelPlural>
+  <OrassanTacticalEngineer.labelMale>Инженер фелинов</OrassanTacticalEngineer.labelMale>
+  <OrassanTacticalEngineer.labelMalePlural>Инженеры фелинов</OrassanTacticalEngineer.labelMalePlural>
+  <OrassanTacticalEngineer.labelFemale>Инженер фелинов</OrassanTacticalEngineer.labelFemale>
+  <OrassanTacticalEngineer.labelFemalePlural>Инженеры фелинов</OrassanTacticalEngineer.labelFemalePlural>
+
+  <OrassanTacticalSniper.label>Снайпер фелинов</OrassanTacticalSniper.label>
+  <OrassanTacticalSniper.labelPlural>Снайперы фелинов</OrassanTacticalSniper.labelPlural>
+  <OrassanTacticalSniper.labelMale>Снайпер фелинов</OrassanTacticalSniper.labelMale>
+  <OrassanTacticalSniper.labelMalePlural>Снайперы фелинов</OrassanTacticalSniper.labelMalePlural>
+  <OrassanTacticalSniper.labelFemale>Снайпер фелинов</OrassanTacticalSniper.labelFemale>
+  <OrassanTacticalSniper.labelFemalePlural>Снайперы фелинов</OrassanTacticalSniper.labelFemalePlural>
+
+  <OrassanTacticalDemolisher.label>Разрушитель фелинов</OrassanTacticalDemolisher.label>
+  <OrassanTacticalDemolisher.labelPlural>Разрушители фелинов</OrassanTacticalDemolisher.labelPlural>
+  <OrassanTacticalDemolisher.labelMale>Разрушитель фелинов</OrassanTacticalDemolisher.labelMale>
+  <OrassanTacticalDemolisher.labelMalePlural>Разрушители фелинов</OrassanTacticalDemolisher.labelMalePlural>
+  <OrassanTacticalDemolisher.labelFemale>Разрушитель фелинов</OrassanTacticalDemolisher.labelFemale>
+  <OrassanTacticalDemolisher.labelFemalePlural>Разрушители фелинов</OrassanTacticalDemolisher.labelFemalePlural>
+
+  <OrassanTacticalCommander.label>Чоммандер фелинов</OrassanTacticalCommander.label>
+  <OrassanTacticalCommander.labelPlural>Чоммандеры фелинов</OrassanTacticalCommander.labelPlural>
+  <OrassanTacticalCommander.labelMale>Чоммандер фелинов</OrassanTacticalCommander.labelMale>
+  <OrassanTacticalCommander.labelMalePlural>Чоммандеры фелинов</OrassanTacticalCommander.labelMalePlural>
+  <OrassanTacticalCommander.labelFemale>Чоммандер фелинов</OrassanTacticalCommander.labelFemale>
+  <OrassanTacticalCommander.labelFemalePlural>Чоммандеры фелинов</OrassanTacticalCommander.labelFemalePlural>
+
 </LanguageData>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Resource_Stuff_Leather.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Resource_Stuff_Leather.xml
@@ -69,6 +69,10 @@
   <!--[Core] <Leather_Lizard.description>Дублёная кожа холоднокровной рептилии. Весьма крепкая, но слабо защищает от холода или жары.</Leather_Lizard.description>-->
   <!--[Core] <Leather_Lizard.stuffProps.stuffAdjective>кожи рептилии</Leather_Lizard.stuffProps.stuffAdjective>-->
 
+  <Leather_Boomanimal.label>бумкожа</Leather_Boomanimal.label>
+  <Leather_Boomanimal.description>Легкая кожа с взрывоопасных животных наподобие бумкрысы или бумалопы. Обладает повышенной горючестью.</Leather_Boomanimal.description>
+  <Leather_Boomanimal.stuffProps.stuffAdjective>бумкожи</Leather_Boomanimal.stuffProps.stuffAdjective>
+
 
   <!-- Tough leathers -->
 

--- a/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
@@ -346,10 +346,6 @@
 						<defName>Kind</defName>
 						<chance>3</chance>
 					</li>
-					<li>
-						<defName>Faith</defName>
-						<chance>1</chance>
-					</li>
 				</forcedRaceTraitEntries>
 
 			</generalSettings>


### PR DESCRIPTION
1 Fixed ratkin faith trait forced (doubling).
2 Remove pawn icon from older version.
3 Correcting asaries late game raids.
4 Added boomanimal leather to increase the reward from the hunt on boomalope and boomrat.
5 Reduced human leather market value.
6 Added orassan's faction late raids.

1 поправлено задвоение насильно выдаваемой черты раткинам-рыцарям;
2 удалена старая иконка пешек, сейчас игра сама генерирует её в зависимости от их внешнего вида;
3 скорректированы рейды азарей в поздней игре (часто приходили в обычном одежде и с огнестрелом даже в очень поздней игре);
4 добавлена бумкожа с неплохими бонусами, добывается из бумкрыс и бумалоп;
5 уменьшена рыночная стоимость кожи двуножки (слишком высокая);
6 добавлено разделение рейдов для фракции орассанов (в начальной игре - слабые рейды, в поздней - сильные рейды).