### PR TITLE
Some trait tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThoughtDefs/Vanilla/Thoughts_Memory_Misc_VanillaRework.xml
+++ b/Mods/Core_SK/Defs/ThoughtDefs/Vanilla/Thoughts_Memory_Misc_VanillaRework.xml
@@ -61,7 +61,7 @@
 		<durationDays>0.5</durationDays>
 		<stackLimit>1</stackLimit>
 		<nullifyingTraits>
-			<li>Tough</li>
+			<li>Hardened</li>
 		</nullifyingTraits>
 		<stages>
 			<li>
@@ -77,7 +77,7 @@
 		<durationDays>0.5</durationDays>
 		<stackLimit>1</stackLimit>
 		<nullifyingTraits>
-			<li>Tough</li>
+			<li>Hardened</li>
 		</nullifyingTraits>
 		<stages>
 			<li>
@@ -94,7 +94,7 @@
 		<durationDays>0.5</durationDays>
 		<stackLimit>1</stackLimit>
 		<nullifyingTraits>
-			<li>Tough</li>
+			<li>Hardened</li>
 		</nullifyingTraits>
 		<stages>
 			<li>
@@ -110,7 +110,7 @@
 		<durationDays>0.5</durationDays>
 		<stackLimit>1</stackLimit>
 		<nullifyingTraits>
-			<li>Tough</li>
+			<li>Hardened</li>
 		</nullifyingTraits>
 		<stages>
 			<li>
@@ -241,6 +241,8 @@
 			<li>Psychopath</li>
 			<li>Bloodlust</li>
 			<li>Cannibal</li>
+			<li>Pragmatist</li>
+			<li>Villian</li>
 		</nullifyingTraits>
 		<stages>
 			<li>
@@ -261,6 +263,7 @@
 			<li>Bloodlust</li>
 			<li>Cannibal</li>
 			<li>Pragmatist</li>
+			<li>Villian</li>
 		</nullifyingTraits>
 		<stages>
 			<li>

--- a/Mods/Core_SK/Defs/TraitDefs/Expanded Traits.xml
+++ b/Mods/Core_SK/Defs/TraitDefs/Expanded Traits.xml
@@ -35,6 +35,7 @@
 		<conflictingTraits>
 			<li>Psychopath</li>
 			<li>Abrasive</li>
+			<li>Naive</li>
 		</conflictingTraits>
 		<requiredWorkTags>
 			<li>Violent</li>
@@ -67,6 +68,11 @@
 		</degreeDatas>
 		<conflictingTraits>
 			<li>ChaoticGenius</li>
+			<li>Ignorant</li>
+			<li>Inventor</li>
+			<li>FastLearner</li>
+			<li>SlowLearner</li>
+			<li>TooSmart</li>
 		</conflictingTraits>
 		<requiredWorkTags>
 			<li>Intellectual</li>
@@ -90,6 +96,7 @@
 		<conflictingTraits>
 			<li>TooSmart</li>
 			<li>FastLearner</li>
+			<li>SlowLearner</li>
 			<li>Ignorant</li>
 			<li>Dumb</li>
 		</conflictingTraits>
@@ -120,10 +127,16 @@
 		<conflictingTraits>
 			<li>TooSmart</li>
 			<li>FastLearner</li>
+			<li>SlowLearner</li>
 			<li>Inventor</li>
 			<li>DIY</li>
 			<li>ChaoticGenius</li>
 			<li>Dumb</li>
+			<li>Chemist</li>
+			<li>Gourmet</li>
+			<li>Medic</li>
+			<li>Trader</li>
+			<li>Diplomat</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -160,7 +173,6 @@
 		</requiredWorkTags>
 		<conflictingTraits>
 			<li>Aptitude</li>
-			<li>Dumb</li>
 			<li>Ignorant</li>
 			<li>Abrasive</li>
 		</conflictingTraits>
@@ -184,6 +196,7 @@
 		<conflictingTraits>
 			<li>Weak</li>
 			<li>Abrasive</li>
+			<li>Nimble</li>
 			<li>Constitution</li>
 			<li>Dodging</li>
 		</conflictingTraits>
@@ -206,7 +219,6 @@
 		</degreeDatas>
 		<conflictingTraits>
 			<li>Strong</li>
-			<li>Weak</li>
 			<li>Abrasive</li>
 			<li>Nimble</li>
 			<li>Constitution</li>
