### PR TITLE
Some 2x3 table fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture.xml
@@ -1134,10 +1134,6 @@
 				<volume>(2.8, 0.6, 1.8)</volume>
 			</shadowData>
 			<damageData>
-				<rectN>(0,0.27,2,3.73)</rectN>
-				<rectS>(0,0.27,2,3.73)</rectS>
-				<rectE>(0.125,0.27,3.75,1.73)</rectE>
-				<rectW>(0.125,0.27,3.75,1.73)</rectW>
 				<cornerTL>Damage/Corner</cornerTL>
 				<cornerTR>Damage/Corner</cornerTR>
 				<cornerBL>Damage/Corner</cornerBL>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Furniture_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Furniture_SK.xml
@@ -96,5 +96,8 @@
 	
 	<ClutterStylist.label>стол парикмахера</ClutterStylist.label>
 	<ClutterStylist.description>Здесь действительно можно сменить имидж и стать блондинкой :)</ClutterStylist.description>
+	
+  	<!-- EN: table (2x3) -->
+  	<Table2x4c.label>стол (2x3)</Table2x4c.label>
 
 </LanguageData>


### PR DESCRIPTION
1 corrected damage data param;
2 fixed rus translation (was 2x4).

1 исправлено отображение повреждений на обычном столе 2х3 (трещины отображались где-то в воздухе);
2 исправлен русский перевод (назывался 2х4).