### PR TITLE
Add nutrition to seeds

### DIFF
--- a/Mods/SeedsPlease/Defs/ThingDefs/Items_Seeds_Base.xml
+++ b/Mods/SeedsPlease/Defs/ThingDefs/Items_Seeds_Base.xml
@@ -37,7 +37,12 @@
       <DeteriorationRate>1</DeteriorationRate>
       <MarketValue>0</MarketValue>
       <SellPriceFactor>0.05</SellPriceFactor>
+	  <Nutrition>0.03</Nutrition>
     </statBases>
+	<ingestible>
+	  <preferability>NeverForNutrition</preferability>
+	  <foodType>VegetableOrFruit</foodType>
+	</ingestible>
     <soundInteract>Grain_Drop</soundInteract>
     <soundDrop>Grain_Drop</soundDrop>
     <thingCategories>


### PR DESCRIPTION
Add nutrition to seeds for chemfuel recipe work. also NeverForNutriton for not consuming

Добавил питательность для семян, чтобы можно было из них гнать биотопливо. Кушать их нельзя
теперь вроде в дев ветку :pekaoh: