### PR TITLE
Some Arcane Technology tweaks and fixes

### DIFF
--- a/Mods/ArcaneTechnology_SK/Patches/Pawn/Pawns.xml
+++ b/Mods/ArcaneTechnology_SK/Patches/Pawn/Pawns.xml
@@ -53,4 +53,32 @@
 		</match>
 	</Operation>
 
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Core SK</li>
+		</mods>
+		<match Class="PatchOperationAddModExtension">
+			<xpath>Defs/PawnKindDef[defName="NovaCommander" or defName="Nova" or @Name="OrionBase" or @Name="SyndicateBase" or defName="OrassanTacticalCommander" or defName="BrotherhoodSentinel" or defName="SectarianSentinel"]</xpath>
+			<value>
+				<li Class="DArcaneTechnology.PawnKindExtension">
+					<pawnKindTechLevel>Ultra</pawnKindTechLevel>
+				</li>				
+			</value>
+		</match>
+	</Operation>
+
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Androids</li>
+		</mods>
+		<match Class="PatchOperationAddModExtension">
+			<xpath>Defs/PawnKindDef[defName="ChjAndroidTownCouncilman"]</xpath>
+			<value>
+				<li Class="DArcaneTechnology.PawnKindExtension">
+					<pawnKindTechLevel>Ultra</pawnKindTechLevel>
+				</li>				
+			</value>
+		</match>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
1 fixed Planetary Recon starting scenario (starting pawns couldn't wear some starting apparels);
2 added all Orion's and Syndicate's pawns ability to use any spacer items;
3 added some faction leader pawn ability to use any spacer items (most faction leaders often use equipment of a higher technological level than ordinary pawns of this faction). Pawn-leader and faction list:
**_Faction = Leader label_**:
Nova alliance = Nova commander;
Orassan enclave = Tactical commander;
Bloodmoon brotherhood = Brotherhood sentinel;
Church of violence = Sectarian sentinel;
Android enclave = Town councilman.

1 исправлен стартовый сценарий "Колонизация" (стартовые пешки не могли носить некоторую стартовую одежду);
2 всем пешкам фракции Корпорации Орион и Синдикат добавлена возможность носить и использовать любые Spacer предметы вне зависимости от текущего уровня развития колонии игрока (захватил пешку одной из топовых фракций в силовой броне, а как её носить - пешка внезапно забывает, выглядит странно);
3 некоторым фракционным лидерам добавлена возможность использовать носить и использовать любые Spacer предметы вне зависимости от текущего уровня развития колонии игрока (т.к. большинство фракционных лидеров зачастую используют снаряжение выше тех. уровня, нежели рядовые пешки этой фракции). Список фракций и фракционных лидеров:
**_Фракция = Описание лидера_**:
Альянс Нова = Командир Новы;
Прайд Фелидэ = Командир фелинов;
Братство кровавой луны = Страж братства;
Церковь насилия = Часовой сектантов;
Анклав андроидов = Городской советник.