### PR TITLE
Ammo naming adjustments

### DIFF
--- a/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Advanced.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Advanced.xml
@@ -3,13 +3,13 @@
 
 	<!-- ==================== 30x64mm Fuel Cell ========================== -->
 
-	<Ammo_30x64mmFuel_Incendiary.label>30x64 мм граната Зажигательная (I)</Ammo_30x64mmFuel_Incendiary.label>
+	<Ammo_30x64mmFuel_Incendiary.label>30x64 мм граната (I)</Ammo_30x64mmFuel_Incendiary.label>
 	<Ammo_30x64mmFuel_Incendiary.description>Боеприпас для ручного гранатомёта "Солнцепёк".</Ammo_30x64mmFuel_Incendiary.description>
 
-	<Ammo_30x64mmFuel_Thermobaric.label>30x64 мм граната Термобарическая (T)</Ammo_30x64mmFuel_Thermobaric.label>
+	<Ammo_30x64mmFuel_Thermobaric.label>30x64 мм граната (T)</Ammo_30x64mmFuel_Thermobaric.label>
 	<Ammo_30x64mmFuel_Thermobaric.description>Боеприпас для ручного гранатомёта "Солнцепёк".</Ammo_30x64mmFuel_Thermobaric.description>
 
-	<Ammo_30x64mmFuel_Foam.label>30x64 мм граната Пена (Foam)</Ammo_30x64mmFuel_Foam.label>
+	<Ammo_30x64mmFuel_Foam.label>30x64 мм граната (Foam)</Ammo_30x64mmFuel_Foam.label>
 	<Ammo_30x64mmFuel_Foam.description>Боеприпас для ручного гранатомёта "Солнцепёк".</Ammo_30x64mmFuel_Foam.description>
 	
 	
@@ -19,7 +19,7 @@
 
 	<!-- ==================== 80x256mm Fuel Cell ========================== -->
 
-	<Ammo_80x256mmFuel_Thermobaric.label>80x256 мм ракета Термобарическая (T)</Ammo_80x256mmFuel_Thermobaric.label>
+	<Ammo_80x256mmFuel_Thermobaric.label>80x256 мм ракета (T)</Ammo_80x256mmFuel_Thermobaric.label>
 	<Ammo_80x256mmFuel_Thermobaric.description>Чрезвычайно мощный боеприпас для тяжелой ракетницы огров.</Ammo_80x256mmFuel_Thermobaric.description>
 	
 	
@@ -27,13 +27,13 @@
 
 	<!-- ==================== 6x24mm Charged ========================== -->
 	
-	<Ammo_6x24mmCharged.label>6x24 мм энерго-боеприпас (CPK)</Ammo_6x24mmCharged.label>
+	<Ammo_6x24mmCharged.label>6x24 мм (CPK)</Ammo_6x24mmCharged.label>
 	<Ammo_6x24mmCharged.description>6x24 мм - высокотехнологичный боеприпас, пуля которого покрыта плёнкой заряженных частиц. \nИспользуется в различных продвинутых снайперских винтовках.</Ammo_6x24mmCharged.description>
 
-	<Ammo_6x24mmCharged_AP.label>6x24 мм энерго-боеприпас Бронебойный (AP)</Ammo_6x24mmCharged_AP.label>
+	<Ammo_6x24mmCharged_AP.label>6x24 мм (AP)</Ammo_6x24mmCharged_AP.label>
 	<Ammo_6x24mmCharged_AP.description>6x24 мм - высокотехнологичный боеприпас, пуля которого покрыта плёнкой заряженных частиц. \nИспользуется в различных продвинутых снайперских винтовках.</Ammo_6x24mmCharged_AP.description>
 
-	<Ammo_6x24mmCharged_Ion.label>6x24 мм энерго-боеприпас Ионизированный (Ion)</Ammo_6x24mmCharged_Ion.label>
+	<Ammo_6x24mmCharged_Ion.label>6x24 мм (Ion)</Ammo_6x24mmCharged_Ion.label>
 	<Ammo_6x24mmCharged_Ion.description>6x24 мм - высокотехнологичный боеприпас, пуля которого покрыта плёнкой заряженных частиц. \nИспользуется в различных продвинутых снайперских винтовках.</Ammo_6x24mmCharged_Ion.description>
 	
 	
@@ -43,7 +43,7 @@
 		
 	<!-- ==================== 12x64mm Charged ========================== -->
 	
-	<Ammo_12x64mmCharged.label>12x64 мм энерго-боеприпас (CPK)</Ammo_12x64mmCharged.label>
+	<Ammo_12x64mmCharged.label>12x64 мм (CPK)</Ammo_12x64mmCharged.label>
 	<Ammo_12x64mmCharged.description>12x64 мм - высокотехнологичный боеприпас, пуля которого покрыта плёнкой заряженных частиц. \nБыл разработан роем механоидов для применения в крупнокалиберном тяжелом вооружении.</Ammo_12x64mmCharged.description>
 	
 	
@@ -51,7 +51,7 @@
 	
 	<!-- ==================== 15x65mm Diffusing Charged ========================== -->
 	
-	<Ammo_15x65mmDiffusingCharged_Buck.label>15x65 мм энерго-боеприпас (Buck)</Ammo_15x65mmDiffusingCharged_Buck.label>
+	<Ammo_15x65mmDiffusingCharged_Buck.label>15x65 мм (Buck)</Ammo_15x65mmDiffusingCharged_Buck.label>
 	<Ammo_15x65mmDiffusingCharged_Buck.description>15x65 мм - картечный боеприпас, разработанный роем механоидов. \nКартечь этого патрона наряду с кинетическим воздействием наносит урон потоком заряженных частиц.</Ammo_15x65mmDiffusingCharged_Buck.description>
 	
 	

--- a/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Grenades.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Grenades.xml
@@ -3,10 +3,10 @@
 
 	<!-- ==================== 30x29mm Grenades ========================== -->
 	
-	<Ammo_30x29mmGrenade_HE.label>30x29 мм граната Фугасная (HE)</Ammo_30x29mmGrenade_HE.label>
+	<Ammo_30x29mmGrenade_HE.label>30x29 мм граната (HE)</Ammo_30x29mmGrenade_HE.label>
 	<Ammo_30x29mmGrenade_HE.description>Довольно маленькая и относительно медленная граната, используемая в различных стационарных гранатомётах.</Ammo_30x29mmGrenade_HE.description>
 
-	<Ammo_30x29mmGrenade_EMP.label>30x29 мм граната Электромагнитная (EMP)</Ammo_30x29mmGrenade_EMP.label>
+	<Ammo_30x29mmGrenade_EMP.label>30x29 мм граната (EMP)</Ammo_30x29mmGrenade_EMP.label>
 	<Ammo_30x29mmGrenade_EMP.description>Довольно маленькая и относительно медленная граната, используемая в различных стационарных гранатомётах.</Ammo_30x29mmGrenade_EMP.description>
 
 	
@@ -15,10 +15,10 @@
 	
 	<!-- ==================== 40x46mm Grenade ========================== -->
 	
