### PR TITLE
Trade tags fix

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Items/Items_Fluffy.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Items/Items_Fluffy.xml
@@ -26,7 +26,7 @@
 		<tickerType>Normal</tickerType>
 		<category>Item</category>
 		<tradeTags>
-			<li>TechHediff</li>
+			<li>Exotic</li>
 		</tradeTags>
 		<thingCategories>
 			<li>BodyParts</li>
@@ -44,7 +44,7 @@
 			<MaxHitPoints>100</MaxHitPoints>
 			<Flammability>1</Flammability>
 			<DeteriorationRate>1</DeteriorationRate>
-			<MarketValue>4000</MarketValue>
+			<MarketValue>1500</MarketValue>
 			<Bulk>7</Bulk>
 			<Mass>4</Mass>
 		</statBases>
@@ -76,7 +76,7 @@
 		<tickerType>Normal</tickerType>
 		<category>Item</category>
 		<tradeTags>
-			<li>TechHediff</li>
+			<li>Exotic</li>
 		</tradeTags>
 		<thingCategories>
 			<li>BodyParts</li>
@@ -94,7 +94,7 @@
 			<MaxHitPoints>100</MaxHitPoints>
 			<Flammability>0</Flammability>
 			<DeteriorationRate>1</DeteriorationRate>
-			<MarketValue>4000</MarketValue>
+			<MarketValue>1500</MarketValue>
 			<Bulk>7</Bulk>
 			<Mass>4</Mass>
 		</statBases>

--- a/Mods/Core_SK/Defs/TraderKindDefs/TraderKinds_Caravan_Outlander_Exotic.xml
+++ b/Mods/Core_SK/Defs/TraderKindDefs/TraderKinds_Caravan_Outlander_Exotic.xml
@@ -1,36 +1,36 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-  <TraderKindDef>
-	<defName>Caravan_Outlander_Exotic</defName>
-    <label>exotic goods trader</label>
-	<commonality>1</commonality>
-    <stockGenerators>
-      <li Class="StockGenerator_SingleDef">
-        <thingDef>Silver</thingDef>
-        <countRange>1500~2800</countRange>
-      </li>
-      <li Class="StockGenerator_SingleDef">
-        <thingDef>ComponentSpacer</thingDef>
-        <countRange>12~30</countRange>
-      </li>
-      <li Class="StockGenerator_SingleDef">
-        <thingDef>ComponentAdvanced</thingDef>
-        <countRange>15~45</countRange>
-      </li>
-      <li Class="StockGenerator_SingleDef">
-        <thingDef>Gold</thingDef>
-        <countRange>20~80</countRange>
-      </li>
-      <li Class="StockGenerator_SingleDef">
-        <thingDef>MedicineUltratech</thingDef>
-        <countRange>-5~8</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>Exotic</tradeTag>
-        <thingDefCountRange>2~6</thingDefCountRange>
-        <countRange>1~3</countRange>
-      </li>
+	<TraderKindDef>
+		<defName>Caravan_Outlander_Exotic</defName>
+		<label>exotic goods trader</label>
+		<commonality>1</commonality>
+		<stockGenerators>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>Silver</thingDef>
+				<countRange>1500~2800</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>ComponentSpacer</thingDef>
+				<countRange>12~30</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>ComponentAdvanced</thingDef>
+				<countRange>15~45</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>Gold</thingDef>
+				<countRange>20~80</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>MedicineUltratech</thingDef>
+				<countRange>-5~8</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>Exotic</tradeTag>
+				<thingDefCountRange>2~6</thingDefCountRange>
+				<countRange>1~3</countRange>
+			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>Alcohol</categoryDef>
 				<totalPriceRange>-300~300</totalPriceRange>
@@ -66,36 +66,41 @@
 				<price>Expensive</price>
 				<totalPriceRange>140~300</totalPriceRange>
 			</li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>RareCrate</tradeTag>
