### PR TITLE
Some USSR ammo fixes

### DIFF
--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Pistols/7.62x25mmTT.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Pistols/7.62x25mmTT.xml
@@ -75,6 +75,7 @@
 			<MarketValue>0.95</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
+		<generateAllowChance>0.3</generateAllowChance>
 		<cookOffProjectile>Bullet_762x25mmTT_AP</cookOffProjectile>
 	</ThingDef>
 
@@ -89,6 +90,7 @@
 			<MarketValue>0.85</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
+		<generateAllowChance>0.45</generateAllowChance>
 		<cookOffProjectile>Bullet_762x25mmTT_HP</cookOffProjectile>
 	</ThingDef>
 
@@ -103,7 +105,7 @@
 			<MarketValue>1.4</MarketValue>
 		</statBases>
 		<ammoClass>IncendiaryAP</ammoClass>
-		<generateCommonality>0.8</generateCommonality>
+		<generateAllowChance>0.15</generateAllowChance>
 		<cookOffProjectile>Bullet_762x25mmTT_API</cookOffProjectile>
 	</ThingDef>
 

--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/545x39mmSoviet.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/545x39mmSoviet.xml
@@ -74,6 +74,7 @@
 			<MarketValue>1.75</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
+		<generateAllowChance>0.45</generateAllowChance>
 		<cookOffProjectile>Bullet_545x39mmSoviet_AP</cookOffProjectile>
 	</ThingDef>
 
@@ -88,6 +89,7 @@
 			<MarketValue>1.65</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
+		<generateAllowChance>0.35</generateAllowChance>
 		<cookOffProjectile>Bullet_545x39mmSoviet_HP</cookOffProjectile>
 	</ThingDef>
 

--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/762x54mmR.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/762x54mmR.xml
@@ -74,6 +74,7 @@
 			<MarketValue>2.85</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
+		<generateAllowChance>0.35</generateAllowChance>
 		<cookOffProjectile>Bullet_762x54mmR_AP</cookOffProjectile>
 	</ThingDef>
 
@@ -88,6 +89,7 @@
 			<MarketValue>2.63</MarketValue>
 		</statBases>
 		<ammoClass>HollowPoint</ammoClass>
+		<generateAllowChance>0.45</generateAllowChance>
 		<cookOffProjectile>Bullet_762x54mmR_HP</cookOffProjectile>
 	</ThingDef>
 

--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/9x39mmSoviet.xml
@@ -75,7 +75,7 @@
 			<MarketValue>2.1</MarketValue>
 		</statBases>
 		<ammoClass>ArmorPiercing</ammoClass>
-		<generateCommonality>0.9</generateCommonality>
+		<generateAllowChance>0.7</generateAllowChance>
 		<cookOffProjectile>Bullet_9x39mmSoviet_AP</cookOffProjectile>
 	</ThingDef>
 
@@ -90,7 +90,7 @@
 			<MarketValue>2.23</MarketValue>
 		</statBases>
 		<ammoClass>Shock</ammoClass>
-		<generateCommonality>0.3</generateCommonality>
+		<generateAllowChance>0.25</generateAllowChance>
 		<cookOffProjectile>Bullet_9x39mmSoviet_SH</cookOffProjectile>
 	</ThingDef>
 	
@@ -105,8 +105,8 @@
 			<MarketValue>2.55</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
-		<generateCommonality>0.4</generateCommonality>
-		<cookOffProjectile>Bullet_9x39mmSoviet_SH</cookOffProjectile>
+		<generateAllowChance>0.35</generateAllowChance>
+		<cookOffProjectile>Bullet_9x39mmSoviet_EMP</cookOffProjectile>
 	</ThingDef>	
 
 	<!-- ================== Projectiles ================== -->


### PR DESCRIPTION
1 replaced generateCommonality param to generateAllowChance to correction chance of ammo type spawn (raids);
2 fixed incorrect 9x39 emp base projectile (was SH instead of EMP).

1 заменен параметр generateCommonality на generateAllowChance (отвечает за шанс появления у рейдов тех или иных видов боеприпасов) (заменил, т.к. первый перестал работать после введения второго);
2 исправлен некорректный базовый снаряд у 9x39 emp боеприпасов (был SH вместо EMP).