### PR TITLE
Some cybernetic organism SK fixes

### DIFF
--- a/Mods/CyberneticOrganism_SK/Defs/Hediffs/Cyborg_hediffs.xml
+++ b/Mods/CyberneticOrganism_SK/Defs/Hediffs/Cyborg_hediffs.xml
@@ -104,9 +104,11 @@
 						<capacities>
 							<li>Stab</li>
 						</capacities>
-						<power>35.0</power>
+						<power>25</power>
 						<cooldownTime>1.5</cooldownTime>
 						<alwaysTreatAsWeapon>false</alwaysTreatAsWeapon>
+						<armorPenetrationSharp>8</armorPenetrationSharp>
+						<armorPenetrationBlunt>4</armorPenetrationBlunt>
 					</li>
 				</tools>
 			</li>
@@ -137,9 +139,10 @@
 						<capacities>
 							<li>Blunt</li>
 						</capacities>
-						<power>25.0</power>
+						<power>20</power>
 						<cooldownTime>1.25</cooldownTime>
 						<alwaysTreatAsWeapon>false</alwaysTreatAsWeapon>
+						<armorPenetrationBlunt>12</armorPenetrationBlunt>
 					</li>
 				</tools>
 			</li>


### PR DESCRIPTION
Added missed armor penetration to outer blade and power arm. Also corrected dmg params.

Добавлено пропущенное бронепробитие для протезов "Встроенное лезвие" и "Силовая рука" (мод "Сybernetic organism SK"). Также немного скорректирован их урон.