### PR TITLE
Some mini turret tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Turrets.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Turrets.xml
@@ -1071,9 +1071,9 @@
 
 	<RecipeDef ParentName="cratecraftbase">
 		<defName>BuildSentryTurret_Crate</defName>
-		<label>Build .40 Rimfire Sentry light crate</label>
+		<label>Build 5.56x45mm NATO Sentry light crate</label>
 		<description>Use this to build an automated sentry light turret, a type of stationary automatic turret. It requires power to function.</description>
-		<jobString>Building .40 Rimfire Sentry light crate.</jobString>
+		<jobString>Building 5.56x45mm NATO Sentry light crate.</jobString>
 		<workAmount>10500</workAmount>
 		<skillRequirements>
 			<Crafting>11</Crafting>
@@ -1090,7 +1090,7 @@
 			<li>
 				<filter>
 					<thingDefs>
-						<li>SMG_Component</li>
+						<li>Rifle_Component</li>
 					</thingDefs>
 				</filter>
 				<count>2</count>
@@ -1118,7 +1118,7 @@
 		<fixedIngredientFilter>
 			<thingDefs>
 						<li>Weapon_Parts</li>
-						<li>SMG_Component</li>
+						<li>Rifle_Component</li>
 						<li>Electronics</li>
 			</thingDefs>
 			<categories>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Security.xml
@@ -187,7 +187,7 @@
 			<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 		</comps>
-		<description>An AI-controlled turret that automatically fires at nearby enemies. Requires 700 W to function.\nCaliber: .45 ACP</description>
+		<description>An AI-controlled turret that automatically fires at nearby enemies. Requires 700 W to function.\nCaliber: 5.56x45mm NATO</description>
 		<stuffCategories>
 			<li>RuggedMetallic</li>
 		</stuffCategories>

--- a/Mods/Core_SK/Defs/ThingDefs_Items/Items_Crate.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Items/Items_Crate.xml
@@ -588,7 +588,7 @@
 
 	<ThingDef ParentName="CrateBase">
 		<defName>SentryTurret_Crate</defName>
-		<label>.40 Rimfire Sentry light crate</label>
+		<label>5.56x45mm NATO Sentry light crate</label>
 		<description>Use this to build a sentry light turret, a type of stationary automatic turret. It requires power to function.</description>
 		<graphicData>
 			<texPath>Things/Item/Resource/WeaponCrate</texPath>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Turrets_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Turrets_SK.xml
@@ -68,9 +68,9 @@
 	
 	<!-- ==================== Auto turrets ========================== -->
 	
-	<BuildSentryTurret_Crate.label>Сделать детали самодельной автотурели .40 RF</BuildSentryTurret_Crate.label> 
-	<BuildSentryTurret_Crate.description>Сделать детали для постройки самодельной автотурели .40 RF.</BuildSentryTurret_Crate.description> 
-	<BuildSentryTurret_Crate.jobString>Делает детали автотурели .40 RF.</BuildSentryTurret_Crate.jobString> 
+	<BuildSentryTurret_Crate.label>Сделать детали самодельной автотурели 5.56x45mm NATO</BuildSentryTurret_Crate.label> 
+	<BuildSentryTurret_Crate.description>Сделать детали для постройки самодельной автотурели 5.56x45mm NATO.</BuildSentryTurret_Crate.description> 
+	<BuildSentryTurret_Crate.jobString>Делает детали автотурели 5.56x45mm NATO.</BuildSentryTurret_Crate.jobString> 
 	
 	<BuildHeavyTurret_Crate.label>Сделать детали автотурели QJG-02А</BuildHeavyTurret_Crate.label> 
 	<BuildHeavyTurret_Crate.description>Сделать детали для постройки автотурели QJG-02А.</BuildHeavyTurret_Crate.description> 

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Ammo_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Items_Ammo_SK.xml
@@ -45,8 +45,8 @@
 	
 	<!-- ==================== Auto turrets ========================== -->
 	 
-	<SentryTurret_Crate.label>Детали самодельной автотурели .40 RF</SentryTurret_Crate.label>
-	<SentryTurret_Crate.description>Детали для стационарной самодельной автотурели .40 RF.</SentryTurret_Crate.description>
+	<SentryTurret_Crate.label>Детали самодельной автотурели 5.56x45mm NATO</SentryTurret_Crate.label>
+	<SentryTurret_Crate.description>Детали для стационарной самодельной автотурели 5.56x45mm NATO.</SentryTurret_Crate.description>
 	
 	<HeavyTurret_Crate.label>Детали автотурели QJG-02А</HeavyTurret_Crate.label> 
 	<HeavyTurret_Crate.description>Детали для тяжёлой автотурели QJG-02А.</HeavyTurret_Crate.description>


### PR DESCRIPTION
1 fixed mini turret misdescriptions;
2 replaced SMG component to Rifle (cuz it now have 5.56 mm caliber).

1 актуализировано описание мини турели и всех связанных с ней предметов;
2 заменены компоненты ПП на винтовочные в крафте деталей мини турели (т.к. калибр нынче промежуточный (5.56 мм)).