### PR TITLE
Fix idle machines and heat

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_AJO.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_AJO.xml
@@ -407,7 +407,7 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
 		</comps>
 	</ThingDef>
@@ -455,7 +455,7 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
 		</comps>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_SK.xml
@@ -1908,7 +1908,7 @@
 			<li Class="CompProperties_Forbiddable"/>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>1500</basePowerConsumption>
+				<basePowerConsumption>100</basePowerConsumption>
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -49,12 +49,7 @@
 					<li>CookingTools</li>
 				</linkableFacilities>
 			</li>
-			<li Class="SK.CompProperties_HeatPusherAdvanced">
-				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>14</heatPerSecond>
-				<heatPushMaxTemperature>18</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Glower">
+		<li Class="CompProperties_Glower">
 				<glowRadius>2</glowRadius>
 				<glowColor>(217,112,33,0)</glowColor>
 			</li>
@@ -350,12 +345,7 @@
 					<li>CookingTools</li>
 				</linkableFacilities>
 			</li>
-			<li Class="SK.CompProperties_HeatPusherAdvanced">
-				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>17</heatPerSecond>
-				<heatPushMaxTemperature>25</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Glower">
+		<li Class="CompProperties_Glower">
 				<glowRadius>3</glowRadius>
 				<glowColor>(217,112,33,0)</glowColor>
 			</li>
@@ -465,12 +455,7 @@
 					<li>CookingTools</li>
 				</linkableFacilities>
 			</li>
-			<li Class="SK.CompProperties_HeatPusherAdvanced">
-				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>18</heatPerSecond>
-				<heatPushMaxTemperature>24</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Glower">
+		<li Class="CompProperties_Glower">
 				<glowRadius>3</glowRadius>
 				<glowColor>(217,112,33,0)</glowColor>
 			</li>
@@ -664,14 +649,9 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>10</heatPerSecond>
-				<heatPushMaxTemperature>35</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_AffectedByFacilities">
+		<li Class="CompProperties_AffectedByFacilities">
 				<linkableFacilities>
 					<li>CookingTools</li>
 				</linkableFacilities>
@@ -941,12 +921,7 @@
 					<li>CookingTools</li>
 				</linkableFacilities>
 			</li>
-			<li Class="SK.CompProperties_HeatPusherAdvanced">
-				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>19</heatPerSecond>
-				<heatPushMaxTemperature>28</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Glower">
+		<li Class="CompProperties_Glower">
 				<glowRadius>3</glowRadius>
 				<glowColor>(217,112,33,0)</glowColor>
 			</li>
@@ -2047,12 +2022,7 @@
 				<glowRadius>3</glowRadius>
 				<glowColor>(217,112,33,0)</glowColor>
 			</li>
-			<li Class="SK.CompProperties_HeatPusherAdvanced">
-				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>25</heatPerSecond>
-				<heatPushMaxTemperature>27</heatPushMaxTemperature>
-			</li>
-			<li Class="SK.CompFueled_Properties">
+		<li Class="SK.CompFueled_Properties">
 				<operatingTemp>500</operatingTemp>
 				<fireDrawOffset>(0.52,0.1,-0.55)</fireDrawOffset>
 				<smokeDrawOffset>(0.5,-0.1,1.5)</smokeDrawOffset>
@@ -2142,12 +2112,7 @@
 					<li>ToolCabinet</li>
 				</linkableFacilities>
 			</li>
-			<li Class="SK.CompProperties_HeatPusherAdvanced">
-				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>20</heatPerSecond>
-				<heatPushMaxTemperature>25</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Glower">
+		<li Class="CompProperties_Glower">
 				<glowRadius>3</glowRadius>
 				<glowColor>(217,112,33,0)</glowColor>
 			</li>
@@ -2265,12 +2230,7 @@
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
 				<idlePowerFactor>0.1</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>25</heatPerSecond>
-				<heatPushMaxTemperature>45</heatPushMaxTemperature>
-			</li>
-			<li>
+		<li>
 				<compClass>CompReportWorkSpeed</compClass>
 			</li>
 		</comps>
@@ -2809,12 +2769,7 @@
 				</linkableFacilities>
 			</li>
 			<li Class="CompProperties_Flickable"/>
-			<li Class="SK.CompProperties_HeatPusherAdvanced">
-				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>30</heatPerSecond>
-				<heatPushMaxTemperature>45</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Glower">
+		<li Class="CompProperties_Glower">
 				<glowRadius>3</glowRadius>
 				<glowColor>(217,112,33,0)</glowColor>
 			</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
