### PR TITLE
Corrected industrial insulation infusions value

### DIFF
--- a/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
@@ -56,13 +56,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-0.2</offset>
+          <offset>-1</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-0.2</offset>
+          <offset>-1</offset>
         </value>
       </li>
     </stats>
@@ -98,13 +98,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-0.2</offset>
+          <offset>-1</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-0.2</offset>
+          <offset>-1</offset>
         </value>
       </li>
     </stats>
@@ -128,7 +128,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-.2</offset>
+          <offset>-1</offset>
         </value>
       </li>
     </stats>
@@ -146,13 +146,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-.04</offset>
+          <offset>-2</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-.02</offset>
+          <offset>-1</offset>
         </value>
       </li>
     </stats>
@@ -170,13 +170,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>.02</offset>
+          <offset>1</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>.04</offset>
+          <offset>2</offset>
         </value>
       </li>
     </stats>
@@ -398,13 +398,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-0.25</offset>
+          <offset>-1.25</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>.5</offset>
+          <offset>2.5</offset>
         </value>
       </li>
       <li>
@@ -984,13 +984,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-0.4</offset>
+          <offset>-1.8</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-0.4</offset>
+          <offset>-1.8</offset>
         </value>
       </li>
     </stats>
@@ -1026,13 +1026,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-0.4</offset>
+          <offset>-1.8</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-0.4</offset>
+          <offset>-1.8</offset>
         </value>
       </li>
     </stats>
@@ -1056,7 +1056,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-.4</offset>
+          <offset>-1.8</offset>
         </value>
       </li>
     </stats>
@@ -1074,13 +1074,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-.08</offset>
+          <offset>-3.6</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-.04</offset>
+          <offset>-1.8</offset>
         </value>
       </li>
     </stats>
@@ -1098,13 +1098,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>.04</offset>
+          <offset>1.8</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>.08</offset>
+          <offset>3.6</offset>
         </value>
       </li>
     </stats>
@@ -1326,13 +1326,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-0.5</offset>
+          <offset>-2.25</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>1</offset>
+          <offset>4.5</offset>
         </value>
       </li>
       <li>
@@ -1907,13 +1907,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-0.6</offset>
+          <offset>-2.4</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-0.6</offset>
+          <offset>-2.4</offset>
         </value>
       </li>
     </stats>
@@ -1949,13 +1949,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-0.6</offset>
+          <offset>-2.4</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-0.6</offset>
+          <offset>-2.4</offset>
         </value>
       </li>
     </stats>
@@ -1979,7 +1979,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-.6</offset>
+          <offset>-2.4</offset>
         </value>
       </li>
     </stats>
@@ -1997,13 +1997,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1.2</offset>
+          <offset>-4.8</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-.06</offset>
+          <offset>-2.4</offset>
         </value>
       </li>
     </stats>
@@ -2021,13 +2021,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>.06</offset>
+          <offset>2.4</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>1.2</offset>
+          <offset>4.8</offset>
         </value>
       </li>
     </stats>
@@ -2249,13 +2249,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-0.75</offset>
+          <offset>-3</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>1.5</offset>
+          <offset>6</offset>
         </value>
       </li>
       <li>
@@ -2824,7 +2824,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1</offset>
+          <offset>-3.5</offset>
         </value>
       </li>
     </stats>
@@ -2860,7 +2860,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1</offset>
+          <offset>-3.5</offset>
         </value>
       </li>
     </stats>
@@ -2884,7 +2884,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1</offset>
+          <offset>-3.5</offset>
         </value>
       </li>
     </stats>
@@ -2902,13 +2902,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1.8</offset>
+          <offset>-6.3</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-.09</offset>
+          <offset>-3.15</offset>
         </value>
       </li>
     </stats>
@@ -2926,13 +2926,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>.09</offset>
+          <offset>3.15</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>1.8</offset>
+          <offset>6.3</offset>
         </value>
       </li>
     </stats>
@@ -3154,13 +3154,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1.25</offset>
+          <offset>-4.4</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>2.25</offset>
+          <offset>7.9</offset>
         </value>
       </li>
       <li>
@@ -3729,7 +3729,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1.25</offset>
+          <offset>-3.75</offset>
         </value>
       </li>
     </stats>
@@ -3765,7 +3765,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1.25</offset>
+          <offset>-3.75</offset>
         </value>
       </li>
     </stats>
@@ -3789,7 +3789,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1.25</offset>
+          <offset>-3.75</offset>
         </value>
       </li>
     </stats>
@@ -3807,13 +3807,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-2.4</offset>
+          <offset>-7.2</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-1.2</offset>
+          <offset>-3.6</offset>
         </value>
       </li>
     </stats>
@@ -3831,13 +3831,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>1.2</offset>
+          <offset>3.6</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>2.4</offset>
+          <offset>7.2</offset>
         </value>
       </li>
     </stats>
@@ -4059,13 +4059,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-1.75</offset>
+          <offset>-5.25</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>3</offset>
+          <offset>9</offset>
         </value>
       </li>
       <li>
@@ -4634,7 +4634,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-2</offset>
+          <offset>-5</offset>
         </value>
       </li>
     </stats>
@@ -4670,7 +4670,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-2</offset>
+          <offset>-5</offset>
         </value>
       </li>
     </stats>
@@ -4694,7 +4694,7 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-2</offset>
+          <offset>-5</offset>
         </value>
       </li>
     </stats>
@@ -4712,13 +4712,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-3.5</offset>
+          <offset>-8.75</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>-2</offset>
+          <offset>-5</offset>
         </value>
       </li>
     </stats>
@@ -4736,13 +4736,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>2</offset>
+          <offset>5</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>3.5</offset>
+          <offset>8.75</offset>
         </value>
       </li>
     </stats>
@@ -5018,13 +5018,13 @@
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
-          <offset>-3</offset>
+          <offset>-7.5</offset>
         </value>
       </li>
       <li>
         <key>ComfyTemperatureMax</key>
         <value>
-          <offset>6</offset>
+          <offset>15</offset>
         </value>
       </li>
       <li>


### PR DESCRIPTION
Some low tier insulation infusions had very low value (0.02 or 0.08). Corrected.

Некоторые низкоуровневые зачарования с бонусом к изоляции имели очень низкие значения (например, 0.08 градусов). Скорректировано. Весь раздел Industrial Boosted в целом имел очень низкие значения изоляции. Немного увеличены.