@@ -270,6 +282,7 @@
 			<li>Religious</li>
 			<li>Cultist</li>
 			<li>Psychopath</li>
+			<li>Naive</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -325,6 +338,7 @@
 			<li>Fanatic</li>
 			<li>Psychopath</li>
 			<li>Villian</li>
+			<li>Numb</li>
 		</conflictingTraits>
 	</TraitDef>	
 
@@ -352,6 +366,7 @@
 		<conflictingTraits>
 			<li>Psychopath</li>
 			<li>Naive</li>
+			<li>Extrovert</li>
 		</conflictingTraits>
 	</TraitDef>  
 
@@ -369,14 +384,17 @@
 				<statOffsets>
 					<MentalBreakThreshold>-0.08</MentalBreakThreshold>
 					<PainShockThreshold>0.15</PainShockThreshold>
+					<ComfyTemperatureMax>6</ComfyTemperatureMax>
+					<ComfyTemperatureMin>-6</ComfyTemperatureMin>
 				</statOffsets>
 			</li>
 		</degreeDatas>
 		<conflictingTraits>
-			<li>Abrasive</li>
-			<li>Reaver</li>
 			<li>Naive</li>
-			<li>PsychicSensitivity</li>
+			<li>Pragmatist</li>
+			<li>PainThreshold</li>
+			<li>Wimp</li>
+			<li>Nerves</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -404,7 +422,6 @@
 		<conflictingTraits>
 			<li>Confident</li>
 			<li>Hardened</li>
-			<li>Tough</li>
 		</conflictingTraits>
 	</TraitDef>	
 
@@ -496,6 +513,7 @@
 		<conflictingTraits>
 			<li>Fast</li>
 			<li>Nimble</li>
+			<li>SpeedOffset</li>
 		</conflictingTraits>
 	</TraitDef>   	
 
@@ -561,23 +579,15 @@
 			<li>Villian</li>
 			<li>Introvert</li>
 			<li>Numb</li>
-			<li>Weak</li>
-			<li>Dumb</li>
-			<li>Ignorant</li>
-			<li>Slow</li>
 			<li>Abrasive</li>
 			<li>AnnoyingVoice</li>
 			<li>Nyctophobe</li>
 			<li>Wimp</li>
 			<li>Bipolar</li>
-			<li>Claustrophobic</li>
 			<li>Psychopath</li>
 			<li>Leader</li>
 			<li>Brawler</li>
-			<li>SpeedOffset</li>
-			<li>Industriousness</li>
 			<li>PsychicSensitivity</li>
-			<li>Beauty</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -604,7 +614,9 @@
 			</li>
 		</degreeDatas>
 		<conflictingTraits>
+			<li>Extrovert</li>
 			<li>Personality</li>
+			<li>Leader</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -631,11 +643,7 @@
 		</degreeDatas>
 		<conflictingTraits>
 			<li>Introvert</li>
-			<li>Villian</li>
 			<li>Numb</li>
-			<li>Weak</li>
-			<li>Dumb</li>
-			<li>Ignorant</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -668,23 +676,16 @@
 			<li>Villian</li>
 			<li>Introvert</li>
 			<li>Numb</li>
-			<li>Weak</li>
-			<li>Dumb</li>
-			<li>Ignorant</li>
-			<li>Slow</li>
 			<li>Abrasive</li>
 			<li>AnnoyingVoice</li>
 			<li>Nyctophobe</li>
 			<li>Wimp</li>
 			<li>Bipolar</li>
-			<li>Claustrophobic</li>
 			<li>Psychopath</li>
 			<li>Personality</li>
 			<li>Brawler</li>
-			<li>SpeedOffset</li>
-			<li>Industriousness</li>
 			<li>PsychicSensitivity</li>
-			<li>Beauty</li>
+			<li>Nerves</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -712,7 +713,6 @@
 			<li>Leader</li>
 			<li>Personality</li>
 			<li>Kind</li>
-			<li>Extrovert</li>
 			<li>Confident</li>
 			<li>Naive</li>
 		</conflictingTraits>

--- a/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
+++ b/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
@@ -38,11 +38,12 @@
 
 	<TraitDef>
 		<defName>BrownThumb</defName>
