### PR TITLE
Some skynet pawns tweaks and fixes

### DIFF
--- a/Mods/Skynet_SK/Defs/FactionDefs/Skynet.xml
+++ b/Mods/Skynet_SK/Defs/FactionDefs/Skynet.xml
@@ -25,7 +25,7 @@
 				<li>(0,600)</li>
 				<li>(14500,650)</li>
 				<li>(17000,1000)</li>
-				<li>(20000,1700)</li>
+				<li>(20000,1750)</li>
 				<li>(100000,10000)</li>
 			</points>
 		</maxPawnCostPerTotalPointsCurve>

--- a/Mods/Skynet_SK/Defs/PawnKindDefs/PawnKinds_Skynet.xml
+++ b/Mods/Skynet_SK/Defs/PawnKindDefs/PawnKinds_Skynet.xml
@@ -360,7 +360,7 @@
 		<defName>SkynetInfiltratorOrigin</defName>
 		<label>T-800</label>
 		<race>SkynetInfiltrator</race>
-		<combatPower>1005</combatPower>
+		<combatPower>1100</combatPower>
 		<weaponMoney>
 			<min>3300</min>
 			<max>4100</max>
@@ -476,7 +476,7 @@
 		<defName>SkynetPrototypeTXOrigin</defName>
 		<label>T-X</label>
 		<race>SkynetPrototypeTX</race>
-		<combatPower>1400</combatPower>
+		<combatPower>1450</combatPower>
 		<weaponMoney>
 			<min>3300</min>
 			<max>4100</max>

--- a/Mods/Skynet_SK/Defs/PawnKindDefs/PawnKinds_Skynet.xml
+++ b/Mods/Skynet_SK/Defs/PawnKindDefs/PawnKinds_Skynet.xml
@@ -360,7 +360,7 @@
 		<defName>SkynetInfiltratorOrigin</defName>
 		<label>T-800</label>
 		<race>SkynetInfiltrator</race>
-		<combatPower>750</combatPower>
+		<combatPower>1005</combatPower>
 		<weaponMoney>
 			<min>3300</min>
 			<max>4100</max>


### PR DESCRIPTION
1 slightly corrected max pawn cost per total point curve (this value always should be more than max pawn power point of this faction pawns (at least a little bit));
2 T-800 origin pawn in high tech armor and absolutely naked T-800 pawn have same cost? really? Fixed this.

1 немного откорректирована максимальная стоимость пешек скайнета в кривой рейдов (верхнее граничное значение (в нашем случае это 20к поинтов) должно быть выше (хотя бы чуть-чуть), чем максимальная стоимость самой дорогой пешки этой фракции (иначе она не будет появляться в рейдах в обычных условиях, по крайне мере мои тесты это выявили));
2 пешка Т-800 Origin в плаще скайнета (хайтек броня с силовым щитом и уклонением) и абсолютно голая Т-800 пешка стоили одинаково. Исправлено.