@@ -54,11 +54,6 @@
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
 				<idlePowerFactor>0.1</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>10</heatPerSecond>
-				<heatPushMaxTemperature>35</heatPushMaxTemperature>
-			</li>
 			<li Class="CompProperties_AffectedByFacilities">
 				<linkableFacilities>
 					<li>CookingTools</li>
@@ -134,11 +129,6 @@
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
 				<idlePowerFactor>0.1</idlePowerFactor>
-			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>12</heatPerSecond>
-				<heatPushMaxTemperature>35</heatPushMaxTemperature>
 			</li>
 			<li Class="CompProperties_AffectedByFacilities">
 				<linkableFacilities>
@@ -223,12 +213,7 @@
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
 				<idlePowerFactor>0.1</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>10</heatPerSecond>
-				<heatPushMaxTemperature>35</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Flickable"/>
+		<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 			<li Class="CompProperties_AffectedByFacilities">
 				<linkableFacilities>
@@ -308,14 +293,9 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>10</heatPerSecond>
-				<heatPushMaxTemperature>35</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Flickable"/>
+		<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 			<li>
 				<compClass>CompReportWorkSpeed</compClass>
@@ -398,12 +378,7 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
-			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>12</heatPerSecond>
-				<heatPushMaxTemperature>35</heatPushMaxTemperature>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
 			<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
@@ -489,14 +464,9 @@
 			</li>
 			<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>35</heatPerSecond>
-				<heatPushMaxTemperature>75</heatPushMaxTemperature>
-			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
 			<li Class="CompProperties_AffectedByFacilities">
 				<linkableFacilities>
@@ -513,7 +483,7 @@
 			<li>PlaceWorker_ReportWorkSpeedPenalties</li>
 		</placeWorkers>
 		<building>
-			<heatPerTickWhileWorking>2</heatPerTickWhileWorking>
+			<heatPerTickWhileWorking>0.2</heatPerTickWhileWorking>
 		</building>
 		<researchPrerequisites>
 			<li>ElectricSmelting</li>
@@ -586,7 +556,7 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
 			<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
@@ -595,7 +565,7 @@
 			</li>
 		</comps>
 		<building>
-			<heatPerTickWhileWorking>0.8</heatPerTickWhileWorking>
+			<heatPerTickWhileWorking>0.2</heatPerTickWhileWorking>
 		</building>
 		<designationHotKey>Misc5</designationHotKey>
 		<placeWorkers>
@@ -840,14 +810,9 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>22</heatPerSecond>
-				<heatPushMaxTemperature>55</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Flickable"/>
+		<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 			<li>
 				<compClass>CompReportWorkSpeed</compClass>
@@ -988,7 +953,7 @@
 			<li>SmeltWeapon</li>
 		</recipes>
 		<building>
-			<heatPerTickWhileWorking>1</heatPerTickWhileWorking>
+			<heatPerTickWhileWorking>0.2</heatPerTickWhileWorking>
 		</building>
 		<tickerType>Normal</tickerType>
 		<comps>
@@ -1007,14 +972,9 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>22</heatPerSecond>
-				<heatPushMaxTemperature>65</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Flickable"/>
+		<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 			<li>
 				<compClass>CompReportWorkSpeed</compClass>
@@ -1115,14 +1075,9 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>35</heatPerSecond>
-				<heatPushMaxTemperature>55</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Flickable"/>
+		<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 			<li>
 				<compClass>CompReportWorkSpeed</compClass>
@@ -1133,7 +1088,7 @@
 			<li>PlaceWorker_ReportWorkSpeedPenalties</li>
 		</placeWorkers>
 		<building>
-			<heatPerTickWhileWorking>2</heatPerTickWhileWorking>
+			<heatPerTickWhileWorking>0.2</heatPerTickWhileWorking>
 		</building>
 		<researchPrerequisites>
 			<li>SK_MetallurgyIII</li>
@@ -1328,12 +1283,7 @@
 				<compClass>CompPowerTrader</compClass>
 				<basePowerConsumption>800</basePowerConsumption>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>20</heatPerSecond>
-				<heatPushMaxTemperature>1500</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Glower">
+		<li Class="CompProperties_Glower">
 				<glowRadius>4</glowRadius>
 				<glowColor>(255,0,0,0)</glowColor>
 			</li>
@@ -1410,12 +1360,7 @@
 				<glowRadius>5</glowRadius>
 				<glowColor>(255,0,0,0)</glowColor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>30</heatPerSecond>