-		<commonality>0.4</commonality>
+		<commonality>0.85</commonality>
 		<degreeDatas>
 			<li>
 				<label>brown thumb</label>
 				<description>{PAWN_nameDef} is a terrible gardener. The only thing {PAWN_pronoun} seems able to grow is weeds.</description>
+				<degree>0</degree>
 				<statOffsets>
 					<PlantHarvestYield>-0.2</PlantHarvestYield>
 					<PlantWorkSpeed>-0.2</PlantWorkSpeed>
@@ -54,10 +55,25 @@
 					</li>
 				</skillGains>
 			</li>
+			<li>
+				<label>green thumb</label>
+				<description>{PAWN_nameDef} has a passion for gardening. {PAWN_pronoun} gets a mood bonus while {PAWN_pronoun} sowing plants.</description>
+				<degree>1</degree>
+				<statOffsets>
+					<PlantHarvestYield>0.2</PlantHarvestYield>
+					<PlantWorkSpeed>0.2</PlantWorkSpeed>
+				</statOffsets>
+				<skillGains>
+					<li>
+						<key>Plants</key>
+						<value>2</value>
+					</li>
+				</skillGains>
+			</li>
 		</degreeDatas>
 		<conflictingTraits>
-			<!-- <li>GreenThumb</li> -->
 			<li>Aptitude</li>
+			<li>Rockhound</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -90,7 +106,6 @@
 			<li>AnimalLover</li>
 			<li>Aptitude</li>
 			<li>Naive</li>
-			<li>Dumb</li>
 			<li>Ignorant</li>
 		</conflictingTraits>
 	</TraitDef>
@@ -125,7 +140,6 @@
 		</requiredWorkTypes>
 		<conflictingTraits>
 			<li>Aptitude</li>
-			<li>Dumb</li>
 			<li>Ignorant</li>
 		</conflictingTraits>
 	</TraitDef>
@@ -152,7 +166,6 @@
 		<conflictingTraits>
 			<li>Aptitude</li>
 			<li>Rockhound</li>
-			<li>Leader</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -210,7 +223,6 @@
 		</requiredWorkTypes>
 		<conflictingTraits>
 			<li>Aptitude</li>
-			<li>Dumb</li>
 			<li>Ignorant</li>
 		</conflictingTraits>
 	</TraitDef>
@@ -325,11 +337,9 @@
 		</degreeDatas>
 		<conflictingTraits>
 			<li>Wimp</li>
-			<li>Dodging</li>
 			<li>Hardened</li>
 			<li>Weak</li>
 			<li>Strong</li>
-			<li>Nimble</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -399,7 +409,6 @@
 		<conflictingTraits>
 			<li>ShootingAccuracy</li>
 			<li>Reaver</li>
-			<li>Dumb</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -431,11 +440,6 @@
 		<requiredWorkTags>
 			<li>Cleaning</li>
 		</requiredWorkTags>
-		<conflictingTraits>
-			<li>Dumb</li>
-			<li>Nimble</li>
-			<li>Ignorant</li>
-		</conflictingTraits>
 	</TraitDef>
 
 	<TraitDef>
@@ -586,7 +590,6 @@
 			<li>Caring</li>
 		</requiredWorkTags>
 		<conflictingTraits>
-			<li>Dumb</li>
 			<li>Ignorant</li>
 		</conflictingTraits>
 	</TraitDef>
@@ -627,9 +630,9 @@
 			<li>Mining</li>
 		</requiredWorkTypes>
 		<conflictingTraits>
-			<!-- <li>GreenThumb</li> -->
 			<li>Aptitude</li>
 			<li>Claustrophobic</li>
+			<li>BrownThumb</li>
 		</conflictingTraits>
 	</TraitDef>
 
@@ -657,8 +660,6 @@
 		</degreeDatas>
 		<conflictingTraits>
 			<li>Nimble</li>
-			<li>Ignorant</li>
-			<li>Dumb</li>
 			<li>Slow</li>
 			<li>Strong</li>
 			<li>Weak</li>
@@ -722,7 +723,7 @@
 			<li>Abrasive</li>
 			<li>AnnoyingVoice</li>
 			<li>CreepyBreathing</li>
-			<li>Dumb</li>
+			<li>Ignorant</li>
 		</conflictingTraits>
 		<requiredWorkTags>
 			<li>Social</li>
