### PR TITLE
Lite 30x29 and 40x46 mm fixes

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Grenade/30x29mmGrenade.xml
@@ -46,17 +46,17 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>7.8</MarketValue>
+			<MarketValue>7.5</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<explosionDamage>70</explosionDamage>
+				<explosionDamage>50</explosionDamage>
 				<explosionDamageDef>Bomb</explosionDamageDef>
 				<explosionRadius>1.5</explosionRadius>
 				<fragRange>4.0</fragRange>
 				<fragments>
-					<Fragment_GrenadeFrag>40</Fragment_GrenadeFrag>
+					<Fragment_GrenadeFrag>30</Fragment_GrenadeFrag>
 				</fragments>
 			</li>
 		</comps>
@@ -70,7 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>8.9</MarketValue>
+			<MarketValue>8</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
 		<generateAllowChance>0</generateAllowChance>
@@ -106,17 +106,17 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1</explosionRadius >
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>50</damageAmountBase>
+			<damageAmountBase>35</damageAmountBase>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<explosionDamage>70</explosionDamage>
+				<explosionDamage>50</explosionDamage>
 				<explosionDamageDef>Bomb</explosionDamageDef>
 				<explosionRadius>1.5</explosionRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<fragRange>4.0</fragRange>
 				<fragments>
-					<Fragment_GrenadeFrag>40</Fragment_GrenadeFrag>
+					<Fragment_GrenadeFrag>30</Fragment_GrenadeFrag>
 				</fragments>
 			</li>
 		</comps>
@@ -126,9 +126,9 @@
 		<defName>Bullet_30x29mmGrenade_EMP</defName>
 		<label>30x29mm grenade (EMP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>1.5</explosionRadius>
+			<explosionRadius>2</explosionRadius>
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>20</damageAmountBase>
+			<damageAmountBase>35</damageAmountBase>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Grenade/40x46mmGrenade.xml
@@ -46,17 +46,17 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>9.4</MarketValue>
+			<MarketValue>9</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<explosionDamage>90</explosionDamage>
+				<explosionDamage>64</explosionDamage>
 				<explosionDamageDef>Bomb</explosionDamageDef>
 				<explosionRadius>1.5</explosionRadius>
 				<fragRange>4.0</fragRange>
 				<fragments>
-					<Fragment_GrenadeFrag>45</Fragment_GrenadeFrag>
+					<Fragment_GrenadeFrag>35</Fragment_GrenadeFrag>
 				</fragments>
 			</li>
 		</comps>
@@ -70,7 +70,7 @@
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>10.9</MarketValue>
+			<MarketValue>10</MarketValue>
 		</statBases>
 		<ammoClass>GrenadeEMP</ammoClass>
 		<generateAllowChance>0</generateAllowChance>
@@ -105,17 +105,17 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>75</damageAmountBase>
+			<damageAmountBase>48</damageAmountBase>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<explosionDamage>90</explosionDamage>
+				<explosionDamage>64</explosionDamage>
 				<explosionDamageDef>Bomb</explosionDamageDef>
 				<explosionRadius>1.5</explosionRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 				<fragRange>4.0</fragRange>
 				<fragments>
-					<Fragment_GrenadeFrag>45</Fragment_GrenadeFrag>
+					<Fragment_GrenadeFrag>35</Fragment_GrenadeFrag>
 				</fragments>
 			</li>
 		</comps>
@@ -125,9 +125,9 @@
 		<defName>Bullet_40x46mmGrenade_EMP</defName>
 		<label>40x46mm grenade (EMP)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<explosionRadius>1.8</explosionRadius>
+			<explosionRadius>2.3</explosionRadius>
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>30</damageAmountBase>
+			<damageAmountBase>48</damageAmountBase>
 		</projectile>
 	</ThingDef>
 


### PR DESCRIPTION
1 corrected 30x29 and 40x46 mm grenades dmg param (too high dmg HE grenade(almost similar 90 mm shell). Reduced. Too low EMP dmg (need ~25 30x29 mm grenades to kill one centiped against 5-7 of HE grenades), slightly up dmg and radius).

1 скорректированы параметры 30x29 и 40x46 мм гранат (HE гранаты по мощности сопоставимы с 90 мм снарядами, урон уменьшен. У ЕМП гранат напротив, урон был слишком низкий (для убийства одной сентипеды требовалось около 25 ЕМП гранат, когда как HE гранат нужно было около 5-7 штук). Немного увеличен урон и радиус ЕМП гранат).