### PR TITLE
Forgot correcting 14.5 mm craft cost...

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -169,7 +169,7 @@
 						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>50</count>
+				<count>40</count>
 			</li>
 			<li>
 				<filter>
@@ -177,7 +177,7 @@
 						<li>HeavyBar</li>
 					</categories>
 				</filter>
-				<count>18</count>
+				<count>15</count>
 			</li>
 			<li>
 				<filter>
@@ -185,7 +185,7 @@
 						<li>Powder</li>
 					</thingDefs>
 				</filter>
-				<count>9</count>
+				<count>8</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -202,7 +202,7 @@
 			<Ammo_145x114mm_FMJ>60</Ammo_145x114mm_FMJ>
 		</products>
 		<skillRequirements>
-			<Crafting>8</Crafting>
+			<Crafting>9</Crafting>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
 		<workSkillLearnFactor>0.8</workSkillLearnFactor>
@@ -222,7 +222,7 @@
 						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>50</count>
+				<count>40</count>
 			</li>
 			<li>
 				<filter>
@@ -230,7 +230,7 @@
 						<li>USLDHBar</li>
 					</categories>
 				</filter>
-				<count>18</count>
+				<count>15</count>
 			</li>
 			<li>
 				<filter>
@@ -238,7 +238,7 @@
 						<li>FSX</li>
 					</thingDefs>
 				</filter>
-				<count>16</count>
+				<count>14</count>
 			</li>
 			<li>
 				<filter>
@@ -246,7 +246,7 @@
 						<li>Powder</li>
 					</thingDefs>
 				</filter>
-				<count>9</count>
+				<count>8</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -264,7 +264,7 @@
 			<Ammo_145x114mm_HE>60</Ammo_145x114mm_HE>
 		</products>
 		<skillRequirements>
-			<Crafting>8</Crafting>
+			<Crafting>9</Crafting>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
 		<workSkillLearnFactor>0.8</workSkillLearnFactor>
@@ -283,7 +283,7 @@
 						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>50</count>
+				<count>40</count>
 			</li>
 			<li>
 				<filter>
@@ -291,7 +291,7 @@
 						<li>HeavyBar</li>
 					</categories>
 				</filter>
-				<count>18</count>
+				<count>15</count>
 			</li>
 			<li>
 				<filter>
@@ -299,7 +299,7 @@
 						<li>Prometheum</li>
 					</thingDefs>
 				</filter>
-				<count>16</count>
+				<count>14</count>
 			</li>
 			<li>
 				<filter>
@@ -307,7 +307,7 @@
 						<li>Powder</li>
 					</thingDefs>
 				</filter>
-				<count>9</count>
+				<count>8</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -325,7 +325,7 @@
 			<Ammo_145x114mm_Incendiary>60</Ammo_145x114mm_Incendiary>
 		</products>
 		<skillRequirements>
-			<Crafting>8</Crafting>
+			<Crafting>9</Crafting>
 		</skillRequirements>
 		<workSkill>Crafting</workSkill>
 		<workSkillLearnFactor>0.8</workSkillLearnFactor>


### PR DESCRIPTION
...after 14.5 mm nerf https://github.com/skyarkhangel/Hardcore-SK/commit/5f3bda2366a3fcaff54208cc66af9cd132940f28
Also increase crafting skill requirement from 8 to 9 (cuz .50 bmg (or 12.7 mm) need 8 crafting skill, 20 mm need 10).

Забыл скорректировать (уменьшить) стоимость крафта 14.5 мм боеприпасов после их небольшого нерфа в коммите https://github.com/skyarkhangel/Hardcore-SK/commit/5f3bda2366a3fcaff54208cc66af9cd132940f28
Также увеличил требование к ремеслу до с 8 до 9 (т.к. .50 bmg (или 12.7 мм) требует 8 ремесла, 20 мм требует 10. Хорошо вписывается между ними).