-	<Ammo_40x46mmGrenade_HE.label>40x46 мм граната Фугасная (HE)</Ammo_40x46mmGrenade_HE.label>
+	<Ammo_40x46mmGrenade_HE.label>40x46 мм граната (HE)</Ammo_40x46mmGrenade_HE.label>
 	<Ammo_40x46mmGrenade_HE.description>Относительно медленная граната, используемая в различных ручных гранатомётах.</Ammo_40x46mmGrenade_HE.description>
 
-	<Ammo_40x46mmGrenade_EMP.label>40x46 мм граната Электромагнитная (EMP)</Ammo_40x46mmGrenade_EMP.label>
+	<Ammo_40x46mmGrenade_EMP.label>40x46 мм граната (EMP)</Ammo_40x46mmGrenade_EMP.label>
 	<Ammo_40x46mmGrenade_EMP.description>Относительно медленная граната, используемая в различных ручных гранатомётах.</Ammo_40x46mmGrenade_EMP.description>
 	
 		

--- a/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_HighCaliber.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_HighCaliber.xml
@@ -3,16 +3,16 @@
 
 	<!-- ==================== .50 BMG ========================== -->
 
-	<Ammo_50BMG_FMJ.label>.50 BMG Оболочечный (FMJ)</Ammo_50BMG_FMJ.label>
+	<Ammo_50BMG_FMJ.label>.50 BMG (FMJ)</Ammo_50BMG_FMJ.label>
 	<Ammo_50BMG_FMJ.description>.50 BMG — крупнокалиберный патрон армий НАТО. Он был создан в качестве боеприпаса для тяжелых пулемётов и крупнокалиберных снайперских винтовок (AMR).</Ammo_50BMG_FMJ.description>
 
-	<Ammo_50BMG_Sabot.label>.50 BMG Подкалиберный (Sabot)</Ammo_50BMG_Sabot.label>
+	<Ammo_50BMG_Sabot.label>.50 BMG (Sabot)</Ammo_50BMG_Sabot.label>
 	<Ammo_50BMG_Sabot.description>.50 BMG — крупнокалиберный патрон армий НАТО. Он был создан в качестве боеприпаса для тяжелых пулемётов и крупнокалиберных снайперских винтовок (AMR).</Ammo_50BMG_Sabot.description>
 
-	<Ammo_50BMG_HE.label>.50 BMG Бронебойно-фугасный (HESH)</Ammo_50BMG_HE.label>
+	<Ammo_50BMG_HE.label>.50 BMG (HESH)</Ammo_50BMG_HE.label>
 	<Ammo_50BMG_HE.description>.50 BMG — крупнокалиберный патрон армий НАТО. Он был создан в качестве боеприпаса для тяжелых пулемётов и крупнокалиберных снайперских винтовок (AMR).</Ammo_50BMG_HE.description>
 
-	<Ammo_50BMG_Incendiary.label>.50 BMG Зажигательно-бронебойный (AP-I)</Ammo_50BMG_Incendiary.label>
+	<Ammo_50BMG_Incendiary.label>.50 BMG (AP-I)</Ammo_50BMG_Incendiary.label>
 	<Ammo_50BMG_Incendiary.description>.50 BMG — крупнокалиберный патрон армий НАТО. Он был создан в качестве боеприпаса для тяжелых пулемётов и крупнокалиберных снайперских винтовок (AMR).</Ammo_50BMG_Incendiary.description>
 
 	
@@ -23,13 +23,13 @@
 			
 	<!-- ==================== 14.5x114mm ========================== -->
 
-	<Ammo_145x114mm_FMJ.label>14.5x114 мм Оболочечный (FMJ)</Ammo_145x114mm_FMJ.label>
+	<Ammo_145x114mm_FMJ.label>14.5x114 мм (FMJ)</Ammo_145x114mm_FMJ.label>
 	<Ammo_145x114mm_FMJ.description>Старый и проверенный противотанковый патрон предназначенный для АТ винтовок и различных тяжёлых пулемётов.</Ammo_145x114mm_FMJ.description>
 
-	<Ammo_145x114mm_HE.label>14.5x114 мм Бронебойно-фугасный (HESH)</Ammo_145x114mm_HE.label>
+	<Ammo_145x114mm_HE.label>14.5x114 мм (HESH)</Ammo_145x114mm_HE.label>
 	<Ammo_145x114mm_HE.description>Старый и проверенный противотанковый патрон предназначенный для АТ винтовок и различных тяжёлых пулемётов.</Ammo_145x114mm_HE.description>
 
-	<Ammo_145x114mm_Incendiary.label>14.5x114 мм Зажигательно-бронебойный (AP-I)</Ammo_145x114mm_Incendiary.label>
+	<Ammo_145x114mm_Incendiary.label>14.5x114 мм (AP-I)</Ammo_145x114mm_Incendiary.label>
 	<Ammo_145x114mm_Incendiary.description>Старый и проверенный противотанковый патрон предназначенный для АТ винтовок и различных тяжёлых пулемётов.</Ammo_145x114mm_Incendiary.description>
 	
 	
@@ -39,13 +39,13 @@
 		
 	<!-- ==================== 20x102mm ========================== -->
 	
-	<Ammo_20x102mm_FMJ.label>20x102 мм Оболочечный (FMJ)</Ammo_20x102mm_FMJ.label>
+	<Ammo_20x102mm_FMJ.label>20x102 мм (FMJ)</Ammo_20x102mm_FMJ.label>
 	<Ammo_20x102mm_FMJ.description>20x102 мм - боеприпасы этого калибра используются для автоматической артиллерии и некоторых пушек.</Ammo_20x102mm_FMJ.description>
 	
-	<Ammo_20x102mm_HE.label>20x102 мм Бронебойно-фугасный (HESH)</Ammo_20x102mm_HE.label>
+	<Ammo_20x102mm_HE.label>20x102 мм (HESH)</Ammo_20x102mm_HE.label>
 	<Ammo_20x102mm_HE.description>20x102 мм - боеприпасы этого калибра используются для автоматической артиллерии и некоторых пушек.</Ammo_20x102mm_HE.description>
 	
-	<Ammo_20x102mm_Incendiary.label>20x102 мм Зажигательно-бронебойный (AP-I)</Ammo_20x102mm_Incendiary.label>
+	<Ammo_20x102mm_Incendiary.label>20x102 мм (AP-I)</Ammo_20x102mm_Incendiary.label>
 	<Ammo_20x102mm_Incendiary.description>20x102 мм - боеприпасы этого калибра используются для автоматической артиллерии и некоторых пушек.</Ammo_20x102mm_Incendiary.description>
 	
 	
@@ -55,13 +55,13 @@
 	
 	<!-- ==================== 30x165mm Soviet ========================== -->
 	
