### PR TITLE
Bulk recipes for Matter Converter

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Matter.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Matter.xml
@@ -38,6 +38,42 @@
 	<workSkill>Crafting</workSkill>
     	<workSkillLearnFactor>0.8</workSkillLearnFactor>
   </RecipeDef>
+
+
+	<!-- Raw resources x10 -->
+    <RecipeDef>
+    <defName>ConvertResourcesRawBulk</defName>
+    <label>Create inorganic matter (x10)</label>
+    <description>Create inorganic matter by processing and converting various types of raw resources. Produces 150.</description>
+    <jobString>Converting resources to inorganic matter.</jobString>
+    <workAmount>10000</workAmount>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <ingredients>
+      <li>
+        <filter>
+          <categories>
+            <li>ResourcesRaw</li>
+          </categories>
+        </filter>
+        <count>300</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <categories>
+        <li>ResourcesRaw</li>
+      </categories>
+    </fixedIngredientFilter>
+    <products>
+      <Matter>150</Matter>
+    </products>
+		<skillRequirements>
+			<Crafting>15</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
   
  
   <!-- ============================================================== -->
@@ -544,5 +580,441 @@
 	<workSkill>Crafting</workSkill>
     	<workSkillLearnFactor>0.8</workSkillLearnFactor>
   </RecipeDef>
+  
+  
+  <!-- ============================================================== -->
+  <!-- Convert from matter in bulk-->
+  <!-- ============================================================== -->
+  
+  
+    <!-- steel x10 -->
+    <RecipeDef>
+    <defName>ConvertToSteelBulk</defName>
+    <label>Convert to iron ore (x10)</label>
+    <description>Convert inorganic matter into iron ore. Produces 100.</description>
+    <jobString>Converting matter into iron ore.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>50</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Steel>100</Steel>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+
+	
+    <!-- copper x10 -->
+    <RecipeDef>
+    <defName>ConvertToCopperBulk</defName>
+    <label>Convert to copper ore (x10)</label>
+    <description>Convert inorganic matter into copper ore. Produces 100.</description>
+    <jobString>Converting matter into copper ore.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>50</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Copper>100</Copper>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+
+	
+    <!-- aluminium x10 -->
+    <RecipeDef>
+    <defName>ConvertToAluminiumBulk</defName>
+    <label>Convert to bauxite ore (x10)</label>
+    <description>Convert inorganic matter into bauxite ore. Produces 80.</description>
+    <jobString>Converting matter into bauxite ore.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>50</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Aluminium>80</Aluminium>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+
+    <!-- Nickel x10 -->
+    <RecipeDef>
+    <defName>ConvertToNickelBulk</defName>
+    <label>Convert to nickel ore (x10)</label>
+    <description>Convert inorganic matter into nickel ore. Produces 20.</description>
+    <jobString>Converting matter into nickel ore.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>150</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Nickel>20</Nickel>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+
+	
+    <!--uranium x10 -->
+    <RecipeDef>
+    <defName>ConvertToUraniumBulk</defName>
+    <label>Convert to uranium ore (x10)</label>
+    <description>Convert inorganic matter into uranium ore. Produces 50.</description>
+    <jobString>Converting matter into uranium ore.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>200</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Uranium>50</Uranium>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+	
+	
+	<!--ilmenite x10 -->
+    <RecipeDef>
+    <defName>ConvertToTitaniumBulk</defName>
+    <label>Convert to ilmenite ore (x10)</label>
+    <description>Convert inorganic matter into ilmenite, the ore of titanium. Produces 20.</description>
+    <jobString>Converting matter into ilmenite Ore.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>15000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>200</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Ilmenite>20</Ilmenite>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+	
+	
+    <!--wolframite x10 -->
+    <RecipeDef>
+    <defName>ConvertToWolframiteBulk</defName>
+    <label>Convert to wolframite ore (x10)</label>
+    <description>Convert inorganic matter into wolframite, the ore of tungsten. Produces 10.</description>
+    <jobString>Converting matter into wolframite ore.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>250</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Wolframite>10</Wolframite>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+
+	
+    <!--silver x10 -->
+    <RecipeDef>
+    <defName>ConvertToSilverBulk</defName>
+    <label>Convert to silver ore (x10)</label>
+    <description>Convert inorganic matter into silver ore. Produces 300.</description>
+    <jobString>Converting matter into silver ore.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>100</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Silver>300</Silver>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+	
+	
+    <!--gold x10 -->
+    <RecipeDef>
+    <defName>ConvertToGoldBulk</defName>
+    <label>Convert to gold ore (x10)</label>
+    <description>Convert inorganic matter into gold ore. Produces 20.</description>
+    <jobString>Converting matter into gold ore.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>60</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Gold>20</Gold>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+	
+	
+	<!-- Polymers x10 -->
+    <RecipeDef>
+    <defName>ConvertToPolymersBulk</defName>
+    <label>Convert to polymers (x10)</label>
+    <description>Convert inorganic matter into polymers. Produces 100.</description>
+    <jobString>Converting matter into polymers.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>50</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Polymers>100</Polymers>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+	
+	<!-- Paraffins x10 -->
+    <RecipeDef>
+    <defName>ConvertToParaffinsBulk</defName>
+    <label>Convert to paraffins (x10)</label>
+    <description>Convert inorganic matter into paraffins. Produces 100.</description>
+    <jobString>Converting matter into paraffins.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>50</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Paraffins>100</Paraffins>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+	</RecipeDef>
+  
+    <!-- Sulphates x10 -->
+    <RecipeDef>
+    <defName>ConvertToSulphatesBulk</defName>
+    <label>Convert to sulphates (x10)</label>
+    <description>Convert inorganic matter into sulphates. Produces 100.</description>
+    <jobString>Converting matter into sulphates.</jobString>
+		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
+		<effectWorking>Smelt</effectWorking>
+    <soundWorking>Recipe_Smelt</soundWorking>
+    <workAmount>12000</workAmount>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Matter</li>
+          </thingDefs>
+        </filter>
+        <count>50</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+		<li>Matter</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Sulphates>100</Sulphates>
+    </products>
+		<skillRequirements>
+			<Crafting>16</Crafting>
+		</skillRequirements>
+	<workSkill>Crafting</workSkill>
+    	<workSkillLearnFactor>0.8</workSkillLearnFactor>
+  </RecipeDef>
+  
+  
   
 </Defs>

