### PR TITLE
Removed old pawn icon texture path (obsolete)

### DIFF
--- a/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
@@ -4,7 +4,6 @@
 		<defName>ChjAndroid</defName>
 		<label>Human android</label>
 		<description>A race of humanlike robots which are mostly female in model variety.\n\nThe origins of these machines are mostly unknown. Some speculate they are escapees from a civilization which used them for labor and some just suggest they are outdated pleasure machines which got dumped by a passing space freighter.\n\nBy design by their previous masters they are weak physically but their raw fortitude is enough to make up for it. Beware of their biological reactor and capacitors violently exploding, if they die by overheating.</description>
-		<uiIconPath>Things/Pawn/Humanlike/UI/IconHuman</uiIconPath>
 		<comps>
 			<li Class="Androids.CompProperties_EnergyTracker">
 				<canHibernate>false</canHibernate>

--- a/Mods/Androids/Defs/AlienRace/AlienRace_Droids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Droids.xml
@@ -4,7 +4,6 @@
 		<defName>ChjDroid</defName>
 		<label>Droid</label>
 		<description>A race of rudimentary humanlike worker robots.\n\nUsually found toiling around in colonies around the rim which got a resident tinkerer.\n\nNot capable of sapience, however their relative cheap cost and ability to work around the clock make them valuable workers.</description>
-		<uiIconPath>Things/Pawn/Humanlike/UI/IconHuman</uiIconPath>
 		<comps>
 			<li Class="Androids.CompProperties_EnergyTracker">
 				<canHibernate>true</canHibernate>
@@ -375,7 +374,6 @@
 	<defName>ChjBattleDroid</defName>
 	<label>Battle droid</label>
 	<description>A race of rudimentary humanlike warrior robots.\n\nUsually found guarding the homes of the wealthy and offices of mega corporations. They show no mercy upon targets who fail to identify themselves. Are traditionally armed with miniguns and core launchers.</description>
-	<uiIconPath>Things/Pawn/Humanlike/UI/IconHuman</uiIconPath>
 	<comps>
 		<li Class="Androids.CompProperties_EnergyTracker">
 			<canHibernate>true</canHibernate>

--- a/Mods/Skynet_SK/Defs/ThingDefs/Races_Skynet.xml
+++ b/Mods/Skynet_SK/Defs/ThingDefs/Races_Skynet.xml
@@ -183,7 +183,6 @@
 		<defName>SkynetInfiltrator</defName>
 		<label>Terminator prototype T800</label>
 		<description>The Terminator is an infiltration unit that is part-man and part-machine. The interior is composed of a hyperalloy combat chassis that is microprocessor-controlled. The exterior is living human tissue. The endoskeleton is assisted by a powerful network of hydraulic servomechanisms. This makes Terminators superhumanly strong. \n\nMain features:\n ++Great armor\n ++Great durability\n --No regeneration abilities\n -- No restore lost limbs\n -Can't change appearance\n --Can't transform arms in melee battle\n -No colony socialization\n --Weak working opportunities\n +Сan't get overheating.</description>
-		<uiIconPath>Things/Pawn/Humanlike/UI/IconHuman</uiIconPath>
 		<statBases>
 			<MoveSpeed>4.6</MoveSpeed>
 			<ArmorRating_Blunt>8</ArmorRating_Blunt>
@@ -337,7 +336,6 @@
 		<defName>SkynetAgent</defName>
 		<label>Terminator T-Hybrid</label>
 		<description>A Hybrid, or T-H, is a human who has been transformed into a cybernetic organism. T-H was successfully transformed into a cybernetic organism, his skeleton replaced with a hyper-alloy replica while still retaining key biological components such as the brain, organs, eyes, and curiously his gums and teeth (though these could have been prosthetic). The result was a stronger, faster, and more resilient vessel in which he could survive beyond death. \n\nMain features:\n -Weak armor\n -Bad durability\n +Average regeneration abilities\n --Can't restore lost limbs\n +Can change appearance\n --Can't transform arms in melee battle\n +Colony socialization\n ++Great working opportunities.\n -Сan get overheating.</description>
-		<uiIconPath>Things/Pawn/Humanlike/UI/IconHuman</uiIconPath>
 		<statBases>
 			<ArmorRating_Blunt>5</ArmorRating_Blunt>
 			<ArmorRating_Sharp>4</ArmorRating_Sharp>
@@ -498,7 +496,6 @@
 		<defName>SkynetPrototypeTX</defName>
 		<label>Terminator prototype T-X</label>
 		<description>The T-X model also known as Terminatrix. It is a composite of the T-800 and T-1000, a solid sophisticated human sized frame endoskeleton covered with a nanorobotic liquid metal "mimetic polyalloy", capable of changing shape, color and temperature in order to mimic living creatures and recover from damage.\n\nMain features:\n +Average armor\n ++Good durability\n ++Strong regeneration abilities\n ++Restore lost limbs, except reactor core and brain\n +Can change appearance\n ++Can transform arms in melee battle\n -No colony socialization\n --Weak working opportunities\n +Сan't get overheating.</description>
-		<uiIconPath>Things/Pawn/Humanlike/UI/IconHuman</uiIconPath>
 		<statBases>
 			<ArmorRating_Blunt>10</ArmorRating_Blunt>
 			<ArmorRating_Sharp>8</ArmorRating_Sharp>


### PR DESCRIPTION
Удален путь к старой унифицированной текстуре иконке пешек (в виде желтого силуэта) (неактуальна, т.к. игра генерирует их самостоятельно на основе внешнего вида пешки).