### PR TITLE
Small Dubs Hygine Fixes

### DIFF
--- a/Mods/Dubs-Bad-Hygiene/Defs/ThingDefs_Buildings/BuildingsD_WaterManagement.xml
+++ b/Mods/Dubs-Bad-Hygiene/Defs/ThingDefs_Buildings/BuildingsD_WaterManagement.xml
@@ -191,21 +191,20 @@
 		<costList>
 		    <Mechanism>1</Mechanism>
 			<ComponentMedieval>15</ComponentMedieval>
-			<WoodLog>500</WoodLog>
 		</costList>
 		<stuffCategories>
 			<li>Metallic</li>
 			<li>Stony</li>
 			<li>Plastic</li>
 		</stuffCategories>
-		<costStuffCount>100</costStuffCount>
+		<costStuffCount>250</costStuffCount>
     <comps>
       <li Class="DubsBadHygiene.CompProperties_WaterStorage">
         <WaterStorageCap>8000</WaterStorageCap>
       </li>
     </comps>
     <statBases>
-      <MaxHitPoints>75</MaxHitPoints>
+      <MaxHitPoints>350</MaxHitPoints>
       <WorkToBuild>2000</WorkToBuild>
       <Flammability>1.0</Flammability>
     </statBases>
@@ -241,9 +240,9 @@
 			<li>Stony</li>
 			<li>Plastic</li>
 		</stuffCategories>
-		<costStuffCount>200</costStuffCount>
+		<costStuffCount>350</costStuffCount>
     <statBases>
-      <MaxHitPoints>150</MaxHitPoints>
+      <MaxHitPoints>550</MaxHitPoints>
       <WorkToBuild>5000</WorkToBuild>
       <Flammability>0.0</Flammability>
     </statBases>

--- a/Mods/Dubs-Bad-Hygiene/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
+++ b/Mods/Dubs-Bad-Hygiene/Defs/ThingDefs_Buildings/BuildingsE_Heating.xml
@@ -249,7 +249,11 @@
 		<stuffCategories>
 			<li>Metallic</li>
 		</stuffCategories>
-		<costStuffCount>130</costStuffCount>
+		<costStuffCount>120</costStuffCount>
+	  	<costList>
+			<ComponentIndustrial>5</ComponentIndustrial>
+			<ElectronicComponents>3</ElectronicComponents>
+		</costList>
     <rotatable>true</rotatable>
     <statBases>
       <MaxHitPoints>125</MaxHitPoints>
@@ -310,6 +314,7 @@
 		<costList>
 			<Glass>10</Glass>
 			<ComponentIndustrial>2</ComponentIndustrial>
+			<ElectronicComponents>2</ElectronicComponents>
 		</costList>
 		<costStuffCount>50</costStuffCount>
     <rotatable>false</rotatable>


### PR DESCRIPTION
ENG:
Water tower where to weak from HP side. A big water tower had same HP as the little water butt. 
Now all tower have more HP and they wont die after two shots.
Also removed wood requirement for water tower. I dont see any sense, why i need wood if i build a metal water tower. 
Base cost is bit higher, but no wood cost because of this. (Yay desert players)
Added electronic cost to "electric boiler" and "solar heater". Before they had no electronic cost at all. (what dont make sense for that technology)

RU:
Водонапорная башня, слаба со стороны ХП. Большая водонапорная башня имела те же самые ХП, что и маленькая водонапорная Бочка. 
Теперь у всех башен больше ХП и они не умрут после двух выстрелов.
Также удалены требования древесины для водонапорной башни. Я не вижу никакого смысла, почему мне нужно дерево, если я построю металлическую водонапорную башню. 
Базовая стоимость немного выше, но нет стоимости древесины из-за этого. (Игроки пустыни Ура)
Добавлена электронная стоимость "электрического котла" и "солнечного нагревателя". Раньше у них вообще не было электронной стоимости. (что не имеет смысла для этой технологии)
