### PR TITLE
Corrected Pirate faction

### DIFF
--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Pirate.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Pirate.xml
@@ -16,6 +16,8 @@
 		<autoFlee>true</autoFlee>
 		<canStageAttacks>true</canStageAttacks>
 		<permanentEnemy>true</permanentEnemy>
+		<goodwillDailyGain>0</goodwillDailyGain>
+		<goodwillDailyFall>0</goodwillDailyFall>
 		<leaderTitle>Renegade</leaderTitle>
 		<earliestRaidDays>30</earliestRaidDays>
 		<raidCommonalityFromPointsCurve>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Pirate.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Pirate.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-	<FactionDef ParentName="SK_HumanFactionBase" Abstract="True">
+	<FactionDef ParentName="SK_HumanFactionBase">
 		<defName>Pirate</defName>
 		<label>renegade band</label>
 		<description>A loose confederation of renegade gangs who've agreed to mostly fight outsiders instead of fighting each other.\n\nRenegades don't sow, they don't build, and they rarely trade. Driven by a blood-and-honor culture that values personal strength and ruthlessness, they enrich themselves by raiding and robbing their more productive neighbors.\n\nTheir technology level depends mostly on who they've managed to steal from recently. Mostly they carry gunpowder weapons, though some prefer to stab victims at close range.</description>
@@ -31,8 +31,9 @@
 		<maxPawnCostPerTotalPointsCurve>
 			<points>
 				<li>(800, 125)</li>
-				<li>(5000, 125)</li>
-				<li>(5500, 155)</li>
+				<li>(3000, 130)</li>
+				<li>(4500, 155)</li>
+				<li>(5500, 170)</li>
 				<li>(6500, 220)</li>
 				<li>(7500, 260)</li>
 				<li>(100000, 10000)</li>


### PR DESCRIPTION
Corrected Pirate faction (was "Abstracted" and don't replace vanila pirate faction (incorrect icon, should have scorpion icon)). Also slightly corrected raid point curve.

Поправил фракцию Пиратов (почему-то была "Абстрактной" и не заменяла собою одноименную ванильную фракцию (сейчас у нас две фракции с похожими иконками в виде черепа и костей - одна - ванильные космические пираты, вторая - агрессивное племя. Теперь пираты будут индустриальными со своей родной иконкой скорпиона). Также немного скорректировал кривую рейдов этих пиратов (т.к. на мой взгляд иначе слишком долго будут рейдить одни оборванцы с деревянными дубинками).