### PR TITLE
Increased power points of Intro_Wimp quest (cuz HSK hasn't any weak animal with enable manhunting (except mosquito))

### DIFF
--- a/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
+++ b/Mods/Core_SK/Royalty/Patches/QuestScriptDefs/QuestScriptDefsPatches.xml
@@ -66,5 +66,17 @@
 		</operations>
 	</Operation>
 
+	<!-- Intro Wimp Quests -->
+	<Operation Class="PatchOperationSequence">
+		<success>Normal</success>
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/QuestScriptDef[defName = "Intro_Wimp"]/root/nodes/li[9]/value</xpath>
+				<value>
+					<value>500</value>
+				</value>
+			</li>
+		</operations>
+	</Operation>
 
 </Patch>


### PR DESCRIPTION
Increased power points of Intro_Wimp quest (cuz HSK hasn't any weak animal with enable manhunting (except mosquito)).

Увеличено число очков угрозу у квеста Intro_Wimp (стартовый квест роялти с убегающей от утки/морской свинки/другого мелкого животного знатной персоны) (т.к. в ХСК не осталось ни одной безобидной зверушки, что могла бы преследовать эту самую знатную персону (кроме москитов)).