### PR TITLE
Some giant animals tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Giants.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Giants.xml
@@ -18,7 +18,7 @@
 			<CarryWeight>330</CarryWeight>
 			<CarryBulk>220</CarryBulk>
 			<ArmorRating_Blunt>6</ArmorRating_Blunt>
-			<ArmorRating_Sharp>0.15</ArmorRating_Sharp>
+			<ArmorRating_Sharp>1.1</ArmorRating_Sharp>
 			<GermResistance>0.21</GermResistance>
 			<GermContainment>0.05</GermContainment>
 		</statBases>
@@ -187,8 +187,8 @@
 			<MeleeCritChance>0</MeleeCritChance>
 			<CarryWeight>510</CarryWeight>
 			<CarryBulk>340</CarryBulk>
-			<ArmorRating_Blunt>0.105</ArmorRating_Blunt>
-			<ArmorRating_Sharp>0.07</ArmorRating_Sharp>
+			<ArmorRating_Blunt>6</ArmorRating_Blunt>
+			<ArmorRating_Sharp>1.2</ArmorRating_Sharp>
 			<GermResistance>0.15</GermResistance>
 		</statBases>
 		<tools>
@@ -366,8 +366,8 @@
 			<MeleeCritChance>0</MeleeCritChance>
 			<CarryWeight>540</CarryWeight>
 			<CarryBulk>360</CarryBulk>
-			<ArmorRating_Blunt>0.12</ArmorRating_Blunt>
-			<ArmorRating_Sharp>0.8</ArmorRating_Sharp>
+			<ArmorRating_Blunt>7</ArmorRating_Blunt>
+			<ArmorRating_Sharp>1.3</ArmorRating_Sharp>
 			<GermResistance>0.15</GermResistance>
 		</statBases>
 		<tools>
@@ -571,6 +571,8 @@
 			<MarketValue>3600</MarketValue>
 			<MeleeDodgeChance>0.05</MeleeDodgeChance>
 			<MeleeCritChance>0</MeleeCritChance>
+			<ArmorRating_Blunt>6</ArmorRating_Blunt>
+			<ArmorRating_Sharp>1.15</ArmorRating_Sharp>
 		</statBases>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
@@ -748,7 +750,7 @@
 				<power>34</power>
 				<cooldownTime>2.5</cooldownTime>
 				<linkedBodyPartsGroup>HornAttackTool</linkedBodyPartsGroup>
-				<armorPenetrationSharp>0.54</armorPenetrationSharp>
+				<armorPenetrationSharp>4.5</armorPenetrationSharp>
 				<armorPenetrationBlunt>4</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
@@ -791,7 +793,7 @@
 				<cooldownTime>2.0</cooldownTime>
 				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 				<chanceFactor>0.7</chanceFactor>
-				<armorPenetrationSharp>0.5</armorPenetrationSharp>
+				<armorPenetrationSharp>3.5</armorPenetrationSharp>
 				<armorPenetrationBlunt>3</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
@@ -933,8 +935,8 @@
 			<MeleeCritChance>0</MeleeCritChance>
 			<CarryWeight>425</CarryWeight>
 			<CarryBulk>290</CarryBulk>
-			<ArmorRating_Blunt>6</ArmorRating_Blunt>
-			<ArmorRating_Sharp>0.1</ArmorRating_Sharp>
+			<ArmorRating_Blunt>8</ArmorRating_Blunt>
+			<ArmorRating_Sharp>3.3</ArmorRating_Sharp>
 		</statBases>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
@@ -945,7 +947,7 @@
 				<power>25</power>
 				<cooldownTime>2.15</cooldownTime>
 				<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
-				<armorPenetrationSharp>1.4</armorPenetrationSharp>
+				<armorPenetrationSharp>4.4</armorPenetrationSharp>
 				<armorPenetrationBlunt>4</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
