### PR TITLE
Some stone balls tweaks and fixes

### DIFF
--- a/Mods/CombatExtended/Languages/Russian/DefInjected/RecipeDefs/Recipes_AmmoNeolithic.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/RecipeDefs/Recipes_AmmoNeolithic.xml
@@ -34,13 +34,13 @@
 <MakeAmmo_BalistaBolt.description>Сделать 10 металлические болты для баллисты.</MakeAmmo_BalistaBolt.description>
 <MakeAmmo_BalistaBolt.jobstring>Делает металлические болты для баллисты.</MakeAmmo_BalistaBolt.jobstring>
 
-<MakeAmmo_StoneBall.label>сделать каменный шар x1</MakeAmmo_StoneBall.label>
-<MakeAmmo_StoneBall.description>Сделать 1 каменный шар.</MakeAmmo_StoneBall.description>
-<MakeAmmo_StoneBall.jobstring>Делает каменный шар.</MakeAmmo_StoneBall.jobstring>
+<MakeAmmo_StoneBall.label>сделать каменный шар x5</MakeAmmo_StoneBall.label>
+<MakeAmmo_StoneBall.description>Сделать 5 каменных шаров.</MakeAmmo_StoneBall.description>
+<MakeAmmo_StoneBall.jobstring>Делает каменные шары.</MakeAmmo_StoneBall.jobstring>
 
-<MakeAmmo_ExplosiveBall.label>сделать взрывной шар x1</MakeAmmo_ExplosiveBall.label>
-<MakeAmmo_ExplosiveBall.description>Сделать 1 взрывной шар.</MakeAmmo_ExplosiveBall.description>
-<MakeAmmo_ExplosiveBall.jobstring>Делает взрывной шар.</MakeAmmo_ExplosiveBall.jobstring>
+<MakeAmmo_ExplosiveBall.label>сделать взрывной шар x5</MakeAmmo_ExplosiveBall.label>
+<MakeAmmo_ExplosiveBall.description>Сделать 5 взрывных шаров.</MakeAmmo_ExplosiveBall.description>
+<MakeAmmo_ExplosiveBall.jobstring>Делает взрывные шары.</MakeAmmo_ExplosiveBall.jobstring>
 
 <MakeAmmo_Dart.label>сделать ядовитые дротики x50</MakeAmmo_Dart.label>
 <MakeAmmo_Dart.description>Сделать 50 ядовитых дротиков.</MakeAmmo_Dart.description>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/CatapultaBalls.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/CatapultaBalls.xml
@@ -56,7 +56,7 @@
 		<defName>Ammo_ExplosiveBall</defName>
 		<label>Explosive Ball</label>
 		<graphicData>
-			<texPath>Things/Projectile/Medieval_Catapult_Ball</texPath>
+			<texPath>Things/Projectile/Medieval_Catapult_ExplosiveBall</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
@@ -152,7 +152,7 @@
 
 	<RecipeDef ParentName="AmmoRecipeNeolithicBase">
 		<defName>MakeAmmo_StoneBall</defName>
-		<label>make stone balls x3</label>
+		<label>make stone balls x5</label>
 		<description>Craft stone balls.</description>
 		<jobString>Making stone balls.</jobString>
 		<targetCountAdjustment>1</targetCountAdjustment>
@@ -174,13 +174,13 @@
 			</categories>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_StoneBall>3</Ammo_StoneBall>
+			<Ammo_StoneBall>5</Ammo_StoneBall>
 		</products>
 	</RecipeDef>
 
 	<RecipeDef ParentName="AmmoRecipeNeolithicBase">
 		<defName>MakeAmmo_ExplosiveBall</defName>
-		<label>make explosive balls x3</label>
+		<label>make explosive balls x5</label>
 		<description>Craft explosive balls.</description>
 		<jobString>Making explosive balls.</jobString>
 		<targetCountAdjustment>1</targetCountAdjustment>
@@ -215,7 +215,7 @@
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>
-			<Ammo_ExplosiveBall>3</Ammo_ExplosiveBall>
+			<Ammo_ExplosiveBall>5</Ammo_ExplosiveBall>
 		</products>
 	</RecipeDef>
 


### PR DESCRIPTION
1 stone and explosive balls had similar texture. Fixed;
2 increased amount of balls (3 -> 5) from crafting recipe (I hope this helps to make catapults a little more popular);
3 some rus translation fixes.

1 каменные и взрывные шары имели одинаковую текстуру, хотя у нас есть две разные текстуры. Исправлено;
2 увеличен выход шаров при крафте с 3 до 5 (надеюсь, это поможет сделать катапульты чуточку популярнее);
3 поправлены переводы рецептов крафта шаров для катапульты.