-        <thingDefCountRange>-3~2</thingDefCountRange>
-        <countRange>1~2</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>NormalCrate</tradeTag>
-        <thingDefCountRange>-2~2</thingDefCountRange>
-        <countRange>1~3</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>SimpleCrate</tradeTag>
-        <thingDefCountRange>1~3</thingDefCountRange>
-        <countRange>1~5</countRange>
-      </li>
-      <li Class="StockGenerator_Animals">
-        <checkTemperature>true</checkTemperature>
-        <tradeTagsSell>
-          <li>AnimalFighter</li>
-		  <li>AnimalExotic</li>
-        </tradeTagsSell>
-        <tradeTagsBuy>
-			<li>AnimalCommon</li>
-          <li>AnimalFighter</li>
-          <li>AnimalExotic</li>
-        </tradeTagsBuy>
-        <kindCountRange>1~2</kindCountRange>
-        <countRange>2~6</countRange>
-      </li>
-     <li Class="StockGenerator_Category">
+			<li Class="StockGenerator_Tag">
+				<tradeTag>RareCrate</tradeTag>
+				<thingDefCountRange>-3~2</thingDefCountRange>
+				<countRange>1~2</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>NormalCrate</tradeTag>
+				<thingDefCountRange>-2~2</thingDefCountRange>
+				<countRange>1~3</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>SimpleCrate</tradeTag>
+				<thingDefCountRange>1~3</thingDefCountRange>
+				<countRange>1~5</countRange>
+			</li>
+			<li Class="StockGenerator_Animals">
+				<checkTemperature>true</checkTemperature>
+				<tradeTagsSell>
+					<li>AnimalFighter</li>
+					<li>AnimalExotic</li>
+				</tradeTagsSell>
+				<tradeTagsBuy>
+					<li>AnimalCommon</li>
+					<li>AnimalFighter</li>
+					<li>AnimalExotic</li>
+				</tradeTagsBuy>
+				<kindCountRange>1~2</kindCountRange>
+				<countRange>2~6</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>TechHediff</tradeTag>
+				<thingDefCountRange>2~4</thingDefCountRange>
+				<countRange>1~1</countRange>
+			</li>
+			<li Class="StockGenerator_Category">
 				<categoryDef>SyntheticOrgans</categoryDef>
 				<thingDefCountRange>-1~3</thingDefCountRange>
 				<countRange>1~2</countRange>
@@ -120,51 +125,56 @@
 				<thingDefCountRange>0~4</thingDefCountRange>
 				<countRange>-1~2</countRange>
 			</li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>Artifact</tradeTag>
-        <thingDefCountRange>1~2</thingDefCountRange>
-        <countRange>1~1</countRange>
-      </li>
-      <li Class="StockGenerator_Category">
-        <categoryDef>Apparel</categoryDef>
-        <thingDefCountRange>1~2</thingDefCountRange>
-        <totalPriceRange>1100~2200</totalPriceRange>
-        <countRange>1~2</countRange>
-      </li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>Artifact</tradeTag>
+				<thingDefCountRange>1~2</thingDefCountRange>
+				<countRange>1~1</countRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>Apparel</categoryDef>
+				<thingDefCountRange>1~2</thingDefCountRange>
+				<totalPriceRange>1100~2200</totalPriceRange>
+				<countRange>1~2</countRange>
+			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>CookingSupplies</categoryDef>
 				<thingDefCountRange>1~3</thingDefCountRange>
 				<totalPriceRange>120~400</totalPriceRange>
 			</li>
-      <li Class="StockGenerator_Art">
-        <countRange>1~2</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>Television</tradeTag>
-        <thingDefCountRange>1~2</thingDefCountRange>
-        <countRange>-2~2</countRange>
-      </li>
-      <li Class="StockGenerator_SingleDef">
-        <thingDef>Telescope</thingDef>
-        <countRange>-2~2</countRange>
-      </li>
-      <li Class="StockGenerator_Animals">
-        <checkTemperature>true</checkTemperature>
-        <tradeTagsSell>
-          <li>AnimalFighter</li>
-		  <li>AnimalExotic</li>
-        </tradeTagsSell>
-        <tradeTagsBuy>
-			<li>AnimalCommon</li>
-          <li>AnimalFighter</li>
-          <li>AnimalExotic</li>
-        </tradeTagsBuy>
-        <minWildness>0.60</minWildness>
-        <kindCountRange>1~3</kindCountRange>
-        <countRange>2~6</countRange>
-      </li>
-      <!--<li Class="StockGenerator_BuyWeirdOrganic" />-->
-    </stockGenerators>
-  </TraderKindDef>
-	
+			<li Class="StockGenerator_Art">
+				<countRange>1~2</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>Television</tradeTag>
+				<thingDefCountRange>1~2</thingDefCountRange>
+				<countRange>-2~2</countRange>
+			</li>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>Telescope</thingDef>
+				<countRange>-2~2</countRange>
+			</li>
+			<li Class="StockGenerator_Animals">
+				<checkTemperature>true</checkTemperature>
+				<tradeTagsSell>
+					<li>AnimalFighter</li>
+					<li>AnimalExotic</li>
+				</tradeTagsSell>
+				<tradeTagsBuy>
+					<li>AnimalCommon</li>
+					<li>AnimalFighter</li>
+					<li>AnimalExotic</li>
+				</tradeTagsBuy>
+				<minWildness>0.60</minWildness>
+				<kindCountRange>1~3</kindCountRange>
+				<countRange>2~6</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>ExoticMisc</tradeTag>
+				<thingDefCountRange>1~2</thingDefCountRange>
+				<countRange>1</countRange>
+			</li>
+			<!--<li Class="StockGenerator_BuyWeirdOrganic" />-->
+		</stockGenerators>
+	</TraderKindDef>
+
 </Defs>

