### PR TITLE
Deleted "woody" category from medical beds

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture_Beds.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture_Beds.xml
@@ -1067,7 +1067,6 @@
 		<size>(1,2)</size>
 		<stuffCategories>
 			<li>Metallic</li>
-			<li>Woody</li>
 			<li>Plastic</li>
 		</stuffCategories>
 		<costStuffCount>60</costStuffCount>
@@ -1118,7 +1117,6 @@
 		<size>(1,2)</size>
 		<stuffCategories>
 			<li>Metallic</li>
-			<li>Woody</li>
 			<li>Plastic</li>
 		</stuffCategories>
 		<costStuffCount>80</costStuffCount>


### PR DESCRIPTION
удалил категорию древесины из мед кроватей