### PR TITLE
Some Royalty armor tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorLocust.xml
+++ b/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorLocust.xml
@@ -15,16 +15,18 @@
 		<stuffCategories>
 			<li>StrongMetallic</li>
 		</stuffCategories>
-		<costStuffCount>110</costStuffCount>
+		<costStuffCount>115</costStuffCount>
 		<costList>
 			<Carbon>20</Carbon>
 			<Compaste>25</Compaste>
-			<Gold>10</Gold>
-			<BiosyntheticMaterial>4</BiosyntheticMaterial>
+			<GoldBar>15</GoldBar>
+			<BiosyntheticMaterial>6</BiosyntheticMaterial>
+			<ComponentUltra>3</ComponentUltra>
 			<Chitin>70</Chitin>
+			<Chemfuel>100</Chemfuel>
 		</costList>
 		<statBases>
-			<WorkToMake>34000</WorkToMake>
+			<WorkToMake>36000</WorkToMake>
 			<MaxHitPoints>195</MaxHitPoints>
 			<Flammability>1</Flammability>
 			<Mass>6</Mass>
@@ -113,7 +115,7 @@
 			<li Class="CompProperties_Reloadable">
 				<maxCharges>5</maxCharges>
 				<ammoDef>Chemfuel</ammoDef>
-				<ammoCountPerCharge>20</ammoCountPerCharge>
+				<ammoCountPerCharge>30</ammoCountPerCharge>
 				<baseReloadTicks>60</baseReloadTicks>
 				<soundReload>Standard_Reload</soundReload>
 				<hotKey>Misc4</hotKey>
@@ -131,7 +133,7 @@
 				<hasStandardCommand>true</hasStandardCommand>
 				<onlyManualCast>True</onlyManualCast>
 				<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
-				<warmupTime>0.5</warmupTime>
+				<warmupTime>0.75</warmupTime>
 				<warmupEffecter>JumpWarmupEffect</warmupEffecter>
 				<requireLineOfSight>true</requireLineOfSight>
 				<targetParams>

--- a/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorLocust.xml
+++ b/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorLocust.xml
@@ -115,7 +115,7 @@
 			<li Class="CompProperties_Reloadable">
 				<maxCharges>5</maxCharges>
 				<ammoDef>Chemfuel</ammoDef>
-				<ammoCountPerCharge>30</ammoCountPerCharge>
+				<ammoCountPerCharge>20</ammoCountPerCharge>
 				<baseReloadTicks>60</baseReloadTicks>
 				<soundReload>Standard_Reload</soundReload>
 				<hotKey>Misc4</hotKey>

--- a/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorMarineGrenadier.xml
+++ b/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorMarineGrenadier.xml
@@ -19,9 +19,10 @@
 		<costList>
 			<Carbon>25</Carbon>
 			<Compaste>20</Compaste>
-			<Gold>10</Gold>
+			<GoldBar>10</GoldBar>
 			<SyntheticFibers>15</SyntheticFibers>
 			<MagneticMaterial>6</MagneticMaterial>
+			<ComponentSpacer>4</ComponentSpacer>
 			<Hexcell>13</Hexcell>
 		</costList>
 		<statBases>

--- a/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorMarinePrestige.xml
+++ b/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorMarinePrestige.xml
@@ -19,7 +19,7 @@
 		<costList>
 			<Carbon>12</Carbon>
 			<Compaste>20</Compaste>
-			<GoldBar>10</GoldBar>
+			<GoldBar>8</GoldBar>
 			<SyntheticFibers>8</SyntheticFibers>
 			<MagneticMaterial>2</MagneticMaterial>
 			<ComponentSpacer>2</ComponentSpacer>

--- a/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorMarinePrestige.xml
+++ b/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorMarinePrestige.xml
@@ -19,9 +19,10 @@
 		<costList>
 			<Carbon>12</Carbon>
 			<Compaste>20</Compaste>
-			<Gold>5</Gold>
+			<GoldBar>10</GoldBar>
 			<SyntheticFibers>8</SyntheticFibers>
 			<MagneticMaterial>2</MagneticMaterial>
+			<ComponentSpacer>2</ComponentSpacer>
 			<Hexcell>5</Hexcell>
 		</costList>
 		<statBases>