--- a/Mods/Core_SK/Defs/TraderKindDefs/TraderKinds_Orbital_ExoticTrader.xml
+++ b/Mods/Core_SK/Defs/TraderKindDefs/TraderKinds_Orbital_ExoticTrader.xml
@@ -68,6 +68,11 @@
 				<thingDef>MedicineUltratech</thingDef>
 				<countRange>-30~20</countRange>
 			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>TechHediff</tradeTag>
+				<thingDefCountRange>2~4</thingDefCountRange>
+				<countRange>1~1</countRange>
+			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>HTextiles</categoryDef>
 				<thingDefCountRange>1~2</thingDefCountRange>
@@ -156,6 +161,11 @@
 				<categoryDef>Leathers</categoryDef>
 				<thingDefCountRange>2~4</thingDefCountRange>
 				<totalPriceRange>600~2200</totalPriceRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>ExoticMisc</tradeTag>
+				<thingDefCountRange>1~2</thingDefCountRange>
+				<countRange>1</countRange>
 			</li>
 			<!--<li Class="StockGenerator_BuyWeirdOrganic" />-->
 		</stockGenerators>

--- a/Mods/Core_SK/Defs/TraderKindDefs/TraderKinds_Orbital_PirateMerchant.xml
+++ b/Mods/Core_SK/Defs/TraderKindDefs/TraderKinds_Orbital_PirateMerchant.xml
@@ -4,37 +4,37 @@
 	<!--========================= Pirate merchant =============================-->
 
 
-  <TraderKindDef>
-    <defName>Orbital_PirateMerchant</defName>
-    <label>Pirate Merchant</label>
-	<commonality>1</commonality>
-	<orbital>true</orbital>
-    <stockGenerators>
-      <li Class="StockGenerator_SingleDef">
-        <thingDef>Silver</thingDef>
-        <countRange>6000~12000</countRange>
-      </li>
-      <li Class="StockGenerator_Slaves">
-        <countRange>2~3</countRange>
-      </li>
-      <li Class="StockGenerator_Category">
-        <categoryDef>WeaponsRanged</categoryDef>
-		<thingDefCountRange>2~4</thingDefCountRange>
+	<TraderKindDef>
+		<defName>Orbital_PirateMerchant</defName>
+		<label>Pirate Merchant</label>
+		<commonality>1</commonality>
+		<orbital>true</orbital>
+		<stockGenerators>
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>Silver</thingDef>
+				<countRange>6000~12000</countRange>
+			</li>
+			<li Class="StockGenerator_Slaves">
+				<countRange>2~3</countRange>
+			</li>
+			<li Class="StockGenerator_Category">
+				<categoryDef>WeaponsRanged</categoryDef>
+				<thingDefCountRange>2~4</thingDefCountRange>
 				<totalPriceRange>400~3000</totalPriceRange>
 				<countRange>1~3</countRange>
-      </li>
+			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>WeaponsMelee</categoryDef>
 				<thingDefCountRange>2~4</thingDefCountRange>
 				<totalPriceRange>400~1500</totalPriceRange>
 				<countRange>1~3</countRange>
 			</li>
-      <li Class="StockGenerator_Category">
-	  <categoryDef>FullArmorCat</categoryDef>
+			<li Class="StockGenerator_Category">
+				<categoryDef>FullArmorCat</categoryDef>
 				<thingDefCountRange>4~10</thingDefCountRange>
 				<totalPriceRange>500~5000</totalPriceRange>
 				<countRange>1~5</countRange>
-      </li>
+			</li>
 			<li Class="StockGenerator_Category">
 				<categoryDef>Alcohol</categoryDef>
 				<totalPriceRange>-300~300</totalPriceRange>
