### PR TITLE
Corrected melchior craft recipe (removed aluminium)

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Alloys.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Alloys.xml
@@ -377,7 +377,7 @@
 	<RecipeDef>
 		<defName>MakeCupronickelAlloy</defName>
 		<label>Smelt melchior alloy</label>
-		<description>Smelts melchior alloy from copper, nickel and aluminum. Melchior has a high electrical resistance. Produces 30.</description>
+		<description>Smelts melchior alloy from copper and nickel. Melchior has a high electrical resistance. Produces 30.</description>
 		<jobString>Smelting melchior alloy.</jobString>
 		<workAmount>1600</workAmount>
 		<workSpeedStat>SmeltingSpeed</workSpeedStat>
@@ -390,20 +390,12 @@
 						<li>CopperBar</li>
 					</thingDefs>
 				</filter>
-				<count>20</count>
+				<count>24</count>
 			</li>
 			<li>
 				<filter>
 					<thingDefs>
 						<li>NickelBar</li>
-					</thingDefs>
-				</filter>
-				<count>4</count>
-			</li>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>AluminiumBar</li>
 					</thingDefs>
 				</filter>
 				<count>6</count>
@@ -413,7 +405,6 @@
 			<thingDefs>
 						<li>CopperBar</li>
 						<li>NickelBar</li>
-						<li>AluminiumBar</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<products>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
@@ -370,7 +370,7 @@
 	<ThingDef ParentName="SK_ResourceBase">
 		<defName>CupronickelAlloy</defName>
 		<label>melchior alloy</label>
-		<description>Melchior is an alloy of Copper, Nickel and Aluminum. This alloy combination has a higher resistance to corrosion and electricity than standard alloys of Copper or Aluminum. Melchior Alloy is a magnetic metal.</description>
+		<description>Melchior is an alloy of Copper and Nickel. This alloy combination has a higher resistance to corrosion and electricity than standard alloys of Copper. Melchior Alloy is a magnetic metal.</description>
 		<graphicData>
 			<texPath>Things/Item/Ingot</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>


### PR DESCRIPTION
This alloy not contain aluminium.

Скорректирован рецепт выплавки мельхиора (убран алюминий). В этом сплаве его на самом деле нет.