### PR TITLE
Some storage tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Core_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
@@ -341,31 +341,30 @@
 		<debug>false</debug>
 	</ArchitectSense.DesignationSubCategoryDef>
 
-<!-- 	<ArchitectSense.DesignationSubCategoryDef>
+ 	<ArchitectSense.DesignationSubCategoryDef>
 		<defName>SubCategory_Pallets</defName>
 		<label>pallets</label>
-		<description>Use to store various materials..</description>
+		<description>Use to store various materials.</description>
 		<defNames>
-			<li>Storage_WoodenPalletSmall</li>
-			<li>Storage_SkipBig</li>
+			<li>LWM_Pallet</li>
+			<li>LWM_DeepStorage_Skip</li>
 		</defNames>
-		<designationCategory>Accessories</designationCategory>
+		<designationCategory>LWM_DS_Storage</designationCategory>
 		<debug>false</debug>
 	</ArchitectSense.DesignationSubCategoryDef>
 
 	<ArchitectSense.DesignationSubCategoryDef>
 		<defName>SubCategory_Containers</defName>
 		<label>containers</label>
-		<description>Use to store various things inside..</description>
+		<description>Use to store various things inside.</description>
 		<defNames>
 			<li>Basket</li>
 			<li>Barrel</li>
 			<li>Chest</li>
+			<li>FabricHamperSingle</li>
 			<li>IndustrialChest</li>
-			<li>ClutterShelf</li>
-			<li>Storage_MedicineCabinet</li>
 		</defNames>
-		<designationCategory>Accessories</designationCategory>
+		<designationCategory>LWM_DS_Storage</designationCategory>
 		<debug>false</debug>
 	</ArchitectSense.DesignationSubCategoryDef>
 
@@ -375,10 +374,10 @@
 		<description>Use to store food inside.</description>
 		<defNames>
 			<li>Pot</li>
-			<li>RefrigeratedTrayRack</li>
-			<li>ClutterSmallServingTable</li>
+			<li>LWM_Meat_Hook</li>
+			<li>TrayRackSingle</li>
 		</defNames>
-		<designationCategory>Accessories</designationCategory>
+		<designationCategory>LWM_DS_Storage</designationCategory>
 		<debug>false</debug>
 	</ArchitectSense.DesignationSubCategoryDef>
 
@@ -387,11 +386,10 @@
 		<label>Apparel storage</label>
 		<description>Haulers carry apparel here for storage.</description>
 		<defNames>
-			<li>Storage_Locker</li>
 			<li>Commode</li>
-			<li>ClutterLockerA</li>
+			<li>Shelf</li>
 		</defNames>
-		<designationCategory>Accessories</designationCategory>
+		<designationCategory>LWM_DS_Storage</designationCategory>
 		<debug>false</debug>
 	</ArchitectSense.DesignationSubCategoryDef>
 
@@ -400,13 +398,43 @@
 		<label>weaponry containers</label>
 		<description>Used to store various ammo, weapons inside.</description>
 		<defNames>
+			<li>LWM_WeaponsLocker</li>
+			<li>LWM_WeaponsCabinet</li>
 			<li>Storage_HazMatContainer</li>
 			<li>Storage_ExplosiveContainer</li>
-			<li>Shelf</li>
+			<li>ClutterLockerA</li>
 		</defNames>
-		<designationCategory>Accessories</designationCategory>
+		<designationCategory>LWM_DS_Storage</designationCategory>
 		<debug>false</debug>
-	</ArchitectSense.DesignationSubCategoryDef> -->
+	</ArchitectSense.DesignationSubCategoryDef>
+
+	<ArchitectSense.DesignationSubCategoryDef>
+		<defName>SubCategory_Shelfs</defName>
+		<label>refrigerators</label>
+		<description>Use to store and refrigerate food inside.</description>
+		<defNames>
+			<li>LWM_VeryBigShelf</li>
+			<li>LWM_BigShelf</li>
+			<li>LWM_Hayloft</li>
+		</defNames>
+		<designationCategory>LWM_DS_Storage</designationCategory>
+		<debug>false</debug>
+	</ArchitectSense.DesignationSubCategoryDef>
+
+	<ArchitectSense.DesignationSubCategoryDef>
+		<defName>SubCategory_Refrigerators</defName>
+		<label>refrigerators</label>
+		<description>Use to store and refrigerate food inside.</description>
+		<defNames>
+			<li>RimFridge_Refrigerator</li>
+			<li>RimFridge_WallRefrigerator</li>
+			<li>RimFridge_SingleRefrigerator</li>
+			<li>RimFridge_SingleWallRefrigerator</li>
+			<li>RimFridge_QuadRefrigerator</li>
+		</defNames>
+		<designationCategory>LWM_DS_Storage</designationCategory>
+		<debug>false</debug>
+	</ArchitectSense.DesignationSubCategoryDef>
 
 	<ArchitectSense.DesignationSubCategoryDef>
 		<defName>SubCategory_Lights</defName>