--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Matter.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Matter.xml
@@ -49,7 +49,7 @@
     <RecipeDef>
     <defName>ConvertToSteel</defName>
     <label>Convert to iron ore</label>
-    <description>Convert inorganic matter into iron ore. Produces 20.</description>
+    <description>Convert inorganic matter into iron ore. Produces 10.</description>
     <jobString>Converting matter into iron ore.</jobString>
 		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
 		<effectWorking>Smelt</effectWorking>
@@ -85,7 +85,7 @@
     <RecipeDef>
     <defName>ConvertToCopper</defName>
     <label>Convert to copper ore</label>
-    <description>Convert inorganic matter into copper ore. Produces 12.</description>
+    <description>Convert inorganic matter into copper ore. Produces 10.</description>
     <jobString>Converting matter into copper ore.</jobString>
 		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
 		<effectWorking>Smelt</effectWorking>
@@ -121,7 +121,7 @@
     <RecipeDef>
     <defName>ConvertToAluminium</defName>
     <label>Convert to bauxite ore</label>
-    <description>Convert inorganic matter into bauxite ore. Produces 10.</description>
+    <description>Convert inorganic matter into bauxite ore. Produces 8.</description>
     <jobString>Converting matter into bauxite ore.</jobString>
 		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
 		<effectWorking>Smelt</effectWorking>
@@ -300,7 +300,7 @@
     <RecipeDef>
     <defName>ConvertToSilver</defName>
     <label>Convert to silver ore</label>
-    <description>Convert inorganic matter into silver ore. Produces 50.</description>
+    <description>Convert inorganic matter into silver ore. Produces 30.</description>
     <jobString>Converting matter into silver ore.</jobString>
 		<workSpeedStat>ElectronicCraftingSpeed</workSpeedStat>
 		<effectWorking>Smelt</effectWorking>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production_Hightech.xml
