### PR TITLE
Small Weapon Fix

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
@@ -150,8 +150,8 @@
             <ShotSpread>0.1</ShotSpread>
             <SwayFactor>1.5</SwayFactor>
             <RangedWeapon_Cooldown>0.5</RangedWeapon_Cooldown>
-            <Bulk>20</Bulk>
-            <Mass>20</Mass>
+            <Bulk>19</Bulk>
+            <Mass>9.5</Mass>
         </statBases>
         <weaponTags>
             <li>MG2</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
@@ -504,9 +504,8 @@
             <Mass>4.3</Mass>
         </statBases>
         <weaponTags>
-            <li>RF2</li>
+            <li>RF4</li>
             <li>AdvancedGun</li>
-            <li>TierTwoRifle</li>
             <li>TierThreeRifle</li>
             <li>CE_AI_Rifle</li>
         </weaponTags>


### PR DESCRIPTION
ENG:
MA39X was too heavy for a LMG. Most LMGs weight (kg) is about 8kg. But this one, dont know why, has 20. Way to much, for what you get. Easier to just use the microgun.

SCAR-H was way to common. Sometimes you get some ferals with pistols and smgs, and then you also see some with a SCAR-H. I for my part had same issue. Had about 4 SCARs but no other rifles. Its because you get that easy feral raids, where they have about 4 SCARs, even if most of them are only armed with pistols and SMGs. You get faster a SCAR-H then you get a M16 or AK.

RU:
MA39X был слишком тяжелым для LMG. Вес большинства LMG (кг) составляет около 8 кг. Но у этого, не знаю почему, 20. Слишком много, за то, что ты получаешь. Легче просто использовать microgun.

SCAR-H был очень распространен.Иногда бывают одичалые с пистолетами и смг, а потом еще и с SCAR-H.  У меня, со своей стороны, была такая же проблема. Я разграбил около 4-х SCAR в рейде с легкими врагами. У них у всех были пистолеты, Смг, а также SCAR. Ты получаешь быстрее SCAR-H, чем M16 или AK.