### PR TITLE
Some hi-tech weapon craft tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_WeaponComponents.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_WeaponComponents.xml
@@ -848,10 +848,10 @@
 				<li>USLDBar</li>
 				<li>HCMBar</li>
 			</categories>
-			<thingDefs>
-				<li>MagneticMaterial</li>
-				<li>AdvMechanism</li>
-			</thingDefs>
+			<disallowedThingDefs>
+				<li>CopperBar</li>
+				<li>TinBar</li>
+			</disallowedThingDefs>
 		</fixedIngredientFilter>
 		<products>
 			<Charged_Component>1</Charged_Component>
@@ -920,6 +920,10 @@
 				<li>BiosyntheticMaterial</li>
 				<li>Microchips</li>
 			</thingDefs>
+			<disallowedThingDefs>
+				<li>CopperBar</li>
+				<li>TinBar</li>
+			</disallowedThingDefs>
 		</fixedIngredientFilter>
 		<products>
 			<Plasma_Component>1</Plasma_Component>
@@ -987,6 +991,10 @@
 				<li>MagneticMaterial</li>
 				<li>Microchips</li>
 			</thingDefs>
+			<disallowedThingDefs>
+				<li>CopperBar</li>
+				<li>TinBar</li>
+			</disallowedThingDefs>
 		</fixedIngredientFilter>
 		<products>
 			<Laser_Component>1</Laser_Component>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Futuristic_Charged.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Futuristic_Charged.xml
@@ -38,10 +38,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>70</count>
+				<count>40</count>
 			</li>
 			<li>
 				<filter>
@@ -63,7 +63,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -110,11 +109,19 @@
 			</li>
 			<li>
 				<filter>
+					<thingDefs>
+						<li>FerrosiliconAlloy</li>
+					</thingDefs>
+				</filter>
+				<count>15</count>
+			</li>
+			<li>
+				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>95</count>
+				<count>45</count>
 			</li>
 			<li>
 				<filter>
@@ -136,7 +143,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Futuristic_Lasers.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Futuristic_Lasers.xml
@@ -38,10 +38,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>70</count>
+				<count>40</count>
 			</li>
 			<li>
 				<filter>
@@ -63,7 +63,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -109,10 +108,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>70</count>
+				<count>40</count>
 			</li>
 			<li>
 				<filter>
@@ -134,7 +133,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -180,10 +178,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>75</count>
+				<count>45</count>
 			</li>
 			<li>
 				<filter>
@@ -205,7 +203,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -251,10 +248,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>80</count>
+				<count>50</count>
 			</li>
 			<li>
 				<filter>
@@ -276,7 +273,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Futuristic_Plazma.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Futuristic_Plazma.xml
@@ -38,10 +38,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>55</count>
+				<count>25</count>
 			</li>
 			<li>
 				<filter>
@@ -63,7 +63,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -109,10 +108,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>75</count>
+				<count>45</count>
 			</li>
 			<li>
 				<filter>
@@ -134,7 +133,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -180,10 +178,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>75</count>
+				<count>45</count>
 			</li>
 			<li>
 				<filter>
@@ -205,7 +203,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -251,10 +248,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>75</count>
+				<count>45</count>
 			</li>
 			<li>
 				<filter>
@@ -276,7 +273,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>
@@ -322,10 +318,10 @@
 			<li>
 				<filter>
 					<categories>
-						<li>Metallic</li>
+						<li>USLDBar</li>
 					</categories>
 				</filter>
-				<count>75</count>
+				<count>45</count>
 			</li>
 			<li>
 				<filter>
@@ -347,7 +343,6 @@
 				<li>Plastic</li>
 			</thingDefs>
 			<categories>
-				<li>SLDBar</li>
 				<li>USLDBar</li>
 			</categories>
 		</fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Chargeblasters.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Chargeblasters.xml
@@ -39,7 +39,7 @@
                 <hasStandardCommand>true</hasStandardCommand>
                 <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>
                 <warmupTime>0.60</warmupTime>
-                <range>50</range>
+                <range>55</range>
                 <ticksBetweenBurstShots>5</ticksBetweenBurstShots>
                 <burstShotCount>3</burstShotCount>
                 <soundCast>Fire_UACPlasmagun</soundCast>
@@ -80,7 +80,7 @@
         <soundInteract>Interact_ChargeRifle</soundInteract>
         <statBases>
             <MarketValue>3200</MarketValue>
-            <SightsEfficiency>1.3</SightsEfficiency>
+            <SightsEfficiency>1.25</SightsEfficiency>
             <ShotSpread>0.05</ShotSpread>
             <SwayFactor>1.25</SwayFactor>
             <RangedWeapon_Cooldown>0.87</RangedWeapon_Cooldown>
@@ -102,7 +102,7 @@
         <verbs>
             <li Class="CombatExtended.VerbPropertiesCE">
                 <recoilPattern>Regular</recoilPattern>
-                <recoilAmount>0.76</recoilAmount>
+                <recoilAmount>0.84</recoilAmount>
                 <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                 <hasStandardCommand>true</hasStandardCommand>
                 <defaultProjectile>Bullet_6x24mmCharged</defaultProjectile>


### PR DESCRIPTION
1 removed all basic metals from hi-tech weapon's components and weapon craft recipes;
2 added few sendust alloy to R6 Splitter craft recipe (to slightly increasing difficulty of craft this weapon compared R3);
3 slightly corrected R3 and R6 param (light boost R3 range and light nerf R6 accuracy (~5-10%)).

1 из рецептов всего хайтек вооружения (оружие + оружейные компоненты) удалены все базовые металлы, крафт немного перебалансирован (сплавов требуется меньше, но использовать, например, бронзу уже не выйдет);
2 добавлено немного альсифер сплава в рецепт R6 Splitter (чтобы немного усложнить его крафт в сравнении с менее эффективным R3, сейчас их крафт идентичен и отличается только кол-вом ресурсов);
3 немного скорректированы параметры R3 и R6 энерговинтовок (немного увеличена дальность стрельбы у R3 и немного снижена точность у R6 (~5-10%)).