-	<Ammo_30x165mm_FMJ.label>30x165 мм Soviet Оболочечный (FMJ)</Ammo_30x165mm_FMJ.label>
+	<Ammo_30x165mm_FMJ.label>30x165 мм Soviet (FMJ)</Ammo_30x165mm_FMJ.label>
 	<Ammo_30x165mm_FMJ.description>30x165 мм - боеприпасы этого калибра используются для автоматической артиллерии и некоторых пушек. \nВ обычных обстоятельствах редко используются для стрельбы по живой силе противника, их назначение - уничтожение бронированных целей и укреплённых укрытий.</Ammo_30x165mm_FMJ.description>
 	
-	<Ammo_30x165mm_HE.label>30x165 мм Soviet Бронебойно-фугасный (HESH)</Ammo_30x165mm_HE.label>
+	<Ammo_30x165mm_HE.label>30x165 мм Soviet (HESH)</Ammo_30x165mm_HE.label>
 	<Ammo_30x165mm_HE.description>30x165 мм - боеприпасы этого калибра используются для автоматической артиллерии и некоторых пушек. \nВ обычных обстоятельствах редко используются для стрельбы по живой силе противника, их назначение - уничтожение бронированных целей и укреплённых укрытий.</Ammo_30x165mm_HE.description>
 	
-	<Ammo_30x165mm_Incendiary.label>30x165 мм Soviet Зажигательно-бронебойный (AP-I)</Ammo_30x165mm_Incendiary.label>
+	<Ammo_30x165mm_Incendiary.label>30x165 мм Soviet (AP-I)</Ammo_30x165mm_Incendiary.label>
 	<Ammo_30x165mm_Incendiary.description>30x165 мм - боеприпасы этого калибра используются для автоматической артиллерии и некоторых пушек. \nВ обычных обстоятельствах редко используются для стрельбы по живой силе противника, их назначение - уничтожение бронированных целей и укреплённых укрытий.</Ammo_30x165mm_Incendiary.description>
 	
 	
@@ -71,13 +71,13 @@
 	
 	<!-- ==================== 30x173mm NATO ========================== -->
 	
-	<Ammo_30x173mm_FMJ.label>30x173 мм NATO Оболочечный (FMJ)</Ammo_30x173mm_FMJ.label>
+	<Ammo_30x173mm_FMJ.label>30x173 мм NATO (FMJ)</Ammo_30x173mm_FMJ.label>
 	<Ammo_30x173mm_FMJ.description>30x173 мм NATO - боеприпасы этого калибра используются для автоматической артиллерии и некоторых пушек. \nВ обычных обстоятельствах редко используются для стрельбы по живой силе противника, их назначение - уничтожение бронированных целей и укреплённых укрытий.</Ammo_30x173mm_FMJ.description>
 	
-	<Ammo_30x173mm_HE.label>30x173 мм NATO Бронебойно-фугасный (HESH)</Ammo_30x173mm_HE.label>
+	<Ammo_30x173mm_HE.label>30x173 мм NATO (HESH)</Ammo_30x173mm_HE.label>
 	<Ammo_30x173mm_HE.description>30x173 мм NATO - боеприпасы этого калибра используются для автоматической артиллерии и некоторых пушек. \nВ обычных обстоятельствах редко используются для стрельбы по живой силе противника, их назначение - уничтожение бронированных целей и укреплённых укрытий.</Ammo_30x173mm_HE.description>
 	
-	<Ammo_30x173mm_Incendiary.label>30x173 мм NATO Зажигательно-бронебойный (AP-I)</Ammo_30x173mm_Incendiary.label>
+	<Ammo_30x173mm_Incendiary.label>30x173 мм NATO (AP-I)</Ammo_30x173mm_Incendiary.label>
 	<Ammo_30x173mm_Incendiary.description>30x173 мм NATO - боеприпасы этого калибра используются для автоматической артиллерии и некоторых пушек. \nВ обычных обстоятельствах редко используются для стрельбы по живой силе противника, их назначение - уничтожение бронированных целей и укреплённых укрытий.</Ammo_30x173mm_Incendiary.description>
 	
 	

--- a/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Pistols.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Pistols.xml
@@ -3,7 +3,7 @@
     
 	<!-- ==================== .40 Rimfire ========================== -->
  
-    <Ammo_40Rimfire.label>.40 Rimfire Оболочечный (FMJ)</Ammo_40Rimfire.label>
+    <Ammo_40Rimfire.label>.40 Rimfire (FMJ)</Ammo_40Rimfire.label>
 	<Ammo_40Rimfire.description>Мелкокалиберный патрон предназначенный для огнестрельного оружия с высоким темпом стрельбы.</Ammo_40Rimfire.description>
 	
 	
@@ -11,13 +11,13 @@
  
 	<!-- ==================== 9x19mm Parabellum ========================== -->
 
-    <Ammo_9x19mmPara_FMJ.label>9x19 мм Para Оболочечный (FMJ)</Ammo_9x19mmPara_FMJ.label>
+    <Ammo_9x19mmPara_FMJ.label>9x19 мм Para (FMJ)</Ammo_9x19mmPara_FMJ.label>
 	<Ammo_9x19mmPara_FMJ.description>Пистолетный унитарный патрон с бесфланцевой гильзой цилиндрической формы с небольшой конусностью, используемый в различных пистолетах и SMG.</Ammo_9x19mmPara_FMJ.description>
  
-    <Ammo_9x19mmPara_AP.label>9x19 мм Para Бронебойный (AP)</Ammo_9x19mmPara_AP.label>
+    <Ammo_9x19mmPara_AP.label>9x19 мм Para (AP)</Ammo_9x19mmPara_AP.label>
 	<Ammo_9x19mmPara_AP.description>Пистолетный унитарный патрон с бесфланцевой гильзой цилиндрической формы с небольшой конусностью, используемый в различных пистолетах и SMG.</Ammo_9x19mmPara_AP.description>
 
-    <Ammo_9x19mmPara_HP.label>9x19 мм Para Экспансивный (HP)</Ammo_9x19mmPara_HP.label>
+    <Ammo_9x19mmPara_HP.label>9x19 мм Para (HP)</Ammo_9x19mmPara_HP.label>
 	<Ammo_9x19mmPara_HP.description>Пистолетный унитарный патрон с бесфланцевой гильзой цилиндрической формы с небольшой конусностью, используемый в различных пистолетах и SMG.</Ammo_9x19mmPara_HP.description>
 	
 	
@@ -27,13 +27,13 @@
 	
 	<!-- ==================== .45 ACP ========================== -->
  
-    <Ammo_45ACP_FMJ.label>.45 ACP Оболочечный (FMJ)</Ammo_45ACP_FMJ.label>
+    <Ammo_45ACP_FMJ.label>.45 ACP (FMJ)</Ammo_45ACP_FMJ.label>
 	<Ammo_45ACP_FMJ.description>Пистолетный унитарный патрон с бесфланцевой гильзой цилиндрической формы и низкой начальной скоростью пули. \nОбладает высокой кучностью стрельбы и хорошим останавливающим действием, но имеет слабую пробивную способность убойность.</Ammo_45ACP_FMJ.description>
  
