### PR TITLE
Added missed mass param to ROM spider pawns

### DIFF
--- a/Mods/Arachnophobia_SK/Defs/PawnKindDefs/ROMA_Spiders.xml
+++ b/Mods/Arachnophobia_SK/Defs/PawnKindDefs/ROMA_Spiders.xml
@@ -21,6 +21,7 @@
 			<LeatherAmount>0</LeatherAmount>
 			<Flammability>3.0</Flammability>
 			<MeatAmount>25</MeatAmount>
+			<Mass>15</Mass>
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
 			<MeleeCritChance>0.1</MeleeCritChance>
 			<SmokeSensitivity>0.5</SmokeSensitivity>

--- a/Mods/Arachnophobia_SK/Defs/PawnKindDefs/ROMA_SpidersGiant.xml
+++ b/Mods/Arachnophobia_SK/Defs/PawnKindDefs/ROMA_SpidersGiant.xml
@@ -21,6 +21,7 @@
 			<LeatherAmount>0</LeatherAmount>
 			<Flammability>3.0</Flammability>
 			<MeatAmount>60</MeatAmount>
+			<Mass>20</Mass>
 			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<SmokeSensitivity>0.5</SmokeSensitivity>

--- a/Mods/Arachnophobia_SK/Defs/PawnKindDefs/ROMA_SpidersQueen.xml
+++ b/Mods/Arachnophobia_SK/Defs/PawnKindDefs/ROMA_SpidersQueen.xml
@@ -20,6 +20,7 @@
 			<ArmorRating_Sharp>4.6</ArmorRating_Sharp>
 			<LeatherAmount>0</LeatherAmount>
 			<MeatAmount>300</MeatAmount>
+			<Mass>80</Mass>
 			<MeleeDodgeChance>0</MeleeDodgeChance>
 			<MeleeCritChance>0.25</MeleeCritChance>
 			<SmokeSensitivity>0.5</SmokeSensitivity>


### PR DESCRIPTION
Added missed mass param to ROM spider pawns

Добавлена пропущенная масса у пауков из арахнофобии (было нулевое значение, из-за чего их нельзя было повесить на мясные крюки).