-				<heatPushMaxTemperature>1500</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_CreatesInfestations" />
+		<li Class="CompProperties_CreatesInfestations" />
 			<li Class="CompProperties_Flickable"/>
 		</comps>
 		<size>(5,5)</size>
@@ -2004,12 +1949,7 @@
 				<glowRadius>6</glowRadius>
 				<glowColor>(217,112,33,0)</glowColor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>28</heatPerSecond>
-				<heatPushMaxTemperature>1000</heatPushMaxTemperature>
-			</li>
-			<li Class="SK.CompProperties_LowIdleDraw">
+		<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
 				<idlePowerFactor>0.1</idlePowerFactor>
 			</li>
@@ -2172,14 +2112,9 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>12</heatPerSecond>
-				<heatPushMaxTemperature>45</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Flickable"/>
+		<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 			<li>
 				<compClass>CompReportWorkSpeed</compClass>
@@ -2781,14 +2716,9 @@
 			</li>
 			<li Class="SK.CompProperties_LowIdleDraw">
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
-				<idlePowerFactor>0.1</idlePowerFactor>
+				<idlePowerFactor>0.0</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>85</heatPerSecond>
-				<heatPushMaxTemperature>1500</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Flickable"/>
+		<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 		</comps>
 		<building>
@@ -2854,12 +2784,7 @@
 				<basePowerConsumption>-1</basePowerConsumption>
 				<transmitsPower>true</transmitsPower>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>90</heatPerSecond>
-				<heatPushMaxTemperature>1500</heatPushMaxTemperature>
-			</li>
-			<li Class="CompProperties_Breakdownable"/>
+		<li Class="CompProperties_Breakdownable"/>
 		</comps>
 		<building>
 			<soundAmbient>MatterFab</soundAmbient>

--- a/Mods/HMC advanced mineral scanner/Defs/ThingDefs/Buildings_Misc_SK.xml
+++ b/Mods/HMC advanced mineral scanner/Defs/ThingDefs/Buildings_Misc_SK.xml
@@ -29,8 +29,12 @@
 			<li Class="CompProperties_Forbiddable"/>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
-				<basePowerConsumption>2500</basePowerConsumption>
+				<basePowerConsumption>250</basePowerConsumption>
 			</li>
+			<li Class="SK.CompProperties_LowIdleDraw">
+                                <compClass>SK.CompPowerLowIdleDraw</compClass>
+                                <idlePowerFactor>0.0</idlePowerFactor>
+                        </li>
 			<li Class="CompProperties_Breakdownable"/>
 			<li Class="CompProperties_Flickable"/>
 			<li Class="SK.CompProperties_ScannerAdvancedMineralsDeep">

--- a/Mods/Rimefeller_SK/Defs/ThingDefs_Buildings/BuildingsB_Oil.xml
+++ b/Mods/Rimefeller_SK/Defs/ThingDefs_Buildings/BuildingsB_Oil.xml
@@ -98,15 +98,15 @@
 				<compClass>CompPowerTrader</compClass>
 				<basePowerConsumption>1000</basePowerConsumption>
 			</li>
+			<li Class="SK.CompProperties_LowIdleDraw">
+                                <compClass>SK.CompPowerLowIdleDraw</compClass>
+                                <idlePowerFactor>0.0</idlePowerFactor>
+                        </li>
 			<li Class="CompProperties_Glower">
 				<glowRadius>6</glowRadius>
 				<glowColor>(252,187,113,0)</glowColor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>8</heatPerSecond>
-			</li>
-			<li Class="CompProperties_Explosive">
+		<li Class="CompProperties_Explosive">
 				<explosiveRadius>7</explosiveRadius>
 				<explosiveDamageType>Flame</explosiveDamageType>
 				<destroyThingOnExplosionSize>1</destroyThingOnExplosionSize>
@@ -376,6 +376,10 @@
 				<basePowerConsumption>175</basePowerConsumption>
 				<shortCircuitInRain>true</shortCircuitInRain>
 			</li>
+				<li Class="SK.CompProperties_LowIdleDraw">
+                                <compClass>SK.CompPowerLowIdleDraw</compClass>
+                                <idlePowerFactor>0.1</idlePowerFactor>
+                        </li>
 			<li Class="CompProperties_Breakdownable"/>
 			<li Class="CompProperties_Flickable"/>
 		</comps>
@@ -432,15 +436,15 @@
 			<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 