-    <Ammo_45ACP_AP.label>.45 ACP Бронебойный (AP)</Ammo_45ACP_AP.label>
+    <Ammo_45ACP_AP.label>.45 ACP (AP)</Ammo_45ACP_AP.label>
 	<Ammo_45ACP_AP.description>Пистолетный унитарный патрон с бесфланцевой гильзой цилиндрической формы низкой начальной скоростью пули. \nОбладает высокой кучностью стрельбы и хорошим останавливающим действием, но имеет слабую пробивную способность и убойность.</Ammo_45ACP_AP.description>
  
-    <Ammo_45ACP_HP.label>.45 ACP Экспансивный (HP)</Ammo_45ACP_HP.label>
+    <Ammo_45ACP_HP.label>.45 ACP (HP)</Ammo_45ACP_HP.label>
 	<Ammo_45ACP_HP.description>Пистолетный унитарный патрон с бесфланцевой гильзой цилиндрической формы низкой начальной скоростью пули. \nОбладает высокой кучностью стрельбы и хорошим останавливающим действием, но имеет слабую пробивную способность и убойность.</Ammo_45ACP_HP.description>
 
 	<Bullet_45ACP_FMJ.label>.45 ACP пуля (FMJ)</Bullet_45ACP_FMJ.label>

--- a/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Rifles.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Rifles.xml
@@ -3,13 +3,13 @@
 
 	<!-- ==================== 5.56x45mm NATO ========================== -->
 
-	<Ammo_556x45mmNATO_FMJ.label>5.56x45 мм NATO Оболочечный (FMJ)</Ammo_556x45mmNATO_FMJ.label>
+	<Ammo_556x45mmNATO_FMJ.label>5.56x45 мм NATO (FMJ)</Ammo_556x45mmNATO_FMJ.label>
 	<Ammo_556x45mmNATO_FMJ.description>Малоимпульсный промежуточный патрон с бесфланцевой гильзой бутылочной формы. Создан на основе патрона .223 Remington. Используется в различных штурмовых винтовках.</Ammo_556x45mmNATO_FMJ.description>
 
-	<Ammo_556x45mmNATO_AP.label>5.56x45 мм NATO Бронебойный (AP)</Ammo_556x45mmNATO_AP.label>
+	<Ammo_556x45mmNATO_AP.label>5.56x45 мм NATO (AP)</Ammo_556x45mmNATO_AP.label>
 	<Ammo_556x45mmNATO_AP.description>Малоимпульсный промежуточный патрон с бесфланцевой гильзой бутылочной формы. Создан на основе патрона .223 Remington. Используется в различных штурмовых винтовках.</Ammo_556x45mmNATO_AP.description>
 
-	<Ammo_556x45mmNATO_HP.label>5.56x45 мм NATO Экспансивный (HP)</Ammo_556x45mmNATO_HP.label>
+	<Ammo_556x45mmNATO_HP.label>5.56x45 мм NATO (HP)</Ammo_556x45mmNATO_HP.label>
 	<Ammo_556x45mmNATO_HP.description>Малоимпульсный промежуточный патрон с бесфланцевой гильзой бутылочной формы. Создан на основе патрона .223 Remington. Используется в различных штурмовых винтовках.</Ammo_556x45mmNATO_HP.description>
 	
 	
@@ -19,13 +19,13 @@
 	
 	<!-- ==================== 7.62x39mm Soviet ========================== -->
 
-	<Ammo_762x39mmSoviet_FMJ.label>7.62x39 мм Soviet Оболочечный (FMJ)</Ammo_762x39mmSoviet_FMJ.label>
+	<Ammo_762x39mmSoviet_FMJ.label>7.62x39 мм Soviet (FMJ)</Ammo_762x39mmSoviet_FMJ.label>
 	<Ammo_762x39mmSoviet_FMJ.description>Промежуточный патрон с невыступающей закраиной. Считается третьим по мощности из автоматных патронов в мире. Используется некоторыми винтовками старого образца.</Ammo_762x39mmSoviet_FMJ.description>
 
-	<Ammo_762x39mmSoviet_AP.label>7.62x39 мм Soviet Бронебойный (AP)</Ammo_762x39mmSoviet_AP.label>
+	<Ammo_762x39mmSoviet_AP.label>7.62x39 мм Soviet (AP)</Ammo_762x39mmSoviet_AP.label>
 	<Ammo_762x39mmSoviet_AP.description>Промежуточный патрон с невыступающей закраиной. Считается третьим по мощности из автоматных патронов в мире. Используется некоторыми винтовками старого образца.</Ammo_762x39mmSoviet_AP.description>
 
-	<Ammo_762x39mmSoviet_HP.label>7.62x39 мм Soviet Экспансивный (HP)</Ammo_762x39mmSoviet_HP.label>
+	<Ammo_762x39mmSoviet_HP.label>7.62x39 мм Soviet (HP)</Ammo_762x39mmSoviet_HP.label>
 	<Ammo_762x39mmSoviet_HP.description>Промежуточный патрон с невыступающей закраиной. Считается третьим по мощности из автоматных патронов в мире. Используется некоторыми винтовками старого образца.</Ammo_762x39mmSoviet_HP.description>
 	
 	
@@ -35,13 +35,13 @@
 	
 	<!-- ==================== .303 British ========================== -->
 
-	<Ammo_303British_FMJ.label>.303 British Оболочечный (FMJ)</Ammo_303British_FMJ.label>
+	<Ammo_303British_FMJ.label>.303 British (FMJ)</Ammo_303British_FMJ.label>
 	<Ammo_303British_FMJ.description>Английский винтовочный унитарный патрон с гильзой с выступающей закраиной. Используется некоторыми винтовками старого образца.</Ammo_303British_FMJ.description>
 
-	<Ammo_303British_AP.label>.303 British Бронебойный (AP)</Ammo_303British_AP.label>
+	<Ammo_303British_AP.label>.303 British (AP)</Ammo_303British_AP.label>
 	<Ammo_303British_AP.description>Английский винтовочный унитарный патрон с гильзой с выступающей закраиной. Используется некоторыми винтовками старого образца.</Ammo_303British_AP.description>
 
-	<Ammo_303British_HP.label>.303 British Экспансивный (HP)</Ammo_303British_HP.label>
+	<Ammo_303British_HP.label>.303 British (HP)</Ammo_303British_HP.label>
 	<Ammo_303British_HP.description>Английский винтовочный унитарный патрон с гильзой с выступающей закраиной. Используется некоторыми винтовками старого образца.</Ammo_303British_HP.description>
 	
 	
@@ -51,13 +51,13 @@
 	
 	<!-- ==================== 7.62x51mm NATO ========================== -->
 
-	<Ammo_762x51mmNATO_FMJ.label>7.62x51 мм NATO Оболочечный (FMJ)</Ammo_762x51mmNATO_FMJ.label>
+	<Ammo_762x51mmNATO_FMJ.label>7.62x51 мм NATO (FMJ)</Ammo_762x51mmNATO_FMJ.label>
 	<Ammo_762x51mmNATO_FMJ.description>Стандартный винтовочно-пулемётный боеприпас. Используется в ряде пулёметов, снайперских и штурмовых винтовок.</Ammo_762x51mmNATO_FMJ.description>
 