--- a/Mods/Core_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Core_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
@@ -410,8 +410,8 @@
 
 	<ArchitectSense.DesignationSubCategoryDef>
 		<defName>SubCategory_Shelfs</defName>
-		<label>refrigerators</label>
-		<description>Use to store and refrigerate food inside.</description>
+		<label>shelfs</label>
+		<description>Use to store some items.</description>
 		<defNames>
 			<li>LWM_VeryBigShelf</li>
 			<li>LWM_BigShelf</li>

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Furniture.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/ResearchProjects_Furniture.xml
@@ -464,7 +464,7 @@
 			<label>Storage II</label>
 			<description>Further research in storage technologies allows building and construction of Cupboards, Shelves, Skip and Racks.</description>
 			<baseCost>250</baseCost>
-			<techLevel>Medieval</techLevel>
+			<techLevel>Industrial</techLevel>
 			<tab>Furniture</tab>
 			<researchViewX>1.58</researchViewX>
 			<researchViewY>6.10</researchViewY>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage.xml
@@ -272,11 +272,10 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</statBases>
 		<stuffCategories>
 			<li>Metallic</li>
-			<li>Woody</li>
 		</stuffCategories>
 		<costStuffCount>30</costStuffCount>
 		<costList>
-			<ComponentMedieval>3</ComponentMedieval>
+			<ComponentIndustrial>3</ComponentIndustrial>
 		</costList>
 		<size>(2,1)</size>
 		<building>
@@ -316,7 +315,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<researchPrerequisites>
 			<li>SK_StorageII</li>
 		</researchPrerequisites>
-		<constructionSkillPrerequisite>2</constructionSkillPrerequisite>
+		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 	</ThingDef>
 
 	<ThingDef ParentName="LWM_DeepStorage">
@@ -1259,7 +1258,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<li>Woody</li>
 			<li>Metallic</li>
 		</stuffCategories>
-		<costStuffCount>70</costStuffCount>
+		<costStuffCount>60</costStuffCount>
 		<costList>
 			<ComponentIndustrial>4</ComponentIndustrial>
 		</costList>
@@ -1286,7 +1285,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</building>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties">
-				<maxNumberStacks>10</maxNumberStacks>
+				<maxNumberStacks>8</maxNumberStacks>
 				<timeStoringTakes>20</timeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
 				<showContents>false</showContents>
@@ -1327,7 +1326,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 			<li>Metallic</li>
 			<li>Woody</li>
 		</stuffCategories>
-		<costStuffCount>60</costStuffCount>
+		<costStuffCount>70</costStuffCount>
 		<costList>
 			<ComponentIndustrial>7</ComponentIndustrial>
 		</costList>
@@ -1354,7 +1353,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		</building>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties" >
-				<maxNumberStacks>8</maxNumberStacks>
+				<maxNumberStacks>10</maxNumberStacks>
 				<timeStoringTakes>50</timeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
 				<showContents>false</showContents>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Storage.xml
@@ -974,7 +974,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<costStuffCount>35</costStuffCount>
 		<costList>
 			<Glass>20</Glass>
-			<ComponentMedieval>6</ComponentMedieval>
+			<ComponentIndustrial>4</ComponentIndustrial>
 		</costList>
 		<building>
 			<fixedStorageSettings>
@@ -998,7 +998,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<tickerType>Rare</tickerType>
 		<comps>
 			<li Class="LWM.DeepStorage.Properties" >
-				<maxNumberStacks>5</maxNumberStacks>
+				<maxNumberStacks>7</maxNumberStacks>
 				<!--<timeStoringTakes>50</timeStoringTakes>-->
 				<minTimeStoringTakes>30</minTimeStoringTakes>
 				<additionalTimeEachStack>15</additionalTimeEachStack>
@@ -1026,7 +1026,7 @@ This template demonstrates that whitespace is obeyed in the description.\n\nSo a
 		<researchPrerequisites>
 			<li>SK_StorageII</li>
 		</researchPrerequisites>
