### PR TITLE
Change seeds food category for "seeds"

### DIFF
--- a/Mods/SeedsPlease/Defs/ThingDefs/Items_Seeds_Base.xml
+++ b/Mods/SeedsPlease/Defs/ThingDefs/Items_Seeds_Base.xml
@@ -41,7 +41,7 @@
     </statBases>
 	<ingestible>
 	  <preferability>NeverForNutrition</preferability>
-	  <foodType>VegetableOrFruit</foodType>
+	  <foodType>Seed</foodType>
 	</ingestible>
     <soundInteract>Grain_Drop</soundInteract>
     <soundDrop>Grain_Drop</soundDrop>


### PR DESCRIPTION
Изменение категории еды для семян на "семяна", в надежде, что караваны не будут кушать их так активно