-	<Ammo_762x51mmNATO_AP.label>7.62x51 мм NATO Бронебойный (AP)</Ammo_762x51mmNATO_AP.label>
+	<Ammo_762x51mmNATO_AP.label>7.62x51 мм NATO (AP)</Ammo_762x51mmNATO_AP.label>
 	<Ammo_762x51mmNATO_AP.description>Стандартный винтовочно-пулемётный боеприпас. Используется в ряде пулёметов, снайперских и штурмовых винтовок.</Ammo_762x51mmNATO_AP.description>
 
-	<Ammo_762x51mmNATO_HP.label>7.62x51 мм NATO Экспансивный (HP)</Ammo_762x51mmNATO_HP.label>
+	<Ammo_762x51mmNATO_HP.label>7.62x51 мм NATO (HP)</Ammo_762x51mmNATO_HP.label>
 	<Ammo_762x51mmNATO_HP.description>Стандартный винтовочно-пулемётный боеприпас. Используется в ряде пулёметов, снайперских и штурмовых винтовок.</Ammo_762x51mmNATO_HP.description>
 	
 	<Bullet_762x51mmNATO_FMJ.label>7.62x51 мм пуля (FMJ)</Bullet_762x51mmNATO_FMJ.label>

--- a/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Rockets.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Rockets.xml
@@ -3,13 +3,13 @@
 
 	<!-- ==================== RPG-7 Grenades ========================== -->
 
-	<Ammo_RPG7Grenade_HEAT.label>РПГ-7 граната Кумулятивный (HEAT)</Ammo_RPG7Grenade_HEAT.label>
+	<Ammo_RPG7Grenade_HEAT.label>РПГ-7 граната (HEAT)</Ammo_RPG7Grenade_HEAT.label>
 	<Ammo_RPG7Grenade_HEAT.description>Ракетоподобная граната разработанная для РПГ-7 гранатомёта.</Ammo_RPG7Grenade_HEAT.description>
 
-	<Ammo_RPG7Grenade_Thermobaric.label>РПГ-7 граната Термобарический (T)</Ammo_RPG7Grenade_Thermobaric.label>
+	<Ammo_RPG7Grenade_Thermobaric.label>РПГ-7 граната (T)</Ammo_RPG7Grenade_Thermobaric.label>
 	<Ammo_RPG7Grenade_Thermobaric.description>Ракетоподобная граната разработанная для РПГ-7 гранатомёта.</Ammo_RPG7Grenade_Thermobaric.description>
 
-	<Ammo_RPG7Grenade_Frag.label>РПГ-7 граната Осколочный (FRAG)</Ammo_RPG7Grenade_Frag.label>
+	<Ammo_RPG7Grenade_Frag.label>РПГ-7 граната (FRAG)</Ammo_RPG7Grenade_Frag.label>
 	<Ammo_RPG7Grenade_Frag.description>Ракетоподобная граната разработанная для РПГ-7 гранатомёта.</Ammo_RPG7Grenade_Frag.description>
 	
 	

--- a/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Shells.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Shells.xml
@@ -3,16 +3,16 @@
 
 	<!-- ==================== 81mm mortar shells ========================== -->
 	
-	<Shell_HighExplosive.label>81 мм миномётный выстрел Фугасный (HE)</Shell_HighExplosive.label>
+	<Shell_HighExplosive.label>81 мм миномётная мина (HE)</Shell_HighExplosive.label>
 	<Shell_HighExplosive.description>Миномётная мина — низкоскоростной оперённый снаряд, предназначенный для стрельбы из миномётов.</Shell_HighExplosive.description>
 	
-	<Shell_Incendiary.label>81 мм миномётная мина Зажигательная (I)</Shell_Incendiary.label>
+	<Shell_Incendiary.label>81 мм миномётная мина (I)</Shell_Incendiary.label>
 	<Shell_Incendiary.description>Миномётная мина — низкоскоростной оперённый снаряд, предназначенный для стрельбы из миномётов.</Shell_Incendiary.description>
 
-	<Shell_EMP.label>81 мм миномётная мина Электромагнитная (EMP)</Shell_EMP.label>
+	<Shell_EMP.label>81 мм миномётная мина (EMP)</Shell_EMP.label>
 	<Shell_EMP.description>Миномётная мина — низкоскоростной оперённый снаряд, предназначенный для стрельбы из миномётов.</Shell_EMP.description>
 	
-	<Shell_Firefoam.label>81 мм миномётная мина Пенная (Firefoam)</Shell_Firefoam.label>
+	<Shell_Firefoam.label>81 мм миномётная мина (Firefoam)</Shell_Firefoam.label>
 	<Shell_Firefoam.description>Миномётная мина — низкоскоростной оперённый снаряд, предназначенный для стрельбы из миномётов.</Shell_Firefoam.description>
 	
 	<Bullet_81mmMortarShell_Incendiary.label>81 мм миномётная мина (I)</Bullet_81mmMortarShell_Incendiary.label>
@@ -20,13 +20,13 @@
 	
 	<!-- ==================== 90mm cannon shells ========================== -->
 
-	<Ammo_90mmCannonShell_HEAT.label>90 мм артиллерийский снаряд Кумулятивный (HEAT)</Ammo_90mmCannonShell_HEAT.label>
+	<Ammo_90mmCannonShell_HEAT.label>90 мм артиллерийский снаряд (HEAT)</Ammo_90mmCannonShell_HEAT.label>
 	<Ammo_90mmCannonShell_HEAT.description>Относительно маленький артиллерийский снаряд, используемый различными пушками.</Ammo_90mmCannonShell_HEAT.description>
 
-	<Ammo_90mmCannonShell_HE.label>90 мм артиллерийский снаряд Фугасный (HE)</Ammo_90mmCannonShell_HE.label>
+	<Ammo_90mmCannonShell_HE.label>90 мм артиллерийский снаряд (HE)</Ammo_90mmCannonShell_HE.label>
 	<Ammo_90mmCannonShell_HE.description>Относительно маленький артиллерийский снаряд, используемый различными пушками.</Ammo_90mmCannonShell_HE.description>
 
-	<Ammo_90mmCannonShell_EMP.label>90 мм артиллерийский снаряд Электромагнитный (EMP)</Ammo_90mmCannonShell_EMP.label>
+	<Ammo_90mmCannonShell_EMP.label>90 мм артиллерийский снаряд (EMP)</Ammo_90mmCannonShell_EMP.label>
 	<Ammo_90mmCannonShell_EMP.description>Относительно маленький артиллерийский снаряд, используемый различными пушками.</Ammo_90mmCannonShell_EMP.description>
 	
 	

--- a/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Shotgun.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/ThingDefs/Ammo_Shotgun.xml
@@ -3,19 +3,19 @@
 
 	<!-- ==================== 12 Gauge ========================== -->
 