@@ -806,6 +806,7 @@
 		<recipes>
 			<!-- Into matter -->
 			<li>ConvertResourcesRaw</li>
+			<li>ConvertResourcesRawBulk</li>
 			<!-- from matter -->
 			<li>ConvertToSteel</li>
 			<li>ConvertToPolymers</li>
@@ -818,6 +819,17 @@
 			<li>ConvertToNickel</li>
 			<li>ConvertToUranium</li>
 			<li>ConvertToTitanium</li>
+			<li>ConvertToSteelBulk</li>
+			<li>ConvertToPolymersBulk</li>
+			<li>ConvertToParaffinsBulk</li>
+			<li>ConvertToSulphatesBulk</li>
+			<li>ConvertToCopperBulk</li>
+			<li>ConvertToAluminiumBulk</li>
+			<li>ConvertToGoldBulk</li>
+			<li>ConvertToSilverBulk</li>
+			<li>ConvertToNickelBulk</li>
+			<li>ConvertToUraniumBulk</li>
+			<li>ConvertToTitaniumBulk</li>
 		</recipes>
 		<tickerType>Normal</tickerType>
 		<comps>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Matter.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Matter.xml
@@ -54,4 +54,56 @@
 	<ConvertToSulphates.description>Конвертировать материю в сульфаты. Производится 10 шт.</ConvertToSulphates.description>
 	<ConvertToSulphates.jobString>Конвертирует материю в сульфаты.</ConvertToSulphates.jobString>
 
