### PR TITLE
Fixed king Hamster wool duplicates in textile categories

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_LeatherAndWool.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_LeatherAndWool.xml
@@ -89,7 +89,7 @@
 				<Mass>0.8</Mass>
 			</statFactors>
 		</stuffProps>
-		<thingCategories>
+		<thingCategories Inherit="false">
 			<li>BTextiles</li>
 		</thingCategories>		
 	</ThingDef>


### PR DESCRIPTION
Fixed king Hamster wool duplicates in textile categories

Исправлено задвоение шерсти королевского хомяка в категории текстиля (одновременно отображался в двух категориях, вместо одной).