@@ -773,9 +774,6 @@
 		<conflictingTraits>
 			<li>Brawler</li>
 			<li>Eyesight</li>
-			<li>Naive</li>
-			<li>Dumb</li>
-			<li>Ignorant</li>
 		</conflictingTraits>
 		<requiredWorkTags>
 			<li>Violent</li>
@@ -848,7 +846,7 @@
 			<li>Abrasive</li>
 			<li>AnnoyingVoice</li>
 			<li>CreepyBreathing</li>
-			<li>Dumb</li>
+			<li>Ignorant</li>
 		</conflictingTraits>
 		<requiredWorkTags>
 			<li>Social</li>
@@ -883,7 +881,6 @@
 		<conflictingTraits>
 			<li>Weak</li>
 			<li>Strong</li>
-			<li>Nimble</li>
 		</conflictingTraits>
 	</TraitDef>
 

--- a/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/Expanded Traits.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/Expanded Traits.xml
@@ -10,7 +10,7 @@
   <!-- Xp mod Related -->
 
   <Dumb.degreeDatas.0.label>тупость</Dumb.degreeDatas.0.label>
-  <Dumb.degreeDatas.0.description>{PAWN_nameDef} очень туго соображает в науке, но обладает бонусом психической устойчивости.</Dumb.degreeDatas.0.description>
+  <Dumb.degreeDatas.0.description>{PAWN_nameDef} очень туго соображает в науке, но обладает высокой исполнительностью.</Dumb.degreeDatas.0.description>
 
   <ChaoticGenius.degreeDatas.0.label>гениальность</ChaoticGenius.degreeDatas.0.label>
   <ChaoticGenius.degreeDatas.0.description>{PAWN_nameDef} имеет невероятный ум, но {PAWN_pronoun} также страдает от неуравновешенности.</ChaoticGenius.degreeDatas.0.description>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/RCT_Traits.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/RCT_Traits.xml
@@ -9,6 +9,8 @@
 
   <BrownThumb.degreeDatas.0.label>плохой садовод</BrownThumb.degreeDatas.0.label>
   <BrownThumb.degreeDatas.0.description>{PAWN_nameDef} страшный садовник. Единственное, что {PAWN_pronoun} способен вырастить это сорняки.</BrownThumb.degreeDatas.0.description>
+  <BrownThumb.degreeDatas.1.label>хороший садовод</BrownThumb.degreeDatas.1.label>
+  <BrownThumb.degreeDatas.1.description>{PAWN_nameDef} имеет страсть к садоводству. {PAWN_pronoun} получает бонус к настроению во время посадки растений.</BrownThumb.degreeDatas.1.description>
 
   <Butcher.degreeDatas.0.label>мясник</Butcher.degreeDatas.0.label>
   <Butcher.degreeDatas.0.description>{PAWN_nameDef} любит готовить мясо для приготовления пищи. {PAWN_possessive} скорость разделываения значительно возрастает, но только если {PAWN_pronoun} имеет дело с трупами животных. {PAWN_pronoun} ужасен при разборке механоидов.</Butcher.degreeDatas.0.description>

--- a/Mods/Core_SK/Patches/TraitDefs_Core_Patch.xml
+++ b/Mods/Core_SK/Patches/TraitDefs_Core_Patch.xml
@@ -120,8 +120,6 @@
 		<value>
 			<li>Ignorant</li>
 			<li>ChaoticGenius</li>
-			<li>Villian</li>
-			<li>Numb</li>
 			<li>Dumb</li>
 		</value>
 	</Operation>
@@ -194,6 +192,7 @@
 		<value>
 			<li>TooSmart</li>
 			<li>Leader</li>
+			<li>Hardened</li>
 		</value>
 	</Operation>
 
@@ -217,6 +216,9 @@
 		<xpath>Defs/TraitDef[defName = "Nimble"]/conflictingTraits</xpath>
 		<value>
 			<li>Dodging</li>
+			<li>Strong</li>
+			<li>Weak</li>
+			<li>Aptitude</li>
 		</value>
 	</Operation>
 
@@ -271,6 +273,9 @@
 		<xpath>Defs/TraitDef[defName = "Wimp"]/conflictingTraits</xpath>
 		<value>
 			<li>PainThreshold</li>
+			<li>Hardened</li>
+			<li>Personality</li>
+			<li>Leader</li>
 		</value>
 	</Operation>
 
