### PR TITLE
Some berserk herb tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/Drugs/Garden Drugs.xml
+++ b/Mods/Core_SK/Defs/Drugs/Garden Drugs.xml
@@ -83,7 +83,8 @@
 		<statBases>
 			<WorkToMake>200</WorkToMake>
 			<MarketValue>13</MarketValue>
-			<Mass>0.005</Mass>
+			<Mass>0.1</Mass>
+			<Bulk>0.1</Bulk>
 			<Nutrition>0.01</Nutrition>
 		</statBases>
 		<techLevel>Neolithic</techLevel>
@@ -133,6 +134,7 @@
 		<comps>
 			<li Class="CompProperties_Drug">
 				<addictiveness>0</addictiveness>
+				<isCombatEnhancingDrug>true</isCombatEnhancingDrug>
 				<listOrder>1000</listOrder>
 				<overdoseSeverityOffset>0.08~0.14</overdoseSeverityOffset>
 			</li>
@@ -158,6 +160,9 @@
 				<minSeverity>0.01</minSeverity>
 				<label>Berserk herb high</label>
 				<painFactor>0.5</painFactor>
+				<statOffsets>
+					<Suppressability>-0.25</Suppressability>
+				</statOffsets>
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
@@ -169,6 +174,9 @@
 				<minSeverity>0.72</minSeverity>
 				<label>Berserk dangerous high</label>
 				<painFactor>0.5</painFactor>
+				<statOffsets>
+					<Suppressability>-0.25</Suppressability>
+				</statOffsets>
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>


### PR DESCRIPTION
1 added "is combat enhancing drug" tag to berserk herb;
2 added missed CE param (bulk and suppressability) to berserk herb. Also slightly increased mass param.

1 добавлен "is combat enhancing drug" тэг для berserk herb (для возможности использования рейдерами при их спавне);
2 добавлены пропущенные параметры CE (объем и вероятность подавления) для berserk herb. Также немного увеличил массу (была меньше, чем у дымолиста раз в десять).