+	<ConvertResourcesRawBulk.label>Конвертировать ресурс в материю (x10)</ConvertResourcesRawBulk.label>
+	<ConvertResourcesRawBulk.description>Конвертировать ресурс в материю. Производится 150 шт.</ConvertResourcesRawBulk.description>
+	<ConvertResourcesRawBulk.jobString>Конвертирует ресурс в материю.</ConvertResourcesRawBulk.jobString>
+
+	<ConvertToSteelBulk.label>Конвертировать материю в железо (x10)</ConvertToSteelBulk.label>
+	<ConvertToSteelBulk.description>Конвертировать материю в железо. Производится 100 шт.</ConvertToSteelBulk.description>
+	<ConvertToSteelBulk.jobString>Конвертирует материю в железо.</ConvertToSteelBulk.jobString>
+
+	<ConvertToCopperBulk.label>Конвертировать материю в медь (x10)</ConvertToCopperBulk.label>
+	<ConvertToCopperBulk.description>Конвертировать материю в медь. Производится 100 шт.</ConvertToCopperBulk.description>
+	<ConvertToCopperBulk.jobString>Конвертирует материю в медь.</ConvertToCopperBulk.jobString>
+
+	<ConvertToAluminiumBulk.label>Конвертировать материю в бокситы (x10)</ConvertToAluminiumBulk.label>
+	<ConvertToAluminiumBulk.description>Конвертировать материю в бокситы. Производится 80 шт.</ConvertToAluminiumBulk.description>
+	<ConvertToAluminiumBulk.jobString>Конвертирует материю в бокситы.</ConvertToAluminiumBulk.jobString>
+	
+	<ConvertToNickelBulk.label>Конвертировать материю в никель (x10)</ConvertToNickelBulk.label>
+	<ConvertToNickelBulk.description>Конвертировать материю в никель. Производится 20 шт.</ConvertToNickelBulk.description>
+	<ConvertToNickelBulk.jobString>Конвертирует материю в никель.</ConvertToNickelBulk.jobString>
+
+	<ConvertToUraniumBulk.label>Конвертировать материю в уран (x10)</ConvertToUraniumBulk.label>
+	<ConvertToUraniumBulk.description>Конвертировать материю в уран. Производится 50 шт.</ConvertToUraniumBulk.description>
+	<ConvertToUraniumBulk.jobString>Конвертирует материю в уран.</ConvertToUraniumBulk.jobString>
+
+	<ConvertToTitaniumBulk.label>Конвертировать материю в ильменит (x10)</ConvertToTitaniumBulk.label>
+	<ConvertToTitaniumBulk.description>Конвертировать материю в ильменит. Производится 20 шт.</ConvertToTitaniumBulk.description>
+	<ConvertToTitaniumBulk.jobString>Конвертирует материю в ильменит.</ConvertToTitaniumBulk.jobString>
+
+	<ConvertToWolframiteBulk.label>Конвертировать материю в вольфрамит (x10)</ConvertToWolframiteBulk.label>
+	<ConvertToWolframiteBulk.description>Конвертировать материю в вольфрамит. Производится 10 шт.</ConvertToWolframiteBulk.description>
+	<ConvertToWolframiteBulk.jobString>Конвертирует материю в вольфрамит.</ConvertToWolframiteBulk.jobString>
+
+	<ConvertToSilverBulk.label>Конвертировать материю в серебро (x10)</ConvertToSilverBulk.label>
+	<ConvertToSilverBulk.description>Конвертировать материю в серебро. Производится 300 шт.</ConvertToSilverBulk.description>
+	<ConvertToSilverBulk.jobString>Конвертирует материю в серебро.</ConvertToSilverBulk.jobString>
+
+	<ConvertToGoldBulk.label>Конвертировать материю в золото (x10)</ConvertToGoldBulk.label>
+	<ConvertToGoldBulk.description>Конвертировать материю в золото. Производится 20 шт.</ConvertToGoldBulk.description>
+	<ConvertToGoldBulk.jobString>Конвертирует материю в золото.</ConvertToGoldBulk.jobString>
+
+	<ConvertToPolymersBulk.label>Конвертировать материю в полимеры (x10)</ConvertToPolymersBulk.label>
+	<ConvertToPolymersBulk.description>Конвертировать материю в полимеры. Производится 100 шт.</ConvertToPolymersBulk.description>
+	<ConvertToPolymersBulk.jobString>Конвертирует материю в полимеры.</ConvertToPolymersBulk.jobString>
+	
+	<ConvertToParaffinsBulk.label>Конвертировать материю в парафин (x10)</ConvertToParaffinsBulk.label>
+	<ConvertToParaffinsBulk.description>Конвертировать материю в парафин. Производится 100 шт.</ConvertToParaffinsBulk.description>
+	<ConvertToParaffinsBulk.jobString>Конвертирует материю в парафин.</ConvertToParaffinsBulk.jobString>
+
+	<ConvertToSulphatesBulk.label>Конвертировать материю в сульфаты (x10)</ConvertToSulphatesBulk.label>
+	<ConvertToSulphatesBulk.description>Конвертировать материю в сульфаты. Производится 100 шт.</ConvertToSulphatesBulk.description>
+	<ConvertToSulphatesBulk.jobString>Конвертирует материю в сульфаты.</ConvertToSulphatesBulk.jobString>
+
 </LanguageData>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Matter.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Matter.xml
@@ -3,47 +3,47 @@
 <LanguageData>
 
 	<ConvertResourcesRaw.label>Конвертировать ресурс в материю</ConvertResourcesRaw.label>
-	<ConvertResourcesRaw.description>Конвертировать ресурс в материю.</ConvertResourcesRaw.description>
+	<ConvertResourcesRaw.description>Конвертировать ресурс в материю. Производится 15 шт.</ConvertResourcesRaw.description>
 	<ConvertResourcesRaw.jobString>Конвертирует ресурс в материю.</ConvertResourcesRaw.jobString>
 
 	<ConvertToSteel.label>Конвертировать материю в железо</ConvertToSteel.label>
-	<ConvertToSteel.description>Конвертировать материю в железо.</ConvertToSteel.description>
+	<ConvertToSteel.description>Конвертировать материю в железо. Производится 10 шт.</ConvertToSteel.description>
 	<ConvertToSteel.jobString>Конвертирует материю в железо.</ConvertToSteel.jobString>
 
 	<ConvertToCopper.label>Конвертировать материю в медь</ConvertToCopper.label>
-	<ConvertToCopper.description>Конвертировать материю в медь.</ConvertToCopper.description>
+	<ConvertToCopper.description>Конвертировать материю в медь. Производится 10 шт.</ConvertToCopper.description>
 	<ConvertToCopper.jobString>Конвертирует материю в медь.</ConvertToCopper.jobString>
 
 	<ConvertToAluminium.label>Конвертировать материю в бокситы</ConvertToAluminium.label>
