### PR TITLE
Some ratkin tweaks and fixes

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/AlienRaceSettings/AlienRaceSettings.xml
+++ b/Mods/RatkinRaceHSK/Defs/AlienRaceSettings/AlienRaceSettings.xml
@@ -43,9 +43,15 @@
 			<alienrefugeekinds>
 				<li>
 					<kindDefs>
+						<li>RatkinVagabond</li>
+					</kindDefs>
+					<chance>35</chance>
+				</li>
+				<li>
+					<kindDefs>
 						<li>RatkinSubject</li>
 					</kindDefs>
-					<chance>50.0</chance>
+					<chance>15</chance>
 				</li>
 			</alienrefugeekinds>
 			<alienwandererkinds>

--- a/Mods/RatkinRaceHSK/Patches/PawnKindDefs/PawnKinds_Ratkin.xml
+++ b/Mods/RatkinRaceHSK/Patches/PawnKindDefs/PawnKinds_Ratkin.xml
@@ -58,6 +58,19 @@
 			</value>
 		  </li>
 
+			<!-- ========== Vanguard ========== -->
+		   <li Class="PatchOperationAddModExtension">
+			<xpath>Defs/PawnKindDef[defName="RatkinVanguard"]</xpath>
+			<value>
+			  <li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+				  <min>3</min>
+				  <max>5</max>
+				</primaryMagazineCount>
+			  </li>
+			</value>
+		  </li>
+
 			<!-- ========== Merchant ========== -->
 		   <li Class="PatchOperationAddModExtension">
 			<xpath>Defs/PawnKindDef[defName="RatkinMerchant"]</xpath>


### PR DESCRIPTION
1 corrected ratkin subject refugee chance spawn. Added ratkin vagabond refugee spawn chance;
2 added few ammo to Ratkin Vanguard pawn (was no ammo);

1 скорректирована вероятность появления раткина-подопытного в качестве беглеца. Добавлена возможность спавна пешки "Раткин бродяга" в качестве беглеца;
2 добавил немного боеприпасов пешке "Ratkin Vanguard" (их просто не было).