+				<li Class="SK.CompProperties_LowIdleDraw">
+                                <compClass>SK.CompPowerLowIdleDraw</compClass>
+                                <idlePowerFactor>0.0</idlePowerFactor>
+                        </li>
 			<li Class="CompProperties_Power">
 				<compClass>CompPowerTrader</compClass>
 				<basePowerConsumption>1200</basePowerConsumption>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>15</heatPerSecond>
-			</li>
-			<li Class="Rimefeller.CompProperties_CrudeCracker">
+		<li Class="Rimefeller.CompProperties_CrudeCracker">
 				<GizmoLabel>Power mode</GizmoLabel>
 				<ProducedPerSecond>0.25</ProducedPerSecond>
 			</li>

--- a/Mods/Rimefeller_SK/Defs/ThingDefs_Buildings/BuildingsB_Refining.xml
+++ b/Mods/Rimefeller_SK/Defs/ThingDefs_Buildings/BuildingsB_Refining.xml
@@ -207,11 +207,7 @@
 			<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>
 
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>6</heatPerSecond>
-			</li>
-			<li Class="CompProperties_Explosive">
+		<li Class="CompProperties_Explosive">
 				<explosiveRadius>8</explosiveRadius>
 				<explosiveDamageType>Flame</explosiveDamageType>
 				<destroyThingOnExplosionSize>2</destroyThingOnExplosionSize>
@@ -254,11 +250,12 @@
 				<compClass>CompPowerTrader</compClass>
 				<basePowerConsumption>1000</basePowerConsumption>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>6</heatPerSecond>
-			</li>
-			<li Class="Rimefeller.CompProperties_Refinery">       
+				<li Class="SK.CompProperties_LowIdleDraw">
+                                <compClass>SK.CompPowerLowIdleDraw</compClass>
+                                <idlePowerFactor>0.0</idlePowerFactor>
+                        </li>
+
+		<li Class="Rimefeller.CompProperties_Refinery">       
 				<compClass>Rimefeller.CompRefineryPolymer</compClass>
 				<Product>Polymers</Product>
 				<StackSize>20</StackSize>
@@ -447,11 +444,11 @@
 				<compClass>CompPowerTrader</compClass>
 				<basePowerConsumption>1000</basePowerConsumption>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>7</heatPerSecond>
-			</li>
-			<li Class="Rimefeller.CompProperties_Refinery">
+	       <li Class="SK.CompProperties_LowIdleDraw">
+                                <compClass>SK.CompPowerLowIdleDraw</compClass>
+                                <idlePowerFactor>0.0</idlePowerFactor>
+                        </li>
+	<li Class="Rimefeller.CompProperties_Refinery">
 				<compClass>Rimefeller.CompRefineryNeutro</compClass>
 				<Product>Paraffins</Product>
 				<StackSize>5</StackSize>
@@ -487,11 +484,11 @@
 				<compClass>CompPowerTrader</compClass>
 				<basePowerConsumption>1000</basePowerConsumption>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>6</heatPerSecond>
-			</li>
-			<li Class="Rimefeller.CompProperties_Refinery">
+	       <li Class="SK.CompProperties_LowIdleDraw">
+                                <compClass>SK.CompPowerLowIdleDraw</compClass>
+                                <idlePowerFactor>0.0</idlePowerFactor>
+                        </li>
+	<li Class="Rimefeller.CompProperties_Refinery">
 				<compClass>Rimefeller.CompRefineryNapalm</compClass>
 				<Product>Sulphates</Product>
 				<StackSize>10</StackSize>
@@ -528,11 +525,11 @@
 				<compClass>CompPowerTrader</compClass>
 				<basePowerConsumption>1200</basePowerConsumption>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>5</heatPerSecond>
-			</li>
-			<li Class="Rimefeller.CompProperties_Refinery">
+	       <li Class="SK.CompProperties_LowIdleDraw">
+                                <compClass>SK.CompPowerLowIdleDraw</compClass>
+                                <idlePowerFactor>0.0</idlePowerFactor>
+                        </li>
+	<li Class="Rimefeller.CompProperties_Refinery">
 				<compClass>Rimefeller.CompRefineryNeutro</compClass>
 				<Product>SyntheticAmmonia</Product>
 				<StackSize>2</StackSize>


### PR DESCRIPTION
* Junk most of the heatpushers of non-heater buildings: they provide OP heat and stupid extra heat which game does not handle well.
* Set idlePowerFactors to 0.0, since power can be kludged with automation anyway
* Cut down power consumption  of penetrating mineral scanner: it's really only useful when manned, and idlePower does not work for it.