@@ -956,7 +958,7 @@
 				<power>25</power>
 				<cooldownTime>2.15</cooldownTime>
 				<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
-				<armorPenetrationSharp>1.4</armorPenetrationSharp>
+				<armorPenetrationSharp>4.4</armorPenetrationSharp>
 				<armorPenetrationBlunt>4</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
@@ -967,7 +969,7 @@
 				<cooldownTime>2.55</cooldownTime>
 				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 				<chanceFactor>0.7</chanceFactor>
-				<armorPenetrationSharp>2.7</armorPenetrationSharp>
+				<armorPenetrationSharp>5</armorPenetrationSharp>
 				<armorPenetrationBlunt>3.7</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
@@ -979,7 +981,7 @@
 				<cooldownTime>2.45</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
-				<chanceFactor>0.2</chanceFactor>
+				<chanceFactor>0.7</chanceFactor>
 				<armorPenetrationBlunt>7.5</armorPenetrationBlunt>
 			</li>
 		</tools>
@@ -1022,6 +1024,9 @@
 			<soundMeleeHitPawn>Pawn_Melee_BigBash_HitPawn</soundMeleeHitPawn>
 			<soundMeleeHitBuilding>Pawn_Melee_BigBash_HitBuilding</soundMeleeHitBuilding>
 			<soundMeleeMiss>Pawn_Melee_BigBash_Miss</soundMeleeMiss>
+			<hediffGiverSets>
+				<li>ThickPassiveSet</li>
+			</hediffGiverSets>
 		</race>
 		<tradeTags>
 			<li>AnimalUncommon</li>
@@ -1039,7 +1044,7 @@
 		<label>megabadger</label>
 		<race>Megabadger</race>
 		<combatPower>400</combatPower>
-		<canArriveManhunter>false</canArriveManhunter>
+		<canArriveManhunter>true</canArriveManhunter>
 		<ecoSystemWeight>1.5</ecoSystemWeight>
 		<lifeStages>
 			<li>
@@ -1104,7 +1109,7 @@
 			<CarryWeight>285</CarryWeight>
 			<CarryBulk>190</CarryBulk>
 			<ArmorRating_Blunt>7</ArmorRating_Blunt>
-			<ArmorRating_Sharp>0.2</ArmorRating_Sharp>
+			<ArmorRating_Sharp>1.2</ArmorRating_Sharp>
 		</statBases>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
@@ -1188,6 +1193,9 @@
 			<soundMeleeHitPawn>Pawn_Melee_BigBash_HitPawn</soundMeleeHitPawn>
 			<soundMeleeHitBuilding>Pawn_Melee_BigBash_HitBuilding</soundMeleeHitBuilding>
 			<soundMeleeMiss>Pawn_Melee_BigBash_Miss</soundMeleeMiss>
+			<hediffGiverSets>
+				<li>ThickPassiveSet</li>
+			</hediffGiverSets>
 		</race>
 		<tradeTags>
 			<li>AnimalUncommon</li>


### PR DESCRIPTION
1 corrected armor and armor penetration of some giant animal (like mamonth, elephant, megabadger and etc);
2 added missed thick leather hediff to mega badger and woolly rhinoceros;
3 added missed armor to megasloth;
4 enabled manhunting for megabagder and significant increased all battle params of him (the description says that he is very dangerous and should be avoided, but in fact, he is a rag...).

1 скорректирована броня и бронепробитие у некоторых гигантских животных (вроде мамонтов, мегабарсуков и т.д.);
2 добавлен пропущенный хедифф "Толстая кожа" для мегабарсука и шерстистого носорога;
3 добавлена пропущенная броня гигантскому ленивцу;
4 мегабарсук теперь может приходить в качестве агрессивного животного (не совсем понятно, почему запретили – мяса и шкур из него много не падает) + значительно усилены его боевые параметры (в описании сказано, что он очень опасен и его стоит избегать, но фактически он тряпка...).