### PR TITLE
FIxes for starting scenarios

### DIFF
--- a/Mods/Core_SK/Defs/ScenarioDefs/Scenarios_C_LostTribe.xml
+++ b/Mods/Core_SK/Defs/ScenarioDefs/Scenarios_C_LostTribe.xml
@@ -76,12 +76,12 @@
 				<li Class="ScenPart_StartingThing_Defined">
 					<def>StartingThing_Defined</def>
 					<thingDef>MeleeWeapon_Club</thingDef>
-					<stuff>WoodLog</stuff>
+					<stuff>WoodPlank</stuff>
 				</li>
 				<li Class="ScenPart_StartingThing_Defined">
 					<def>StartingThing_Defined</def>
 					<thingDef>MeleeWeapon_Spear</thingDef>
-					<stuff>WoodLog</stuff>
+					<stuff>Bronze</stuff>
 				</li>
 				<li Class="ScenPart_StartingThing_Defined">
 					<def>StartingThing_Defined</def>
@@ -111,13 +111,6 @@
 					<visible>false</visible>
 					<thingDef>WoodLog</thingDef>
 					<count>320</count>
-				</li>
-				<li Class="ScenPart_ScatterThingsAnywhere">
-					<def>ScatterThingsAnywhere</def>
-					<visible>false</visible>
-					<thingDef>HeadPike</thingDef>
-					<stuff>WoodLog</stuff>
-					<count>5</count>
 				</li>
 				<li Class="ScenPart_ScatterThingsAnywhere">
 					<def>ScatterThingsAnywhere</def>

--- a/Mods/Core_SK/Defs/ScenarioDefs/Scenarios_L_MoonFall.xml
+++ b/Mods/Core_SK/Defs/ScenarioDefs/Scenarios_L_MoonFall.xml
@@ -75,7 +75,7 @@
 				<li Class="ScenPart_StartingThing_Defined">
 					<def>StartingThing_Defined</def>
 					<thingDef>MeleeWeapon_Club</thingDef>
-					<stuff>WoodLog</stuff>
+					<stuff>WoodPlank</stuff>
 				</li>
 				<li Class="ScenPart_StartingThing_Defined">
 					<def>StartingThing_Defined</def>
@@ -95,7 +95,7 @@
 				<li Class="ScenPart_StartingThing_Defined">
 					<def>StartingThing_Defined</def>
 					<thingDef>MeleeWeapon_Spear</thingDef>
-					<stuff>WoodLog</stuff>
+					<stuff>Bronze</stuff>
 				</li>
 				<li Class="ScenPart_StartingThing_Defined">
 					<def>StartingThing_Defined</def>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
@@ -54,13 +54,13 @@
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Woodcutting_Handaxe</thingDef>
-                <stuff>WoodLog</stuff>
+                <stuff>Bronze</stuff>
                 <count>2</count>
             </li>
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Building_Hammer</thingDef>
-                <stuff>WoodLog</stuff>
+                <stuff>WoodPlank</stuff>
                 <count>2</count>
             </li>
             <li Class="ScenPart_StartingThing_Defined">
@@ -86,13 +86,13 @@
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Woodcutting_Handaxe</thingDef>
-                <stuff>WoodLog</stuff>
+                <stuff>Bronze</stuff>
                 <count>2</count>
             </li>
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Building_Hammer</thingDef>
-                <stuff>WoodLog</stuff>
+                <stuff>WoodPlank</stuff>
                 <count>2</count>
             </li>
             <li Class="ScenPart_StartingThing_Defined">
@@ -223,13 +223,13 @@
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Woodcutting_Handaxe</thingDef>
-                <stuff>WoodLog</stuff>
+                <stuff>Bronze</stuff>
                 <count>2</count>
             </li>
             <li Class="ScenPart_StartingThing_Defined">
                 <def>StartingThing_Defined</def>
                 <thingDef>TFJ_Tool_Building_Hammer</thingDef>
-                <stuff>WoodLog</stuff>
+                <stuff>WoodPlank</stuff>
                 <count>2</count>
             </li>
             <li Class="ScenPart_StartingThing_Defined">


### PR DESCRIPTION
- Changed clubs to be made of planks instead of logs
- Changed spears to be made out of bronze instead of planks.... I mean... What's the *point*?
- Changed starting axes to be made out of bronze instead of planks - what a great idea to cut wood with another piece of wood
- Removed heads on pikes from starting objects - they behave incorrectly if spawned by game instead of being constructed from actual corpses

-----------------------
- Поменял материал стартового топора и копья с досок на бронзу
- Поменял материал стартовой дубины с брёвен на доски
- Убрал головы на пиках их стартовых объектов - игра не может их корректно заспавнить и выкидывает ошибку, придётся украшать карту самим.