### PR TITLE
Исправление бага невозможности получения титула

### DIFF
--- a/Mods/Core_SK/Royalty/Defs/RoyalTitles/RoyalTitles_Kingdom.xml
+++ b/Mods/Core_SK/Royalty/Defs/RoyalTitles/RoyalTitles_Kingdom.xml
@@ -13,7 +13,7 @@
   </RoyalTitleDef>
 
   <RoyalTitleDef ParentName="BaseKingdomTitle">
-    <defName>Freeholder</defName>
+    <defName>FreeholderKingdom</defName>
     <label>freeholder</label>
     <description>The Royal title of freeholder gives an Royal citizen the right to own productive private property.\n\nIn the Kingdom, most freeholders own no more than a tiny shop or taxi, but some can become very wealthy as merchants, entrepreneurs, or investors.</description>
     <seniority>0</seniority>


### PR DESCRIPTION
 при выполнении квеста за 12+ очков короны пешкой у которой ещё не было титула - невозможно начать квест церемонии присвоения титула ("аколит" или выше), так как для церемонии требуется наличие тронного зала у пешки, а пешку на трон посадить нельзя, потому что у неё нет титула.

для сравнения: в ванили в аналогичной ситуации сразу после выполнения квеста за очки, пешка немедленно получает самый простенький титул "фриголдер". и её можно посадить на трон.

причина бага: в хск были добавлены дополнительные титулы для другой фракции Kingdom. изза неаккуратной копипасты деф фриголдера Kingdom переопределил деф фриголдера Роялки. 