### PR TITLE
Removed colonist corpses from saltpeter pit's extracts nitre from body recipe's default filter settings

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_UniversalFermenter.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_UniversalFermenter.xml
@@ -550,6 +550,15 @@
 				<li>CorpsesMechanoid</li>
 			</disallowedCategories>
 		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<categories>
+				<li>CorpsesHumanlike</li>
+				<li>CorpsesAnimal</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowCorpsesColonist</li>
+			</specialFiltersToDisallow>
+		</defaultIngredientFilter>
 		<products>
 			<Nitre>30</Nitre>
 		</products>


### PR DESCRIPTION
Из фильтра по умолчанию рецепта извлечения селитры из тел удалены колонисты игрока.