### PR TITLE
Fix of fix of dark mood thoughts.

### DIFF
--- a/Mods/Core_SK/Defs/ThoughtDefs/Extratraits/Thoughts_Situation_General.xml
+++ b/Mods/Core_SK/Defs/ThoughtDefs/Extratraits/Thoughts_Situation_General.xml
@@ -11,6 +11,9 @@
     <li>NightOwl</li>
 		<li>Undergrounder</li>
 	</requiredTraits>
+  <nullifyingTraits>
+       <li>Nyctophobe</li>
+  </nullifyingTraits>
     <stages>
       <li>
         <label>in darkness</label>


### PR DESCRIPTION
Nyctophobe in dark environment will not receive buff from other darkly traits (NightOwl, Undergrounder, etc).