### PR TITLE
Removed vanila max point limitation for one of pawn group maker of pirate raid (was 1000 points)

### DIFF
--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Pirate.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Pirate.xml
@@ -168,7 +168,6 @@
 				<!-- Normal fights, drifters only (very rare) -->
 				<kindDef>Combat</kindDef>
 				<commonality>2.5</commonality>
-				<maxTotalPoints>1000</maxTotalPoints>
 				<options>
 					<Drifter>10</Drifter>
 				</options>


### PR DESCRIPTION
Убрал ванильное ограничение в 1000 поинтов для одной из рейдовых групп фракции пиратов (зачем нужно - не понятно, у остальных групп фракции такого нет, шанс спавна такого рейда при этом около нулевой).