### PR TITLE
Mood penalty adjustments

### DIFF
--- a/Mods/CoreTranslation/Languages/Russian-SK/DefInjected/ThoughtDef/Thoughts_Memory_Misc.xml
+++ b/Mods/CoreTranslation/Languages/Russian-SK/DefInjected/ThoughtDef/Thoughts_Memory_Misc.xml
@@ -12,7 +12,7 @@
   <BondedAnimalBanished.stages.bonded_animal_banished.description>Моего любимого питомца выгнали из поселения!</BondedAnimalBanished.stages.bonded_animal_banished.description>
   
   <!-- EN: I butchered humanlike -->
-  <ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.label>разделан человек</ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.label>
+  <ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.label>я разделал человека</ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.label>
   <!-- EN: I butchered someone up like an animal. -->
   <ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.description>Мне пришлось разделать человека. Словно это было животное.</ButcheredHumanlikeCorpse.stages.I_butchered_humanlike.description>
   
@@ -65,7 +65,7 @@
   <KnowBuriedInSarcophagus.stages.buried_in_sarcophagus.description>Нашего поселенца похоронили в красивом саркофаге. Да покоится его душа с миром!</KnowBuriedInSarcophagus.stages.buried_in_sarcophagus.description>
   
   <!-- EN: we butchered humanlike -->
-  <KnowButcheredHumanlikeCorpse.stages.We_butchered_humanlike.label>разделан человек</KnowButcheredHumanlikeCorpse.stages.We_butchered_humanlike.label>
+  <KnowButcheredHumanlikeCorpse.stages.We_butchered_humanlike.label>тут разделывают людей</KnowButcheredHumanlikeCorpse.stages.We_butchered_humanlike.label>
   <!-- EN: We butchered someone up like an animal. -->
   <KnowButcheredHumanlikeCorpse.stages.We_butchered_humanlike.description>Мы только что разделали человека, словно это было животное.</KnowButcheredHumanlikeCorpse.stages.We_butchered_humanlike.description>
 

--- a/Mods/Core_SK/Defs/BodyParts/BodyParts_Special.xml
+++ b/Mods/Core_SK/Defs/BodyParts/BodyParts_Special.xml
@@ -56,6 +56,9 @@
 			<ThingDef>DeathAcidifier</ThingDef>
 		</descriptionHyperlinks>
 		<jobString>Installing death acidifier.</jobString>
+		<recipeUsers>
+      		<li>Human</li>
+    	</recipeUsers>
 		<ingredients>
 			<li>
 				<filter>

--- a/Mods/Core_SK/Defs/ThoughtDefs/Vanilla/Thoughts_Memory_Misc_VanillaRework.xml
+++ b/Mods/Core_SK/Defs/ThoughtDefs/Vanilla/Thoughts_Memory_Misc_VanillaRework.xml
@@ -234,9 +234,9 @@
 
 	<ThoughtDef>
 		<defName>ButcheredHumanlikeCorpse</defName>
-		<durationDays>6.0</durationDays>
+		<durationDays>3.0</durationDays>
 		<stackLimit>30</stackLimit>
-		<stackedEffectMultiplier>1.0</stackedEffectMultiplier>
+		<stackedEffectMultiplier>0.95</stackedEffectMultiplier>
 		<nullifyingTraits>
 			<li>Psychopath</li>
 			<li>Bloodlust</li>
@@ -253,9 +253,9 @@
 
 	<ThoughtDef>
 		<defName>KnowButcheredHumanlikeCorpse</defName>
-		<durationDays>6.0</durationDays>
+		<durationDays>3.0</durationDays>
 		<stackLimit>30</stackLimit>
-		<stackedEffectMultiplier>1.0</stackedEffectMultiplier>
+		<stackedEffectMultiplier>0.95</stackedEffectMultiplier>
 		<nullifyingTraits>
 			<li>Psychopath</li>
 			<li>Bloodlust</li>

--- a/Mods/Core_SK/Defs/ThoughtDefs/Vanilla/Thoughts_Memory_Misc_VanillaRework.xml
+++ b/Mods/Core_SK/Defs/ThoughtDefs/Vanilla/Thoughts_Memory_Misc_VanillaRework.xml
@@ -236,7 +236,7 @@
 		<defName>ButcheredHumanlikeCorpse</defName>
 		<durationDays>3.0</durationDays>
 		<stackLimit>30</stackLimit>
-		<stackedEffectMultiplier>0.95</stackedEffectMultiplier>
+		<stackedEffectMultiplier>0.92</stackedEffectMultiplier>
 		<nullifyingTraits>
 			<li>Psychopath</li>
 			<li>Bloodlust</li>
@@ -255,7 +255,7 @@
 		<defName>KnowButcheredHumanlikeCorpse</defName>
 		<durationDays>3.0</durationDays>
 		<stackLimit>30</stackLimit>
-		<stackedEffectMultiplier>0.95</stackedEffectMultiplier>
+		<stackedEffectMultiplier>0.88</stackedEffectMultiplier>
 		<nullifyingTraits>
 			<li>Psychopath</li>
 			<li>Bloodlust</li>


### PR DESCRIPTION
Reduced debuff duration of butchering humans from 6 to 3 days.
Reduced stacked effect multiplier form 1.0 to 0.95 so max mood debuff from butching 30 corpses downed drom -90 to -47.
Yep its wired exponential dependency of stacked effect multiplier.
Praise those filthy corpse eaters. Awful.

Update 1: Reduced stacked effect multiplier to 0.92 and 0.88 for personal and colony debuffs (-34 and -24 total). Fixed RUS translation for mood labels.