### PR TITLE
Corrected mechanoid's raids

### DIFF
--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Mech.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Mech.xml
@@ -54,10 +54,10 @@
 					<Mech_Crawler>85</Mech_Crawler>
 					<Mech_Lancer>70</Mech_Lancer>
 					<Mech_Scyther>60</Mech_Scyther>
-					<Mech_Pikeman>51</Mech_Pikeman>
+					<Mech_Pikeman>20</Mech_Pikeman>
 					<Mech_Centipede>50</Mech_Centipede>
 					<Mech_HGScyther>45</Mech_HGScyther>
-					<Mech_SniperLancer>41</Mech_SniperLancer>
+					<Mech_SniperLancer>35</Mech_SniperLancer>
 					<Mech_CentipedeInferno>40</Mech_CentipedeInferno>
 				</options>
 			</li>
@@ -78,9 +78,9 @@
 				<options>
 					<Mech_Lancer>70</Mech_Lancer>
 					<Mech_Scyther>60</Mech_Scyther>
-					<Mech_Pikeman>55</Mech_Pikeman>
+					<Mech_Pikeman>25</Mech_Pikeman>
 					<Mech_HGScyther>50</Mech_HGScyther>
-					<Mech_SniperLancer>40</Mech_SniperLancer>
+					<Mech_SniperLancer>35</Mech_SniperLancer>
 				</options>
 			</li>
 			<li>


### PR DESCRIPTION
After adding pikeman to mech raids in this commit https://github.com/skyarkhangel/Hardcore-SK/commit/2f776db0ac099c3f63fc04d6cbb5f86a211b482b balance shifted towards flimsy snipers. This should help correcting this.

После добавления драгунов в рейды механоидов в https://github.com/skyarkhangel/Hardcore-SK/commit/2f776db0ac099c3f63fc04d6cbb5f86a211b482b, баланс рейдов механоидов сильно сместился в сторону хлипких снайперов. Предлагаю немного скорректировать это и уменьшить общее кол-во снайперов в рейдах механоидов, где есть драгуны (драгуны тоже снайперы, к сведению).