### PR TITLE
Changed Dromedary trader tag from Uncommon to Common

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Arid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Arid.xml
@@ -678,7 +678,7 @@
 			<soundMeleeMiss>Pawn_Melee_BigBash_Miss</soundMeleeMiss>
 		</race>
 		<tradeTags>
-			<li>AnimalUncommon</li>
+			<li>AnimalCommon</li>
 			<li>AnimalFarm</li>
 		</tradeTags>
 		<modExtensions>


### PR DESCRIPTION
Currently they're only vendorable to Royalty settlements, Orbital traders, and Animal trader caravans.

I can't figure out what else i need to change to make then as normal vendorable animals to any settlement on the map like Horses/Muffalo/Sheep etc.

If anyone has any idea tag me in discord and I can make the changes or someone else can.