-	<ConvertToAluminium.description>Конвертировать материю в бокситы.</ConvertToAluminium.description>
+	<ConvertToAluminium.description>Конвертировать материю в бокситы. Производится 8 шт.</ConvertToAluminium.description>
 	<ConvertToAluminium.jobString>Конвертирует материю в бокситы.</ConvertToAluminium.jobString>
 	
 	<ConvertToNickel.label>Конвертировать материю в никель</ConvertToNickel.label>
-	<ConvertToNickel.description>Конвертировать материю в никель.</ConvertToNickel.description>
+	<ConvertToNickel.description>Конвертировать материю в никель. Производится 2 шт.</ConvertToNickel.description>
 	<ConvertToNickel.jobString>Конвертирует материю в никель.</ConvertToNickel.jobString>
 
 	<ConvertToUranium.label>Конвертировать материю в уран</ConvertToUranium.label>
-	<ConvertToUranium.description>Конвертировать материю в уран.</ConvertToUranium.description>
+	<ConvertToUranium.description>Конвертировать материю в уран. Производится 5 шт.</ConvertToUranium.description>
 	<ConvertToUranium.jobString>Конвертирует материю в уран.</ConvertToUranium.jobString>
 
 	<ConvertToTitanium.label>Конвертировать материю в ильменит</ConvertToTitanium.label>
-	<ConvertToTitanium.description>Конвертировать материю в ильменит.</ConvertToTitanium.description>
+	<ConvertToTitanium.description>Конвертировать материю в ильменит. Производится 2 шт.</ConvertToTitanium.description>
 	<ConvertToTitanium.jobString>Конвертирует материю в ильменит.</ConvertToTitanium.jobString>
 
 	<ConvertToWolframite.label>Конвертировать материю в вольфрамит</ConvertToWolframite.label>
-	<ConvertToWolframite.description>Конвертировать материю в вольфрамит.</ConvertToWolframite.description>
+	<ConvertToWolframite.description>Конвертировать материю в вольфрамит. Производится 1 шт.</ConvertToWolframite.description>
 	<ConvertToWolframite.jobString>Конвертирует материю в вольфрамит.</ConvertToWolframite.jobString>
 
 	<ConvertToSilver.label>Конвертировать материю в серебро</ConvertToSilver.label>
-	<ConvertToSilver.description>Конвертировать материю в серебро.</ConvertToSilver.description>
+	<ConvertToSilver.description>Конвертировать материю в серебро. Производится 30 шт.</ConvertToSilver.description>
 	<ConvertToSilver.jobString>Конвертирует материю в серебро.</ConvertToSilver.jobString>
 
 	<ConvertToGold.label>Конвертировать материю в золото</ConvertToGold.label>
-	<ConvertToGold.description>Конвертировать материю в золото.</ConvertToGold.description>
+	<ConvertToGold.description>Конвертировать материю в золото. Производится 2 шт.</ConvertToGold.description>
 	<ConvertToGold.jobString>Конвертирует материю в золото.</ConvertToGold.jobString>
 
 	<ConvertToPolymers.label>Конвертировать материю в полимеры</ConvertToPolymers.label>
-	<ConvertToPolymers.description>Конвертировать материю в полимеры.</ConvertToPolymers.description>
+	<ConvertToPolymers.description>Конвертировать материю в полимеры. Производится 10 шт.</ConvertToPolymers.description>
 	<ConvertToPolymers.jobString>Конвертирует материю в полимеры.</ConvertToPolymers.jobString>
 	
 	<ConvertToParaffins.label>Конвертировать материю в парафин</ConvertToParaffins.label>


### PR DESCRIPTION
Adds x10 recipes for Matter Converter to reduce how often pawns search for jobs while working on it, making it less laggy in the late game. Also fixes some MC descriptions to show correct product counts.

Добавляет x10 рецепты для конвертера материи, чтобы пешки, работающие на нём, реже искали работу и меньше лагали. В описаниях рецептов в конвертере материи добавлено количество получаемых ресурсов.