### PR TITLE
Fixed Energy Tab mismatch labels on English language

### DIFF
--- a/Mods/EnergyTab_SK/Languages/English/Keyed/Manager_Keyed.xml
+++ b/Mods/EnergyTab_SK/Languages/English/Keyed/Manager_Keyed.xml
@@ -4,8 +4,8 @@
   <EnergyTab.Power>Energy</EnergyTab.Power>
 
   <EnergyTab.HistoryProduction>Generation</EnergyTab.HistoryProduction>
-  <EnergyTab.HistoryConsumption>Storage</EnergyTab.HistoryConsumption>
-  <EnergyTab.HistoryBatteries>Consumption</EnergyTab.HistoryBatteries>
+  <EnergyTab.HistoryConsumption>Consumption</EnergyTab.HistoryConsumption>
+  <EnergyTab.HistoryBatteries>Storage</EnergyTab.HistoryBatteries>
 
   <!--controls-->
   <EnergyTab.PeriodShown>Period on the charts: {0}</EnergyTab.PeriodShown>


### PR DESCRIPTION
Storage and consumption labels switched as it should be.