-	<Ammo_12Gauge_Buck.label>.12 Картечь (Buck)</Ammo_12Gauge_Buck.label>
+	<Ammo_12Gauge_Buck.label>.12 (Buck)</Ammo_12Gauge_Buck.label>
 	<Ammo_12Gauge_Buck.description>.12 патрон - самый распространённый боеприпас с дробью, используемый в различных дробовиках.</Ammo_12Gauge_Buck.description>
 
-	<Ammo_12Gauge_Bird.label>.12 Дробь (Bird)</Ammo_12Gauge_Bird.label>
+	<Ammo_12Gauge_Bird.label>.12 (Bird)</Ammo_12Gauge_Bird.label>
 	<Ammo_12Gauge_Bird.description>.12 патрон - самый распространённый боеприпас с дробью, используемый в различных дробовиках.</Ammo_12Gauge_Bird.description>
 
-	<Ammo_12Gauge_Slug.label>.12 Пулевой (Slug)</Ammo_12Gauge_Slug.label>
+	<Ammo_12Gauge_Slug.label>.12 (Slug)</Ammo_12Gauge_Slug.label>
 	<Ammo_12Gauge_Slug.description>.12 патрон - самый распространённый боеприпас с дробью, используемый в различных дробовиках.</Ammo_12Gauge_Slug.description>
 
-	<Ammo_12Gauge_Beanbag.label>.12 Мелкая дробь (Beanbag)</Ammo_12Gauge_Beanbag.label>
+	<Ammo_12Gauge_Beanbag.label>.12 (Beanbag)</Ammo_12Gauge_Beanbag.label>
 	<Ammo_12Gauge_Beanbag.description>.12 патрон - самый распространённый боеприпас с дробью, используемый в различных дробовиках.</Ammo_12Gauge_Beanbag.description>
 
-	<Ammo_12Gauge_ElectroSlug.label>.12 Электромагнитный (EMP)</Ammo_12Gauge_ElectroSlug.label>
+	<Ammo_12Gauge_ElectroSlug.label>.12 (EMP)</Ammo_12Gauge_ElectroSlug.label>
 	<Ammo_12Gauge_ElectroSlug.description>.12 патрон - самый распространённый боеприпас с дробью, используемый в различных дробовиках.</Ammo_12Gauge_ElectroSlug.description>
 	
 	<!-- Projectiles -->

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Ammo_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Ammo_SK.xml
@@ -36,7 +36,7 @@
 
 	<!-- ==================== M72 LAW grenades ========================== -->
  
-	<Ammo_M72LAW.label>M72 LAW граната Кумулятивная (HEAT)</Ammo_M72LAW.label> 
+	<Ammo_M72LAW.label>M72 LAW граната (HEAT)</Ammo_M72LAW.label> 
 	<Ammo_M72LAW.description>M72 LAW — американский одноразовый противотанковый гранатомёт.</Ammo_M72LAW.description>
 	
 	
@@ -44,10 +44,10 @@
 	
 	<!-- ==================== AT Missile rounds ========================== -->	
 
-	<Ammo_SPG9Grenade_HEAT.label>СПГ-9 граната Кумулятивная (HEAT)</Ammo_SPG9Grenade_HEAT.label> 
+	<Ammo_SPG9Grenade_HEAT.label>СПГ-9 граната (HEAT)</Ammo_SPG9Grenade_HEAT.label> 
 	<Ammo_SPG9Grenade_HEAT.description>СПГ-9 граната Кумулятивная — боеприпас для тяжелого станкового вооружения, предназначена для уничтожения тяжело бронированных целей.</Ammo_SPG9Grenade_HEAT.description>
 	
-	<Ammo_SPG9Grenade_Frag.label>СПГ-9 граната Осколочная (FRAG)</Ammo_SPG9Grenade_Frag.label> 
+	<Ammo_SPG9Grenade_Frag.label>СПГ-9 граната (FRAG)</Ammo_SPG9Grenade_Frag.label> 
 	<Ammo_SPG9Grenade_Frag.description>СПГ-9 граната Осколочная — боеприпас для тяжелого станкового вооружения, предназначена для уничтожения живой силы противника.</Ammo_SPG9Grenade_Frag.description> 
 	
 	
@@ -59,13 +59,13 @@
 	<Ammo_PlasmaBolt.label>Плазменная энергоячейка (EC)</Ammo_PlasmaBolt.label>
 	<Ammo_PlasmaBolt.description>Плазменная энергоячейка - боеприпас для хайтек вооружения. Представляет собой микроконтейнер с ионизированным газом.\n\nПри стрельбе оболочка контейнера разрушается и газ под воздействием экстремального нагрева и электромагнитных полей разгоняется в стволе оружия, формируясь в высокотемпературный сгусток.\n\nОдинаково эффективен и против живой силы и против бронированных целей.</Ammo_PlasmaBolt.description>  
 	
-	<Ammo_PlasmaPelletBolt.label>Плазменная энергоячейка Фракционная (FRAC)</Ammo_PlasmaPelletBolt.label>
+	<Ammo_PlasmaPelletBolt.label>Плазменная энергоячейка (FRAC)</Ammo_PlasmaPelletBolt.label>
 	<Ammo_PlasmaPelletBolt.description>Плазменная энергоячейка Фракционная - боеприпас для хайтек вооружения. Представляет собой микроконтейнер с ионизированным газом.\n\nПри стрельбе оболочка контейнера разрушается и газ под воздействием экстремального нагрева и электромагнитных полей разгоняется в стволе оружия, формируясь в высокотемпературный нестабильный сгусток, который разрушается при контакте с атмосферным воздухом.\n\nКонус разлета фракций покрывает большую площадь, но быстро теряет энергию, оставаясь эфеективным только на коротких и средних дистанциях.</Ammo_PlasmaPelletBolt.description> 
 	
-	<Ammo_BlasterBolt.label>Бластерная энергоячейка Бронебойная (AP)</Ammo_BlasterBolt.label>
+	<Ammo_BlasterBolt.label>Бластерная энергоячейка (AP)</Ammo_BlasterBolt.label>
 	<Ammo_BlasterBolt.description>Бластерная энергоячейка Бронебойная - боеприпас для хайтек вооружения. Представляет собой микробатарею повышенной мощности.\n\nПри стрельбе за счет бОльшего высвобождения энергии, бластерный луч эффективнее прожигает броню цели.</Ammo_BlasterBolt.description> 	
 	
-	<Ammo_BlasterPelletBolt.label>Бластерная энергоячейка Бронебойно-фракционная (AP-FRAC)</Ammo_BlasterPelletBolt.label>
+	<Ammo_BlasterPelletBolt.label>Бластерная энергоячейка (AP-FRAC)</Ammo_BlasterPelletBolt.label>
 	<Ammo_BlasterPelletBolt.description>Бластерная энергоячейка Бронебойно-фракционная - боеприпас для хайтек вооружения. Представляет собой микробатарею повышенной мощности.\n\nПри стрельбе сконцентрированный бластерный луч проходит через надульный разделитель оружия, расщепляясь на несколько более слабых.\n\nКонусный разлет лучей позволяет охватить бОльшую площадь, но за счет их быстрого рассеивания в атмосфере, этот боеприпас имеет сниженную дальность действия.</Ammo_BlasterPelletBolt.description> 	
 	
 	<Ammo_ChargedLaser.label>Лазерная энергоячейка (EC)</Ammo_ChargedLaser.label> 