@@ -43,7 +43,7 @@
 				<categoryDef>Drugs</categoryDef>
 				<totalPriceRange>-300~300</totalPriceRange>
 			</li>
-				<li Class="StockGenerator_SingleDef">
+			<li Class="StockGenerator_SingleDef">
 				<thingDef>Luciferium</thingDef>
 				<price>Expensive</price>
 				<countRange>-20~13</countRange>
@@ -66,55 +66,60 @@
 				<price>Expensive</price>
 				<totalPriceRange>700~1200</totalPriceRange>
 			</li>
-      <li Class="StockGenerator_SingleDef">
-        <thingDef>MedicineIndustrial</thingDef>
-        <price>Expensive</price>
-        <countRange>5~15</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>BodyPartOrImplant</tradeTag>
-        <thingDefCountRange>-4~8</thingDefCountRange>
-        <countRange>1~1</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>Implant</tradeTag>
-        <thingDefCountRange>-3~6</thingDefCountRange>
-        <countRange>1~1</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>BodyPartsBionic</tradeTag>
-        <price>Expensive</price>
-        <thingDefCountRange>-4~6</thingDefCountRange>
-        <countRange>1~3</countRange>
-      </li>
-	  	<li Class="StockGenerator_Category">
+			<li Class="StockGenerator_SingleDef">
+				<thingDef>MedicineIndustrial</thingDef>
+				<price>Expensive</price>
+				<countRange>5~15</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>TechHediff</tradeTag>
+				<thingDefCountRange>1~2</thingDefCountRange>
+				<countRange>1~1</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>BodyPartOrImplant</tradeTag>
+				<thingDefCountRange>-4~8</thingDefCountRange>
+				<countRange>1~1</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>Implant</tradeTag>
+				<thingDefCountRange>-3~6</thingDefCountRange>
+				<countRange>1~1</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>BodyPartsBionic</tradeTag>
+				<price>Expensive</price>
+				<thingDefCountRange>-4~6</thingDefCountRange>
+				<countRange>1~3</countRange>
+			</li>
+			<li Class="StockGenerator_Category">
 				<categoryDef>BodyPartsNatural</categoryDef>
 				<thingDefCountRange>1~3</thingDefCountRange>
 				<countRange>-2~2</countRange>
 			</li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>Artifact</tradeTag>
-        <thingDefCountRange>-5~1</thingDefCountRange>
-        <countRange>1~1</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>RareCrate</tradeTag>
-        <thingDefCountRange>-3~3</thingDefCountRange>
-        <countRange>1~3</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>NormalCrate</tradeTag>
-        <thingDefCountRange>-2~5</thingDefCountRange>
-        <countRange>3~8</countRange>
-      </li>
-      <li Class="StockGenerator_Tag">
-        <tradeTag>SimpleCrate</tradeTag>
-        <thingDefCountRange>1~8</thingDefCountRange>
-        <countRange>3~8</countRange>
-      </li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>Artifact</tradeTag>
+				<thingDefCountRange>-5~1</thingDefCountRange>
+				<countRange>1~1</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>RareCrate</tradeTag>
+				<thingDefCountRange>-3~3</thingDefCountRange>
+				<countRange>1~3</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>NormalCrate</tradeTag>
+				<thingDefCountRange>-2~5</thingDefCountRange>
+				<countRange>3~8</countRange>
+			</li>
+			<li Class="StockGenerator_Tag">
+				<tradeTag>SimpleCrate</tradeTag>
+				<thingDefCountRange>1~8</thingDefCountRange>
+				<countRange>3~8</countRange>
+			</li>
 			<!--<li Class="StockGenerator_BuyWeirdOrganic" />-->
-    </stockGenerators>
-  </TraderKindDef>
+		</stockGenerators>
+	</TraderKindDef>
 
 
 </Defs>


### PR DESCRIPTION
- changed trade tags on kirin and fenix hearts to make them tradable (nerfed their cost to account for the change)
- added a few missing tags from vanilla caravans mainly to maintain compatibility with other mods and give their items a chance to appear in hcsk caravans (also probably a few interesting things will become tradable)

- добавил теги для покупки/продажи сердец кирина и феникса, сильно снизил стоимость сердец т.к. сами существа не то что бы очень сильные, а предметы не очень то и ценные
- добавил теги для торговли из ванили, многие моды их используют, а из за того что в хск в караванах используется своё распределение - многие предметы никогда не появляются у торговцев, тесты не выявили каких то серьёзных сдвигов в ассортименте