### PR TITLE
Some incedent tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/Storyteller/Incidents_Map_Misc.xml
+++ b/Mods/Core_SK/Defs/Storyteller/Incidents_Map_Misc.xml
@@ -360,7 +360,7 @@
 		<minRefireDays>30</minRefireDays>
 		<modExtensions>
 			<li Class="SK.ExtendedIncident">
-				<allowedTemperatureRange>0~999</allowedTemperatureRange>
+				<allowedTemperatureRange>-10~999</allowedTemperatureRange>
 				<!-- current map temperature-->
 			</li>
 		</modExtensions>
@@ -378,12 +378,25 @@
 		<minRefireDays>8</minRefireDays>
 		<allowedBiomes>
 			<li>Tundra</li>
+			<li>TundraArchipelago</li>
+			<li>TundraArchipelago_Fresh</li>
 			<li>AridShrubland</li>
 			<li>BorealForest</li>
+			<li>BorealArchipelago</li>
+			<li>BorealArchipelago_Fresh</li>
+			<li>ColdBog</li>
+			<li>ColdBogArchipelago</li>
+			<li>ColdBogArchipelago_Fresh</li>
+			<li>TemperateForest</li>
+			<li>TemperateArchipelago</li>
+			<li>TemperateArchipelago_Fresh</li>
+			<li>TemperateSwamp</li>
+			<li>TemperateSwampArchipelago</li>
+			<li>TemperateSwampArchipelago_Fresh</li>
 		</allowedBiomes>
 		<modExtensions>
 			<li Class="SK.ExtendedIncident">
-				<allowedTemperatureRange>-5~999</allowedTemperatureRange>
+				<allowedTemperatureRange>-35~999</allowedTemperatureRange>
 				<!-- current map temperature-->
 			</li>
 		</modExtensions>

--- a/Mods/Core_SK/Defs/Storyteller/Incidents_SK_Events.xml
+++ b/Mods/Core_SK/Defs/Storyteller/Incidents_SK_Events.xml
@@ -246,7 +246,7 @@ A seemingly endless supernatural rain has begun, altering the very composition o
 		</disabledWhen>
 		<modExtensions>
 			<li Class="SK.ExtendedIncident">
-				<allowedTemperatureRange>0~30</allowedTemperatureRange>
+				<allowedTemperatureRange>-5~35</allowedTemperatureRange>
 				<!-- current map temperature-->
 				<allowedBiomeRainfall>700~8000</allowedBiomeRainfall>
 				<!--300,600 - desert. 800-1200 - arid. 2000-4000 tropic/swamp -->
@@ -338,7 +338,7 @@ It will last anywhere between a season to several years.</letterText>
 			<li>Map_PlayerHome</li>
 		</targetTags>
 		<workerClass>SK.Events.IncidentWorker_CaravanAnimal</workerClass>
-		<baseChance>1.2</baseChance>
+		<baseChance>1</baseChance>
 	</IncidentDef>
 
 	<IncidentDef>
@@ -367,7 +367,7 @@ It will last anywhere between a season to several years.</letterText>
 			<li>Map_PlayerHome</li>
 		</targetTags>
 		<workerClass>SK.Events.IncidentWorker_AnimalBattle</workerClass>
-		<baseChance>1.25</baseChance>
+		<baseChance>1.05</baseChance>
 	</IncidentDef>
 
 	<IncidentDef>
@@ -597,7 +597,7 @@ Drought is devastating for plant life and will quickly destroy all the crops not
 		<earliestDay>14</earliestDay>
 		<modExtensions>
 			<li Class="SK.ExtendedIncident">
-				<allowedTemperatureRange>0~999</allowedTemperatureRange>
+				<allowedTemperatureRange>-5~999</allowedTemperatureRange>
 				<!-- current map temperature-->
 			</li>
 		</modExtensions>
@@ -902,7 +902,7 @@ Drought is devastating for plant life and will quickly destroy all the crops not
 		<category>Misc</category>
 		<workerClass>SK.Events.IncidentWorker_ColonistStash</workerClass>
 		<minRefireDays>4</minRefireDays>
-		<baseChance>3</baseChance>
+		<baseChance>2.7</baseChance>
 	</IncidentDef>
 
 	<IncidentDef>

--- a/Mods/Core_SK/Royalty/Patches/IncidentDefs/IncidentPatch.xml
+++ b/Mods/Core_SK/Royalty/Patches/IncidentDefs/IncidentPatch.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/IncidentDef[defName="ProblemCauser"]/earliestDay</xpath>
+		<value>
+			<earliestDay>200</earliestDay>
+		</value>
+	</Operation>
+
+</Patch>

--- a/Mods/NPS_SK/Patches/incidents-patches.xml
+++ b/Mods/NPS_SK/Patches/incidents-patches.xml
@@ -65,4 +65,18 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/IncidentDef[defName="Alphabeavers"]/allowedBiomes</xpath>
+		<value>
+			<li>DesertSaltFields</li>
+			<li>Grasslands</li>
+			<li>Oasis</li>			
+			<li>RedwoodForest</li>
+			<li>VolcanicFlow</li>
+			<li>Steppes</li>
+			<li>Savanna</li>
+			<li>Permafrost</li>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
[ENG]
1 added 200 day delay to "ProblemCauser" event (this a set of some mechanoid clusters or enemy base events with different dangerous buildings (like weather changer, psy suppressor and etc));

2 added more allowed biomes to alphabeavers events (+ added NPS biomes patch). Also expanded temperature range of this event;

3 very slightly expanded temperature range of "crop blight", "devourers of crops" and "psychic rain" events;

4 slightly decreased spawn chance of "caravan animals wander in", "battle animals wander in" and "colonist stash" events (~10-20%) (very high spawn frequency).

[RUS]
1 добавлена задержка в 200 дней для события "ProblemCauser" (это набор событий, состоящий из эвентов вида "пси-подавитель с кластером механоидов/вражеской базой появился рядом с вашим поселением и пока вы его не сломаете, он никуда не денется") во избежание спавна кластеров на старте игры;

2 добавлено больше доступных биомов для события "Альфабобры!" (+добавил патч для совместимости с модом NPS_SK). Также расширен допустимый температурный диапазон (ранее бобры были ограничены холодными биомами и относительно теплыми температурами, из-за чего эвент можно сказать вообще никогда не срабатывал);

3 чуть-чуть расширен температурный диапазон для событий "Вредители" (в ванильной версии это "болезнь растений"), "Пожиратели посевов" и "Пси-дождь";

4 немного уменьшена вероятность появления событий "караванные животные", "боевые животные" и "заначка поселенца" (~на 10-20%) (из-за слишком высокой частоты срабатывания).