@@ -87,13 +87,13 @@
 		
 	<!-- ==================== 120mm cannon shells ========================== -->	
 	
-	<Ammo_120mmCannonShell_HEAT.label>120mm орудийный снаряд Кумулятивный (HEAT)</Ammo_120mmCannonShell_HEAT.label> 
+	<Ammo_120mmCannonShell_HEAT.label>120mm орудийный снаряд (HEAT)</Ammo_120mmCannonShell_HEAT.label> 
 	<Ammo_120mmCannonShell_HEAT.description>120mm орудийный снаряд предназначенный для тяжелых пушек.</Ammo_120mmCannonShell_HEAT.description>
 	
-	<Ammo_120mmCannonShell_HE.label>120mm орудийный снаряд Фугасный (HE)</Ammo_120mmCannonShell_HE.label> 
+	<Ammo_120mmCannonShell_HE.label>120mm орудийный снаряд (HE)</Ammo_120mmCannonShell_HE.label> 
 	<Ammo_120mmCannonShell_HE.description>120мм орудийный снаряд предназначенный для тяжелых пушек.</Ammo_120mmCannonShell_HE.description> 
 	
-	<Ammo_120mmCannonShell_EMP.label>120mm орудийный снаряд Электромагнитный (EMP)</Ammo_120mmCannonShell_EMP.label> 
+	<Ammo_120mmCannonShell_EMP.label>120mm орудийный снаряд (EMP)</Ammo_120mmCannonShell_EMP.label> 
 	<Ammo_120mmCannonShell_EMP.description>120мм орудийный снаряд предназначенный для тяжелых пушек.</Ammo_120mmCannonShell_EMP.description> 
 	
 	
@@ -103,10 +103,10 @@
 	
 	<!-- ==================== 155mm howitzer shells ========================== -->	
 	
-	<Ammo_155mmHowitzerShell_HE.label>155mm гаубичный снаряд Фугасный (HE)</Ammo_155mmHowitzerShell_HE.label> 
+	<Ammo_155mmHowitzerShell_HE.label>155mm гаубичный снаряд (HE)</Ammo_155mmHowitzerShell_HE.label> 
 	<Ammo_155mmHowitzerShell_HE.description>Американский 155-мм высокоточный фугасный артиллерийский снаряд, созданный для поражения различных защищённых, в том числе подвижных целей.</Ammo_155mmHowitzerShell_HE.description> 
 	
-	<Ammo_155mmHowitzerShell_EMP.label>155mm гаубичный снаряд Электромагнитный (EMP)</Ammo_155mmHowitzerShell_EMP.label> 
+	<Ammo_155mmHowitzerShell_EMP.label>155mm гаубичный снаряд (EMP)</Ammo_155mmHowitzerShell_EMP.label> 
 	<Ammo_155mmHowitzerShell_EMP.description>Американский 155-мм высокоточный фугасный артиллерийский снаряд, созданный для поражения различных защищённых, в том числе подвижных целей.</Ammo_155mmHowitzerShell_EMP.description> 
 	
 	
@@ -115,7 +115,7 @@
 	
 	<!-- ==================== 130mm rocket missiles ========================== -->	
 	
-	<Ammo_130mmRocketMissile.label>130mm ракетный снаряд Фугасный (HE)</Ammo_130mmRocketMissile.label> 
+	<Ammo_130mmRocketMissile.label>130mm ракетный снаряд (HE)</Ammo_130mmRocketMissile.label> 
 	<Ammo_130mmRocketMissile.description>130мм ракетный снаряд, предназначенный для уничтожения тяжелой техники.</Ammo_130mmRocketMissile.description>
 	
 	

--- a/Mods/HMC weapon pack – USSR/Languages/Russian/DefInjected/ThingDefs/Ammo_SK_HMC.xml
+++ b/Mods/HMC weapon pack – USSR/Languages/Russian/DefInjected/ThingDefs/Ammo_SK_HMC.xml
@@ -4,13 +4,13 @@
 
 	<!-- ==================== 5.45x39mm Soviet ========================== -->	
  
-	<Ammo_545x39mmSoviet_FMJ.label>5.45x39mm Soviet Оболочечный (FMJ)</Ammo_545x39mmSoviet_FMJ.label> 
+	<Ammo_545x39mmSoviet_FMJ.label>5.45x39mm Soviet (FMJ)</Ammo_545x39mmSoviet_FMJ.label> 
 	<Ammo_545x39mmSoviet_FMJ.description>5,45×39mm — малоимпульсный советский промежуточный унитарный патрон центрального воспламенения.</Ammo_545x39mmSoviet_FMJ.description> 
 	
-	<Ammo_545x39mmSoviet_AP.label>5.45x39mm Soviet Бронебойный (AP)</Ammo_545x39mmSoviet_AP.label> 
+	<Ammo_545x39mmSoviet_AP.label>5.45x39mm Soviet (AP)</Ammo_545x39mmSoviet_AP.label> 
 	<Ammo_545x39mmSoviet_AP.description>5,45×39mm — малоимпульсный советский промежуточный унитарный патрон центрального воспламенения.</Ammo_545x39mmSoviet_AP.description> 
 	
-	<Ammo_545x39mmSoviet_HP.label>5.45x39mm Soviet Экспансивный (HP)</Ammo_545x39mmSoviet_HP.label> 
+	<Ammo_545x39mmSoviet_HP.label>5.45x39mm Soviet (HP)</Ammo_545x39mmSoviet_HP.label> 
 	<Ammo_545x39mmSoviet_HP.description>5,45×39mm — малоимпульсный советский промежуточный унитарный патрон центрального воспламенения.</Ammo_545x39mmSoviet_HP.description>
 	
 	
@@ -20,13 +20,13 @@
 
 	<!-- ==================== 7.62x54mmR ========================== -->
 
-	<Ammo_762x54mmR_FMJ.label>7.62x54 мм R Оболочечный (FMJ)</Ammo_762x54mmR_FMJ.label>
+	<Ammo_762x54mmR_FMJ.label>7.62x54 мм R (FMJ)</Ammo_762x54mmR_FMJ.label>
 	<Ammo_762x54mmR_FMJ.description>"Рантовый" — унитарный винтовочный патрон с гильзой с выступающей закраиной размерностью 7,62 × 53,72 мм, общей максимальной длиной патрона 77,16 мм, диаметром пули 7,62 мм и энергией 3990 Дж. Используется во многих пулемётах и винтовках.</Ammo_762x54mmR_FMJ.description>
 