@@ -326,6 +331,13 @@
 			<li>Nerves</li>
 			<li>NaturalMood</li>
 			<li>Leader</li>
+			<li>Religious</li>
+			<li>Fanatic</li>
+			<li>Cultist</li>
+			<li>Naive</li>
+			<li>Numb</li>
+			<li>AnimalLover</li>
+			<li>Pragmatist</li>
 		</value>
 	</Operation>
 
@@ -333,11 +345,11 @@
 		<success>Always</success>
 		<operations>
 			<li Class="PatchOperationTest">
-				<xpath>Defs/TraitDef[defName = "Tough"]/conflictingTraits</xpath>
+				<xpath>Defs/TraitDef[defName = "PsychicSensitivity"]/conflictingTraits</xpath>
 				<success>Invert</success>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/TraitDef[defName = "Tough"]</xpath>
+				<xpath>Defs/TraitDef[defName = "PsychicSensitivity"]</xpath>
 				<value>
 					<conflictingTraits/>
 				</value>
@@ -346,24 +358,83 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/TraitDef[defName = "Tough"]/conflictingTraits</xpath>
+		<xpath>Defs/TraitDef[defName = "PsychicSensitivity"]/conflictingTraits</xpath>
 		<value>
-			<li>Abrasive</li>
-			<li>Reaver</li>
-			<li>Psychopath</li>
-			<li>Naive</li>
-			<li>PsychicSensitivity</li>
+			<li>Cultist</li>
+			<li>Personality</li>
+			<li>Leader</li>
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationTest">
+				<xpath>Defs/TraitDef[defName = "Kind"]/conflictingTraits</xpath>
+				<success>Invert</success>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName = "Kind"]</xpath>
+				<value>
+					<conflictingTraits/>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/TraitDef[defName = "Tough"]/degreeDatas/li[1]</xpath>
+		<xpath>Defs/TraitDef[defName = "Kind"]/conflictingTraits</xpath>
 		<value>
-			<statOffsets>
-				<MentalBreakThreshold>-0.05</MentalBreakThreshold>
-				<ComfyTemperatureMax>6</ComfyTemperatureMax>
-				<ComfyTemperatureMin>-6</ComfyTemperatureMin>
-			</statOffsets>
+			<li>Villian</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationTest">
+				<xpath>Defs/TraitDef[defName = "SlowLearner"]/conflictingTraits</xpath>
+				<success>Invert</success>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName = "SlowLearner"]</xpath>
+				<value>
+					<conflictingTraits/>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraitDef[defName = "SlowLearner"]/conflictingTraits</xpath>
+		<value>
+			<li>Dumb</li>
+			<li>ChaoticGenius</li>
+			<li>Ignorant</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationTest">
+				<xpath>Defs/TraitDef[defName = "SpeedOffset"]/conflictingTraits</xpath>
+				<success>Invert</success>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/TraitDef[defName = "SpeedOffset"]</xpath>
+				<value>
+					<conflictingTraits/>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/TraitDef[defName = "SpeedOffset"]/conflictingTraits</xpath>
+		<value>
+			<li>Fast</li>
+			<li>Slow</li>
 		</value>
 	</Operation>
 

--- a/Mods/MultiLang Colorful Traits/Defs/Mod_SK.xml
+++ b/Mods/MultiLang Colorful Traits/Defs/Mod_SK.xml
@@ -45,6 +45,8 @@
 			<li>Diplomat#2</li> <!-- мастер дипломатии / master diplomat -->
 			<li>Constitution#1</li> <!-- сильный иммунитет / strong constitution -->
 			<li>EatingSpeed#1</li> <!-- обжора / glutton -->
+			<li>BrownThumb#1</li> <!-- хороший садовод / green thumb -->
+			<li>ShootingAccuracy#2</li> <!-- меткий выстрел / deadshot -->
 		</traits>
 	</Trait.ColorDef>
 	
@@ -70,7 +72,6 @@
 			
 			<li>Personality#2</li> <!-- златоуст / Silver Tongue -->
 			<li>Medic#2</li> <!-- мастер-медик / master medic -->
-			<li>ShootingAccuracy#2</li> <!-- меткий выстрел / deadshot -->
 		</traits>
 	</Trait.ColorDef>
 	
