### PR TITLE
Some tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Orassan.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Orassan.xml
@@ -326,7 +326,7 @@
 	<PawnKindDef Name="OrassanTacticalBase" ParentName="OrassanVillagerBase" Abstract="True">
 		<combatPower>325</combatPower>
 		<invFoodDef>MealNutrientPaste</invFoodDef>
-		<itemQuality>Good</itemQuality>
+		<itemQuality>Normal</itemQuality>
 		<apparelIgnoreSeasons>true</apparelIgnoreSeasons>
 		<gearHealthRange>
 			<min>0.75</min>
@@ -481,7 +481,7 @@
 		<defName>OrassanTacticalCommander</defName>
 		<label>tactical commander</label>
 		<combatPower>350</combatPower>
-		<itemQuality>Normal</itemQuality>
+		<itemQuality>Good</itemQuality>
 		<isFighter>true</isFighter>
 		<canBeSapper>true</canBeSapper>
 		<apparelTags>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
@@ -522,9 +522,9 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>2</explosionRadius>
 			<damageDef>Flame</damageDef>
-			<damageAmountBase>100</damageAmountBase>
+			<damageAmountBase>20</damageAmountBase>
 			<explosionDelay>180</explosionDelay>
-			<postExplosionSpawnThingDef>Filth_Fuel</postExplosionSpawnThingDef>
+			<preExplosionSpawnThingDef>Filth_Fuel</preExplosionSpawnThingDef>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Mote_GrenadePin</casingMoteDefname>


### PR DESCRIPTION
1 fix flame grenade explosion params. Too much damage for flame grenade (can destroy any body parts on explosion):

![image](https://user-images.githubusercontent.com/62516232/106390331-b17a5600-6409-11eb-871a-ba690308c06d.png)
also grenade will not set afire fuel flith on spawn.
2 Fix T2 orassan's raid pawns item quailty (wrong place normal and good. Swap its).

1 поправил параметры зажигательной гранаты. Слишком большой урон для такого типа гранат (мог оторвать даже торс). Также не поджигал топливную лужу при взрыве. Поправил (по идее, взрыв должен поджигать содержимое, иначе толку от него нет);
2 поправил качество предметов Т2 рейдов орассанов (у обычных рейдеров оно было выше, чем у коммандира, должно быть наоборот. Поменял местами).