### PR TITLE
Light Enemy ship event fixes

### DIFF
--- a/Mods/Core_SK/Defs/Storyteller/Incidents_SK_Events.xml
+++ b/Mods/Core_SK/Defs/Storyteller/Incidents_SK_Events.xml
@@ -1033,7 +1033,7 @@ Drought is devastating for plant life and will quickly destroy all the crops not
 		<workerClass>SK.Events.IncidentWorker_EnemyShipPart</workerClass>
 		<letterLabel>Enemy ship incoming</letterLabel>
 		<letterText>An enemy ship landed near our colony!</letterText>
-		<letterDef>NegativeEvent</letterDef>
+		<letterDef>ThreatBig</letterDef>
 		<pointsScaleable>true</pointsScaleable>
 		<tale>Raid</tale>
 		<populationEffect>None</populationEffect>


### PR DESCRIPTION
Changed Enemy ship event letter def from simple negative event to big threat (visual only, replaced color from yellow to red).

![image](https://user-images.githubusercontent.com/62516232/114406578-177d1980-9bc1-11eb-934c-47b0a3176203.png)

Изменен параметр выпадающего письма для события "Вражеский десант" с обычного негативного события на "Большая угроза" (только визуальные изменения, жёлтый цвет заменен на красный).