### PR TITLE
Fixed energy fist. Had not CE tool compatibility (and therefore ignored any armor).

### DIFF
--- a/Mods/CombatExtended/Defs/TraitDefs/Traits_Spectrum.xml
+++ b/Mods/CombatExtended/Defs/TraitDefs/Traits_Spectrum.xml
@@ -3,7 +3,7 @@
 
   <TraitDef>
     <defName>Bravery</defName>
-    <commonality>0.001</commonality>
+    <commonality>1</commonality>
     <degreeDatas>
       <li>
         <label>cowardly</label>
@@ -11,6 +11,7 @@
         <degree>-1</degree>
         <statOffsets>
           <Suppressability>0.25</Suppressability>
+          <MentalBreakThreshold>0.02</MentalBreakThreshold>
         </statOffsets>
       </li>
       <li>
@@ -19,6 +20,7 @@
         <degree>1</degree>
         <statOffsets>
           <Suppressability>-0.50</Suppressability>
+          <MentalBreakThreshold>-0.02</MentalBreakThreshold>
         </statOffsets>
       </li>
       <li>
@@ -27,6 +29,7 @@
         <degree>2</degree>
         <statOffsets>
           <Suppressability>-1.0</Suppressability>
+          <MentalBreakThreshold>-0.04</MentalBreakThreshold>
         </statOffsets>
       </li>      
     </degreeDatas>

--- a/Mods/CyberneticOrganism_SK/Defs/Hediffs/Cyborg_hediffs.xml
+++ b/Mods/CyberneticOrganism_SK/Defs/Hediffs/Cyborg_hediffs.xml
@@ -66,7 +66,7 @@
 		<comps>
 			<li Class="HediffCompProperties_VerbGiver">
 				<tools>
-					<li>
+					<li Class="CombatExtended.ToolCE">
 						<label>arm</label>
 						<capacities>
 							<li>Poke</li>
@@ -74,6 +74,7 @@
 						<power>15.0</power>
 						<cooldownTime>0.25</cooldownTime>
 						<alwaysTreatAsWeapon>false</alwaysTreatAsWeapon>
+						<armorPenetrationBlunt>40</armorPenetrationBlunt>
 					</li>
 				</tools>
 			</li>


### PR DESCRIPTION
Update: also returned CE traits commonality (cuz suppression now works). Also gave this traits small mental break threshold boost/penalty (if someone want play without suppression then trait become useless).

P.S. please don't adding conflict with other mental traits! CE traits are primarily designed to interact with the suppression mechanic!

Исправлена энергетическая кисть. Отсутствовала поддержка CE и бронепробитие (из-за этого она игнорировала любую броню).

Update: также вернул частоту появления CE черт характера, связанных с подавлением (т.к. теперь подавление работает). Также добавил этим чертам небольшой бонус/штраф к порогу нервного срыва (если кто-то захочет поиграть без подавления, то эти черты становятся бесполезными).

P.S. не надо добавлять их в конфликтные с другими чертами на порог срыва! Черты CE в первую очередь предназначены для взаимодействия с механикой подавления!