### PR TITLE
Some ratkin's pawns tweaks and fixes

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
+++ b/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
@@ -11,11 +11,9 @@
 		<canMakeRandomly>true</canMakeRandomly>
 		<leaderTitle>prime executor</leaderTitle>
 		<earliestRaidDays>135</earliestRaidDays>
-
 		<factionNameMaker>NamerFaction_RatkinKingdom</factionNameMaker>
 		<settlementNameMaker>NamerSettlement_RatkinKingdom</settlementNameMaker>
 		<pawnNameMaker>NamerPerson_RatkinKingdom</pawnNameMaker>
-
 		<canSiege>true</canSiege>
 		<canStageAttacks>true</canStageAttacks>
 		<factionIconPath>Icon/RK_icon</factionIconPath>
@@ -210,12 +208,15 @@
 			<thingDefs>
 				<li>DevilstrandCloth</li>
 			</thingDefs>
+			<disallowedThingDefs>
+				<li>Chitin</li>
+				<li>Velour</li>
+			</disallowedThingDefs>
 		</apparelStuffFilter>
 	</FactionDef>
 
 	<FactionDef ParentName="RatkinFactionBase">
 		<defName>Rakinia</defName>
-		<earliestRaidDays>135</earliestRaidDays>
 		<label>ratkin kingdom</label>
 		<description>Ratkin War Kingdom. It is a invasive xenophobic species that lives visible to human beings and want to kill them all.</description>
 		<colorSpectrum>
@@ -229,7 +230,6 @@
 
 	<FactionDef ParentName="RatkinFactionBase">
 		<defName>Rakiniville</defName>
-		<earliestRaidDays>135</earliestRaidDays>
 		<label>ratkin kingdom</label>
 		<description>랫킨 왕국입니다. 인간들 눈에 띄지 않도록 숨어서 살고 있으며 농경생활을 위주로 생활하는 비 침략적인 종족입니다.</description>
 		<colorSpectrum>

--- a/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
+++ b/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
@@ -224,7 +224,7 @@
 			<li>(0.95, 0.25, 0.00)</li>
 		</colorSpectrum>
 		<startingGoodwill>-90~-80</startingGoodwill>
-		<naturalColonyGoodwill>0~10</naturalColonyGoodwill>
+		<naturalColonyGoodwill>-90~-80</naturalColonyGoodwill>
 		<factionIconPath>Icon/RK_icon3</factionIconPath>
 	</FactionDef>
 

--- a/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
+++ b/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
@@ -219,8 +219,8 @@
 			<max>2000</max>
 		</apparelMoney>
 		<weaponMoney>
-			<min>2000</min>
-			<max>3500</max>
+			<min>700</min>
+			<max>1750</max>
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_LightWeapon</li>
@@ -235,7 +235,7 @@
 		<defName>RatkinDefender</defName>
 		<label>ratkin defender</label>
 		<baseRecruitDifficulty>0.65</baseRecruitDifficulty>
-		<combatPower>225</combatPower>
+		<combatPower>180</combatPower>
 		<isFighter>true</isFighter>
 		<minGenerationAge>21</minGenerationAge>
 		<backstoryFiltersOverride>
@@ -254,8 +254,8 @@
 			<max>8000</max>
 		</apparelMoney>
 		<weaponMoney>
-			<min>2000</min>
-			<max>3500</max>
+			<min>450</min>
+			<max>1125</max>
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_Defender</li>
@@ -340,8 +340,8 @@
 			<li>RK_GaurdenUniform</li>
 		</apparelRequired>
 		<weaponMoney>
-			<min>3000</min>
-			<max>5000</max>
+			<min>1000</min>
+			<max>2000</max>
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_Sword</li>
@@ -403,8 +403,8 @@
 			<max>8000</max>
 		</apparelMoney>
 		<weaponMoney>
-			<min>2000</min>
-			<max>3500</max>
+			<min>400</min>
+			<max>1000</max>
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_Knight</li>
@@ -449,8 +449,8 @@
 			<max>8000</max>
 		</apparelMoney>
 		<weaponMoney>
-			<min>1500</min>
-			<max>4000</max>
+			<min>600</min>
+			<max>1500</max>
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_EliteDefender</li>
@@ -499,8 +499,8 @@
 			<max>8000</max>
 		</apparelMoney>
 		<weaponMoney>
-			<min>2000</min>
-			<max>4500</max>
+			<min>750</min>
+			<max>2000</max>
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_HeavyLance</li>
@@ -645,9 +645,6 @@
 		</techHediffsRequired>
 		<apparelAllowHeadgearChance>1</apparelAllowHeadgearChance>
 	</PawnKindDef>
-
-
-	
 	<!-- 기타 -->
 	<!-- 곳간털이범 -->
 	<PawnKindDef ParentName="RKCombatantBase">
@@ -678,8 +675,8 @@
 		</apparelTags>
 		<apparelColor>(100,100,100)</apparelColor>
 		<weaponMoney>
-			<min>750</min>
-			<max>1500</max>
+			<min>80</min>
+			<max>160</max>
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_RatkinThiefWeapon</li>
@@ -714,8 +711,8 @@
 			<max>5000</max>
 		</apparelMoney>
 		<weaponMoney>
-			<min>3000</min>
-			<max>3500</max>
+			<min>150</min>
+			<max>650</max>
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_Murderer</li>
@@ -744,8 +741,8 @@
 			<max>4800</max>
 		</apparelMoney>
 		<weaponMoney>
-			<min>3000</min>
-			<max>5000</max>
+			<min>1000</min>
+			<max>2000</max>
 		</weaponMoney>
 		<weaponTags>
 			<li>RK_Sword</li>
@@ -906,9 +903,4 @@
 			<li>RK_Combatant</li>
 		</apparelTags>
 	</PawnKindDef>
-	
-
-
-
-
 </Defs>


### PR DESCRIPTION
1 fixed ratkin kingdom (hostile faction) natural colony goodwill param (it will reducing now);
2 corrected melee ratkin raider pawns weapon cost to remove chance to spawn with hi-tech materials (like alpha/beta poly, titan etc). Also disabled chitin and velour spawn for ratkin's apparels (raids only).

1 поправлено периодическое изменение отношения враждебной фракции раткинов (теперь должно уменьшаться со временем, а не увеличиваться);
2 скорректирована стоимость оружия ближнего боя у пешек-рейдеров раткинов (для исключения возможности появления хайтек материалов вроде альфа/бета поли, титана и т.д). Также выключена возможность спавна одежды из хитина и велюра.