@@ -85,25 +86,27 @@
 			<li>Introvert</li> <!-- интроверт / shy -->
 			<li>Villian</li> <!-- злодей / villian -->
 			<li>Allergic</li> <!-- аллергик / animal hater -->
-			<li>BrownThumb</li> <!-- плохой садовод / brown thumb -->
+			<li>Cultist</li> <!-- оккультизм / cultist -->
+			<li>Pyrophobia</li> <!-- пирофобия / pyrophobia -->
 			
 			<!-- Spectrum -->
 			
 			<li>EatingSpeed#-1</li> <!-- гурман / nibbler -->
-                        <li>PainThreshold#-1</li> <!-- непереносимость боли / low pain tolerance -->
+            <li>PainThreshold#-1</li> <!-- непереносимость боли / low pain tolerance -->
 			<li>Medic#-1</li> <!-- плохой медик / poor medic -->
 			<li>Dodging#-1</li> <!-- вялость / sluggish -->
 			<li>Trader#-1</li> <!-- простофиля / sucker -->
 			<li>Diplomat#-1</li> <!-- неуклюжесть / uncouth -->
+			<li>BrownThumb#0</li> <!-- плохой садовод / brown thumb -->
 		</traits>
 	</Trait.ColorDef>
 	
 	<Trait.ColorDef ParentName="ColorTerrible">
 		<defName>clrMod_SK_Terrible</defName>
 		<traits>
-			<li>Cultist</li> <!-- оккультизм / cultist -->
-			<li>Pyrophobia</li> <!-- пирофобия / pyrophobia -->
 			<li>Bipolar</li> <!-- биполярный / bipolar -->
+			<li>Claustrophobic</li> <!-- клаустрофобия / claustrophobic -->
+			<li>Slow</li> <!-- неторопливость / slow -->
 			
 			<!-- Spectrum -->
 			
@@ -111,8 +114,6 @@
 			<li>Constitution#-1</li> <!-- слабый иммунитет / weak constitution -->
 			<li>Eyesight#-1</li> <!-- близорукость / near-sighted -->
 			<li>Aptitude#-1</li> <!-- неумелый / inept -->
-			<li>Claustrophobic</li> <!-- клаустрофобия / claustrophobic -->
-			<li>Slow</li> <!-- неторопливость / slow -->
 		</traits>
 	</Trait.ColorDef>
 	

--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Weapon.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Weapon.xml
@@ -545,6 +545,9 @@
 			<skillRequirements>
 				<Crafting>7</Crafting>
 			</skillRequirements>
+			<recipeUsers Inherit="false">
+				<li>RK_ElectricSmithy</li>
+			</recipeUsers>
 		</recipeMaker>
 		<statBases>
 			<SightsEfficiency>0.9</SightsEfficiency>


### PR DESCRIPTION
1 Fixed some casuses with trait conflicting (like introvert + extrovert combination);
2 Corrected traits conflicting param of some traits (illogical connections);
3 Corrected vanilla traits patch (added some trait missed conflict param);
4 Moved all additional bonuses (stats and thoughts) from Tough trait to Hardened (cuz Tough and Hardened was almost similar));
5 Returned green thumb trait (cuz we have not any traits with plant work bonuses. The trait completely copies a bad gardener, but gives bonuses instead of penalties);
6 Some trait color corrections;
7 Remove ratkin autocrossbow recipe from fueled smithy.

1 Исправлены некоторые казусы из-за некорректно проставленных конфликтов черт характера (например, комбинация интроверта + экстроверта);

![image](https://user-images.githubusercontent.com/62516232/111312401-0fdd5a00-8681-11eb-88f0-6fb4e0d69369.png)

2 Скорректированы конфликты черт характера (убрал некоторые нелогичные связи, дополнил недостающие);
3 Скорректирован патч ванильных черт характера (добавил некоторые пропущенные черты характера);
4 Перенесены все бонусы (статов и мыслей) черты характера "Живучесть" к черте "Закалённый" (т.к. они практически не отличались друг от друга, но первая имела хороший бонус к уменьшению получаемого урона, теперь будут различными);
5 Возвращена черта характера "Хороший садовод" (т.к. плохой садовод у нас есть, а хорошего нет. Черта полностью копируют плохого садовода, но дает бонусы вместо штрафов);
6 Скорректирован цвет некоторых черт характера;
7 Рецепт автоарбалета раткинов убран с топливной кузни.