### PR TITLE
Corrected 9x39 mm EMP and SH ammo damage types

### DIFF
--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/9x39mmSoviet.xml
@@ -149,16 +149,11 @@
 		<defName>Bullet_9x39mmSoviet_SH</defName>
 		<label>9mm Soviet bullet (SH)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>5</damageAmountBase>
+			<damageAmountBase>1</damageAmountBase>
+			<damageDef>ElectricShock</damageDef>
 			<!-- <armorPenetrationBase>0.46</armorPenetrationBase> -->
-			<armorPenetrationSharp>7.8</armorPenetrationSharp>
-			<armorPenetrationBlunt>30.4</armorPenetrationBlunt>
-			  <secondaryDamage>
-				<li>
-				  <def>ElectricShock</def>
-				  <amount>5</amount>
-				</li>
-			  </secondaryDamage>
+			<armorPenetrationSharp>7.3</armorPenetrationSharp>
+			<armorPenetrationBlunt>28.5</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 	
@@ -166,16 +161,11 @@
 		<defName>Bullet_9x39mmSoviet_EMP</defName>
 		<label>9mm Soviet bullet (EMP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>7</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
+			<damageDef>EMP</damageDef>
 			<!-- <armorPenetrationBase>0.37</armorPenetrationBase> -->
 			<armorPenetrationSharp>9.4</armorPenetrationSharp>
-			<armorPenetrationBlunt>36.6</armorPenetrationBlunt>
-			  <secondaryDamage>
-				<li>
-				  <def>EMP</def>
-				  <amount>8</amount>
-				</li>
-			  </secondaryDamage>			
+			<armorPenetrationBlunt>36.6</armorPenetrationBlunt>			
 		</projectile>
 	</ThingDef>	
 


### PR DESCRIPTION
Скорректировал параметры урона у 9х39 мм патронов (EMP и SH).