### PR TITLE
Replaced wood planks to primitive components in passive coolers

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
@@ -576,7 +576,7 @@
 			<Flammability>0</Flammability>
 		</statBases>
 		<costList>
-			<WoodPlank>50</WoodPlank>
+			<ComponentMedieval>20</ComponentMedieval>
 		</costList>
 		<soundImpactDefault>BulletImpact_Ground</soundImpactDefault>
 		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
@@ -645,7 +645,7 @@
 			<Flammability>0</Flammability>
 		</statBases>
 		<costList>
-			<WoodPlank>50</WoodPlank>
+			<ComponentMedieval>20</ComponentMedieval>
 		</costList>
 		<soundImpactDefault>BulletImpact_Ground</soundImpactDefault>
 		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>


### PR DESCRIPTION
It's allow use any wood planks (like bamboo or redwood) in recipe.

В рецепте строительства пассивных охладителей доски из обычного дерева заменены на примитивные компоненты.
Это позволит использовать любые доски (бамбук или красное дерево), а не только обыкновенные.