### PR TITLE
Some tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -188,8 +188,7 @@
 		</stuffCategories>
 		<costStuffCount>95</costStuffCount>
 		<costList>
-			<ComponentMedieval>6</ComponentMedieval>
-			<Mechanism>2</Mechanism>
+			<ComponentMedieval>8</ComponentMedieval>
 		</costList>
 		<minifiedDef>MinifiedThing</minifiedDef>
 		<thingCategories>

--- a/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
+++ b/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
@@ -1,5 +1,23 @@
 ﻿<Patch>
 
+	<!-- Quests helpers -->
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/QuestScriptDef[defName = "Util_MaybeGenerateHelpers"]/root/nodes/li[@Class= "QuestNode_IsNull"]/elseNode/elseNode/elseNode/node/nodes/li[name= "helpersCount"]/elseNode/nodes/li[1]/curve/points</xpath>
+				<value>
+                    <points>
+                        <li>(260,  1)</li>
+                        <li>(1000, 2)</li>
+                        <li>(2000, 4)</li>
+                        <li>(5000, 6)</li>
+                    </points>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
 	<!-- Monument Quests -->
 	<Operation Class="PatchOperationSequence">
 		<success>Always</success>


### PR DESCRIPTION
1 Corrected quest helper count curve (Royalty).
2 Replace 2 industrial mechanisms to 2 primitive components (cuz butcher table require neolitic research).

1 скорректировал кривую количества пешек-помощников, выдаваемых за некоторые квесты (Royalty) (их стало меньше);
2 убрал требования двух механизмов для крафта разделочного стола (сам стол доступен в неолите, а механизмы для крафта требуют индустриальных компонентов). Взамен увеличил количество примитивных компонентов с 6 до 8.