-		<constructionSkillPrerequisite>4</constructionSkillPrerequisite>
+		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 	</ThingDef>
 
 	<ThingDef Name="LWM_Hayloft" ParentName="LWM_DeepStorage">

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
@@ -85,7 +85,7 @@
 	<SubCategory_AmmoContainers.label>оружейные контейнеры</SubCategory_AmmoContainers.label>
 	<SubCategory_AmmoContainers.description>Контейнеры, используемые для хранения снарядов и оружия.</SubCategory_AmmoContainers.description>
 
-	<SubCategory_Shelfs.label>полки</SubCategory_Shelfs.label>
+	<SubCategory_Shelfs.label>стеллажи</SubCategory_Shelfs.label>
 	<SubCategory_Shelfs.description>Контейнеры, используемые для хранения различных предметов.</SubCategory_Shelfs.description>
 
 	<SubCategory_Refrigerators.label>холодильники</SubCategory_Refrigerators.label>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
@@ -68,26 +68,34 @@
 	<SubCategory_Books.label>книги</SubCategory_Books.label> 
 	<SubCategory_Books.description>Мебель для хранения и использования книг.</SubCategory_Books.description> 
 
-	<!-- Accessories -->
-	
-	<SubCategory_PlantPots.label>горшки</SubCategory_PlantPots.label> 
-	<SubCategory_PlantPots.description>Горшки для выращивания комнатных декоративных растений.</SubCategory_PlantPots.description> 
-	
-	<SubCategory_Pallets.label>поддоны</SubCategory_Pallets.label> 
-	<SubCategory_Pallets.description>Различные поддоны для хранения ресурсов.</SubCategory_Pallets.description> 
-	
-	<SubCategory_Containers.label>контейнеры</SubCategory_Containers.label> 
-	<SubCategory_Containers.description>Различные контейнеры для хранения ресурсов.</SubCategory_Containers.description> 
-	
-	<SubCategory_FoodContainers.label>пищевые контейнеры</SubCategory_FoodContainers.label> 
+	<!-- Storages -->
+
+	<SubCategory_Pallets.label>поддоны</SubCategory_Pallets.label>
+	<SubCategory_Pallets.description>Различные поддоны для хранения ресурсов.</SubCategory_Pallets.description>
+
+	<SubCategory_Containers.label>контейнеры</SubCategory_Containers.label>
+	<SubCategory_Containers.description>Различные контейнеры для хранения ресурсов.</SubCategory_Containers.description>
+
+	<SubCategory_FoodContainers.label>пищевые контейнеры</SubCategory_FoodContainers.label>
 	<SubCategory_FoodContainers.description>Различные контейнеры для хранения пищи.</SubCategory_FoodContainers.description>
-	
-	<SubCategory_ApparelStorage.label>комоды</SubCategory_ApparelStorage.label> 
-	<SubCategory_ApparelStorage.description>Комоды для хранения одежды.</SubCategory_ApparelStorage.description> 
-	
-	<SubCategory_AmmoContainers.label>оружейные контейнеры</SubCategory_AmmoContainers.label> 
-	<SubCategory_AmmoContainers.description>Контейнеры, используемые для хранения снарядов и оружия.</SubCategory_AmmoContainers.description> 
-	
+
+	<SubCategory_ApparelStorage.label>комоды</SubCategory_ApparelStorage.label>
+	<SubCategory_ApparelStorage.description>Комоды для хранения одежды.</SubCategory_ApparelStorage.description>
+
+	<SubCategory_AmmoContainers.label>оружейные контейнеры</SubCategory_AmmoContainers.label>
+	<SubCategory_AmmoContainers.description>Контейнеры, используемые для хранения снарядов и оружия.</SubCategory_AmmoContainers.description>
+
+	<SubCategory_Shelfs.label>полки</SubCategory_Shelfs.label>
+	<SubCategory_Shelfs.description>Контейнеры, используемые для хранения различных предметов.</SubCategory_Shelfs.description>
+
+	<SubCategory_Refrigerators.label>холодильники</SubCategory_Refrigerators.label>
+	<SubCategory_Refrigerators.description>Контейнеры, используемые для хранения и заморозки пищи.</SubCategory_Refrigerators.description>
+
+	<!-- Accessories -->
+
+	<SubCategory_PlantPots.label>горшки</SubCategory_PlantPots.label>
+	<SubCategory_PlantPots.description>Горшки для выращивания комнатных декоративных растений.</SubCategory_PlantPots.description>
+
 	<SubCategory_Lights.label>заправляемые светильники</SubCategory_Lights.label> 
 	<SubCategory_Lights.description>Светильники требующие зарядки топливом или ресурсами.</SubCategory_Lights.description> 
 	

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_TestStorages.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_TestStorages.xml
@@ -16,6 +16,13 @@
   <LWM_BigShelf_Frame.label>Большой стеллаж (строительство)</LWM_BigShelf_Frame.label>
   <LWM_BigShelf_Frame.description>Большой стеллаж для хранения разных предметов, от артиллерийских снарядов до произведений искусства, от бионических рук до кирпичей, от стульев до трупов. \n\nЛежащие в нём вещи не портятся, даже если они на улице.</LWM_BigShelf_Frame.description>
 