@@ -129,9 +130,10 @@
 		<costList>
 			<Carbon>25</Carbon>
 			<Compaste>20</Compaste>
-			<Gold>10</Gold>
+			<GoldBar>15</GoldBar>
 			<SyntheticFibers>15</SyntheticFibers>
 			<MagneticMaterial>6</MagneticMaterial>
+			<ComponentSpacer>5</ComponentSpacer>
 			<Hexcell>13</Hexcell>
 		</costList>
 		<statBases>

--- a/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorReconPrestige.xml
+++ b/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorReconPrestige.xml
@@ -20,8 +20,9 @@
 		<costList>
 			<Carbon>20</Carbon>
 			<Compaste>25</Compaste>
-			<Gold>10</Gold>
+			<GoldBar>15</GoldBar>
 			<BiosyntheticMaterial>4</BiosyntheticMaterial>
+			<ComponentSpacer>3</ComponentSpacer>
 			<Chitin>70</Chitin>
 		</costList>
 		<statBases>
@@ -133,8 +134,9 @@
 		<costList>
 			<Compaste>20</Compaste>
 			<Chitin>30</Chitin>
-			<Gold>5</Gold>
+			<GoldBar>10</GoldBar>
 			<MagneticMaterial>2</MagneticMaterial>
+			<ComponentSpacer>1</ComponentSpacer>
 			<Hexcell>3</Hexcell>
 		</costList>
 		<statBases>

--- a/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorReconPrestige.xml
+++ b/Mods/Core_SK/Royalty/Defs/ThingDefs_Apparel/ArmorReconPrestige.xml
@@ -134,7 +134,7 @@
 		<costList>
 			<Compaste>20</Compaste>
 			<Chitin>30</Chitin>
-			<GoldBar>10</GoldBar>
+			<GoldBar>8</GoldBar>
 			<MagneticMaterial>2</MagneticMaterial>
 			<ComponentSpacer>1</ComponentSpacer>
 			<Hexcell>3</Hexcell>

--- a/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/ApparelArmorCataphractBase.xml
+++ b/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/ApparelArmorCataphractBase.xml
@@ -163,7 +163,7 @@
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorCataphractPrestige"]</xpath>
 		<value>
 			<costList>
-				<Gold>12</Gold>
+				<GoldBar>18</GoldBar>
 			</costList>
 		</value>
 	</Operation>
@@ -314,7 +314,7 @@
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetCataphractPrestige"]</xpath>
 		<value>
 			<costList>
-				<Gold>6</Gold>
+				<GoldBar>9</GoldBar>
 			</costList>
 		</value>
 	</Operation>	

--- a/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/ApparelArmorCataphractBase.xml
+++ b/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/ApparelArmorCataphractBase.xml
@@ -314,7 +314,7 @@
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetCataphractPrestige"]</xpath>
 		<value>
 			<costList>
-				<GoldBar>9</GoldBar>
+				<GoldBar>12</GoldBar>
 			</costList>
 		</value>
 	</Operation>	

--- a/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/ApparelArmorCataphractBase.xml
+++ b/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/ApparelArmorCataphractBase.xml
@@ -314,7 +314,7 @@
 		<xpath>Defs/ThingDef[defName="Apparel_ArmorHelmetCataphractPrestige"]</xpath>
 		<value>
 			<costList>
-				<GoldBar>12</GoldBar>
+				<GoldBar>9</GoldBar>
 			</costList>
 		</value>
 	</Operation>	


### PR DESCRIPTION
1 light locust armor nerf (slightly more cost/work, added few ultra component and chemfuel to craft recipe), increased warmup time to jump (0.5 -> 0.75 sec.);
2 replaced golden ore to gold bar in all royalty armor recipes. Also added few spacer component to this armor recipes.

1 небольшой нерф брони богомола (немного увеличена стоимость/время создания, в рецепт добавлено немного ультра компонентов и химтопливо (как в рецепте прыжкового ранца), увеличено время задержки перед прыжком (0.5 -> 0.75 сек.);
2 золотая руда в рецептах королевской брони Роялти заменена на золотой сплав. Также в рецепт крафта этой брони добавлено немного высокоточных компонентов.