-	<Ammo_762x54mmR_AP.label>7.62x54 мм R Бронебойный (AP)</Ammo_762x54mmR_AP.label>
+	<Ammo_762x54mmR_AP.label>7.62x54 мм R (AP)</Ammo_762x54mmR_AP.label>
 	<Ammo_762x54mmR_AP.description>"Рантовый" — унитарный винтовочный патрон с гильзой с выступающей закраиной размерностью 7,62 × 53,72 мм, общей максимальной длиной патрона 77,16 мм, диаметром пули 7,62 мм и энергией 3990 Дж. Используется во многих пулемётах и винтовках.</Ammo_762x54mmR_AP.description>
 
-	<Ammo_762x54mmR_HP.label>7.62x54 мм R Экспансивный (HP)</Ammo_762x54mmR_HP.label>
+	<Ammo_762x54mmR_HP.label>7.62x54 мм R (HP)</Ammo_762x54mmR_HP.label>
 	<Ammo_762x54mmR_HP.description>"Рантовый" — унитарный винтовочный патрон с гильзой с выступающей закраиной размерностью 7,62 × 53,72 мм, общей максимальной длиной патрона 77,16 мм, диаметром пули 7,62 мм и энергией 3990 Дж. Используется во многих пулемётах и винтовках.</Ammo_762x54mmR_HP.description>
 	
 	
@@ -36,16 +36,16 @@
 
 	<!-- ==================== 9x39mm Soviet ========================== -->
 	
-	<Ammo_9x39mmSoviet_FMJ.label>9x39 мм Soviet Оболочечный (FMJ)</Ammo_9x39mmSoviet_FMJ.label>
+	<Ammo_9x39mmSoviet_FMJ.label>9x39 мм Soviet (FMJ)</Ammo_9x39mmSoviet_FMJ.label>
 	<Ammo_9x39mmSoviet_FMJ.description>9x39 мм, он же СП-5 (Снайперский Патрон) - специально разработанный патрон, предназначенный для бесшумных автоматов и снайперских винтовок.</Ammo_9x39mmSoviet_FMJ.description>
 
-	<Ammo_9x39mmSoviet_AP.label>9x39 мм Soviet Бронебойный (AP)</Ammo_9x39mmSoviet_AP.label>
+	<Ammo_9x39mmSoviet_AP.label>9x39 мм Soviet (AP)</Ammo_9x39mmSoviet_AP.label>
 	<Ammo_9x39mmSoviet_AP.description>9x39 мм, он же СП-6 (Снайперский Патрон) - специально разработанный патрон, предназначенный для бесшумных автоматов и снайперских винтовок.</Ammo_9x39mmSoviet_AP.description>
 	
-	<Ammo_9x39mmSoviet_SH.label>9x39 мм Шоковый (SH)</Ammo_9x39mmSoviet_SH.label>
+	<Ammo_9x39mmSoviet_SH.label>9x39 мм (SH)</Ammo_9x39mmSoviet_SH.label>
 	<Ammo_9x39mmSoviet_SH.description>9x39 мм (SH) - наработки современников Римворлда. Специально разработанный дозвуковой патрон, предназначенный для безопасного и малокровного захвата. Также может использоваться для охоты.</Ammo_9x39mmSoviet_SH.description>
 	
-	<Ammo_9x39mmSoviet_EMP.label>9x39 мм Электромагнитный (EMP)</Ammo_9x39mmSoviet_EMP.label>
+	<Ammo_9x39mmSoviet_EMP.label>9x39 мм (EMP)</Ammo_9x39mmSoviet_EMP.label>
 	<Ammo_9x39mmSoviet_EMP.description>9x39 мм (EMP) - наработки современников Римворлда. Специально разработанный дозвуковой патрон с миниатюрным генератором электромагнитного импульса, предназначенный для ликвидации механоидов.</Ammo_9x39mmSoviet_EMP.description>	
 	
 	<Bullet_9x39mmSoviet_FMJ.label>9x39 мм пуля (FMJ)</Bullet_9x39mmSoviet_FMJ.label>
@@ -55,16 +55,16 @@
 
 	<!-- ==================== 7.62x25mm TT ========================== -->
 
-	<Ammo_762x25mmTT_FMJ.label>7.62x25mm TT Оболочечный (FMJ)</Ammo_762x25mmTT_FMJ.label>
+	<Ammo_762x25mmTT_FMJ.label>7.62x25mm TT (FMJ)</Ammo_762x25mmTT_FMJ.label>
 	<Ammo_762x25mmTT_FMJ.description>Старый оболоченный боеприпас неизвестного происхождения. Исходя из особенностей данного боеприпаса, можно сделать вывод, что использовали его для стрельбы из оружия пистолетного калибра. Был найден относительно недавно в руинах давно угасшей цивилизации.</Ammo_762x25mmTT_FMJ.description>
 
-	<Ammo_762x25mmTT_AP.label>7.62x25mm TT Бронебойный (AP)</Ammo_762x25mmTT_AP.label>
+	<Ammo_762x25mmTT_AP.label>7.62x25mm TT (AP)</Ammo_762x25mmTT_AP.label>
 	<Ammo_762x25mmTT_AP.description>Старый бронебойный боеприпас неизвестного происхождения. Исходя из особенностей данного боеприпаса, можно сделать вывод, что использовали его для стрельбы из оружия пистолетного калибра. Был найден относительно недавно в руинах давно угасшей цивилизации.</Ammo_762x25mmTT_AP.description>
 
-	<Ammo_762x25mmTT_HP.label>7.62x25mm TT Экспансивный (HP)</Ammo_762x25mmTT_HP.label>
+	<Ammo_762x25mmTT_HP.label>7.62x25mm TT (HP)</Ammo_762x25mmTT_HP.label>
 	<Ammo_762x25mmTT_HP.description>Старый экспансивный боеприпас неизвестного происхождения. Исходя из особенностей данного боеприпаса, можно сделать вывод, что использовали его для стрельбы из оружия пистолетного калибра. Был найден относительно недавно в руинах давно угасшей цивилизации.</Ammo_762x25mmTT_HP.description>
 
-	<Ammo_762x25mmTT_API.label>7.62x25mm TT Зажигательно-бронебойный (AP-I)</Ammo_762x25mmTT_API.label>
+	<Ammo_762x25mmTT_API.label>7.62x25mm TT (AP-I)</Ammo_762x25mmTT_API.label>
 	<Ammo_762x25mmTT_API.description>Старый зажигательно-бронебойный боеприпас неизвестного происхождения. Исходя из особенностей данного боеприпаса, можно сделать вывод, что использовали его для стрельбы из оружия пистолетного калибра. Был найден относительно недавно в руинах давно угасшей цивилизации.</Ammo_762x25mmTT_API.description>
 
 	<Bullet_762x25mmTT_FMJ.label>7.62x25mm TT пуля (FMJ)</Bullet_762x25mmTT_FMJ.label>


### PR DESCRIPTION
Корректировка русского перевода для видимости количества боеприпасов в окне инвентаря.
Подробная информация о боеприпасе по-прежнему доступна в описании предмета.

---
Correction of the Russian translation for the visibility of the amount of ammunition in the inventory window.
Details of the ammunition are still available in the item description.

![image](https://user-images.githubusercontent.com/67763632/104184521-a04eb280-5424-11eb-8936-a06d951910de.png)