+  <LWM_VeryBigShelf.label>Высокий стеллаж</LWM_VeryBigShelf.label>
+  <LWM_VeryBigShelf.description>Высокий стеллаж для хранения разных предметов, от артиллерийских снарядов до произведений искусства, от бионических рук до кирпичей, от стульев до трупов. \n\nХранимые предметы не будут ветшать, даже если стеллаж расположить вне помещения.</LWM_VeryBigShelf.description>
+  <LWM_VeryBigShelf_Blueprint.label>Высокий стеллаж (проект)</LWM_VeryBigShelf_Blueprint.label>
+  <LWM_VeryBigShelf_Blueprint_Install.label>Высокий стеллаж (проект)</LWM_VeryBigShelf_Blueprint_Install.label>
+  <LWM_VeryBigShelf_Frame.label>Высокий стеллаж (строительство)</LWM_VeryBigShelf_Frame.label>
+  <LWM_VeryBigShelf_Frame.description>Высокий стеллаж для хранения разных предметов, от артиллерийских снарядов до произведений искусства, от бионических рук до кирпичей, от стульев до трупов. \n\nЛежащие в нём вещи не портятся, даже если они на улице.</LWM_VeryBigShelf_Frame.description>
+
   <LWM_Food_Basket.label>Бочки для еды</LWM_Food_Basket.label>
   <LWM_Food_Basket.description>Мини-зернохранилище для хранения сырой пищи и растительных веществ.</LWM_Food_Basket.description>
   <LWM_Food_Basket_Blueprint.label>Бочки для еды (проект)</LWM_Food_Basket_Blueprint.label>

--- a/Mods/Rimefeller_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Rimefeller_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
@@ -15,6 +15,7 @@
 			<li>ParaffinRefiner</li>
 			<li>SulphateRefiner</li>
 			<li>SyntheticAmmoniaRefiner</li>
+			<li>RefineryLoadingBay</li>
 		</defNames>
 		<designationCategory>Rimefeller</designationCategory>
 		<debug>false</debug>


### PR DESCRIPTION
1 added sub categories to all storages;
2 corrected skip and serving table recipe craft (replaced medieval component to industrial, removed woody stuff categories (for skip only), increased max number stack to 7 (serving table only) and incresed construction skill prerequisite to 6 (both));
3 moved storage II researsh to industrial tech level (cuz most storages on this researsh level require industrial component);
4 added refinery loading bay to refineries sub category;
5 corrected weapons cabinet and weapons locker recipes;
6 some rus translation fixes.

1 добавлены подкатегории всем хранилищам (сортировка);
2 скорректированы параметры контейнера (улучшенная палета) и сервировочного стола (примитивные компоненты заменены на индустриальные, у контейнера убрана возможность быть созданным из дерева (т.к. не соответствует его описанию, он металлический), у сервировочного стола увеличено количество стаков с 5 до 7, увеличено требование к строительству для обоих контейнеров до 6);
3 технология "хранилища II" сдвинута на индустриальный технологический уровень (т.к. большая часть хранилищ, открываемых в этом разделе, используют индустриальные компоненты);
4 разгрузочная платформа переработчика теперь располагается в категории "Переработчики";
5 скорректировал параметры оружейного шкафа и крепкого оружейного шкафа;
6 скорректированы русские переводы хранилищ.

@skyarkhangel нужно выключить одну галку по умолчанию в настройках LWM (которую ранее обсуждали в дискорде):
https://discord.com/channels/272340793174392832/780721751360798740/802956075137630209
Иначе будут задвоения. Эта галка также виновата в некорректном расположении некоторых других построек (вроде погрузчика для переработчиков нефти).