### PR TITLE
Lite update HMC weapon pack – USSR mod

### DIFF
--- a/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/9x39mmSoviet.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/CombatExtended/Ammo/Rifle/9x39mmSoviet.xml
@@ -150,7 +150,7 @@
 		<label>9mm Soviet bullet (SH)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>1</damageAmountBase>
-			<damageDef>ElectricShock</damageDef>
+			<damageDef>ElectricShockHMC</damageDef>
 			<!-- <armorPenetrationBase>0.46</armorPenetrationBase> -->
 			<armorPenetrationSharp>7.3</armorPenetrationSharp>
 			<armorPenetrationBlunt>28.5</armorPenetrationBlunt>

--- a/Mods/HMC weapon pack – USSR/Defs/DamageDefs/Damages_LocalInjury_HMC.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/DamageDefs/Damages_LocalInjury_HMC.xml
@@ -1,0 +1,32 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+	<DamageDef ParentName="LocalInjuryBase">
+		<defName>ElectricShockHMC</defName>
+		<label>Electric Shock Bullet</label>
+		<harmsHealth>false</harmsHealth>
+		<makesBlood>false</makesBlood>
+		<canInterruptJobs>true</canInterruptJobs>
+		<externalViolence>true</externalViolence>
+		<deathMessage>{0} shocked to death.</deathMessage>
+		<defaultDamage>5</defaultDamage>
+		<defaultStoppingPower>1</defaultStoppingPower>
+		<defaultArmorPenetration>0.1</defaultArmorPenetration>
+		<buildingDamageFactor>0</buildingDamageFactor>
+		<hediff>ElectricShock</hediff>
+		<harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
+		<armorCategory>Sharp</armorCategory>
+		<canUseDeflectMetalEffect>false</canUseDeflectMetalEffect>
+		<impactSoundType>Electric</impactSoundType>
+		<explosionAffectOutsidePartsOnly>true</explosionAffectOutsidePartsOnly>
+		<explosionCellMote>Mote_BlastEMP</explosionCellMote>
+		<explosionColorEdge>(0.8, 0.8, 0.8, 1)</explosionColorEdge>
+		<explosionInteriorMote>Mote_ElectricalSpark</explosionInteriorMote>
+		<makesAnimalsFlee>true</makesAnimalsFlee>
+		<combatLogRules>Damage_Stun</combatLogRules>
+		<modExtensions>
+			<li Class="CombatExtended.DamageDefExtensionCE">
+				<harmOnlyOutsideLayers>true</harmOnlyOutsideLayers>
+			</li>
+		</modExtensions>
+	</DamageDef>
+</Defs>

--- a/Mods/HMC weapon pack – USSR/Defs/ThingDefs_Weapons/Weapons_Carabines.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/ThingDefs_Weapons/Weapons_Carabines.xml
@@ -80,13 +80,13 @@
             <ShotSpread>0.057</ShotSpread>
             <SwayFactor>1.27</SwayFactor>
             <RangedWeapon_Cooldown>0.72</RangedWeapon_Cooldown>
-            <Bulk>7.50</Bulk>
+            <Bulk>7.5</Bulk>
             <Mass>2.7</Mass>
         </statBases>
         <weaponTags>
-            <li>RF3</li>
-            <li>AdvancedGun</li>
-            <li>TierOneRifle</li>
+            <li>RF2</li>
+            <li>Gun</li>
+            <li>TierTwoRifle</li>
             <li>CE_AI_Rifle</li>
         </weaponTags>
         <thingCategories>

--- a/Mods/HMC weapon pack – USSR/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
@@ -79,7 +79,7 @@
         </graphicData>
         <soundInteract>Interact_Rifle</soundInteract>
         <statBases>
-            <MarketValue>2960</MarketValue>
+            <MarketValue>2500</MarketValue>
             <SightsEfficiency>1.01</SightsEfficiency>
             <ShotSpread>0.12</ShotSpread>
             <SwayFactor>1.5</SwayFactor>

--- a/Mods/HMC weapon pack – USSR/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
@@ -80,7 +80,6 @@
         </statBases>
         <weaponTags>
             <li>RF3</li>
-            <li>RF2</li>
             <li>AdvancedGun</li>
             <li>TierTwoRifle</li>
             <li>CE_AI_Rifle</li>


### PR DESCRIPTION
1 fixed 9x39 SH ammo (ignored any armor value). Now penetration based on RHA armor value;
2 some weapon tag and cost fixes.

1 поправлены 9х39 SH боеприпасы (игнорировали любую броню). Теперь бронепробитие зависит от значения брони в БКГ;
2 некоторые правки тегов и стоимости вооружения мода.