### PR TITLE
Small fueled lightning rework

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -779,7 +779,6 @@
 				<fuelFilter>
 					<thingDefs>
 						<li>Kindling</li>
-						<li>Tallow</li>
 					</thingDefs>
 					<categories>
 						<li>Wooden</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -664,9 +664,6 @@
 					<thingDefs>
 						<li>Kindling</li>
 					</thingDefs>
-					<categories>
-						<li>Wooden</li>
-					</categories>
 				</fuelFilter>
 				<initialFuelPercent>0</initialFuelPercent>
 				<showAllowAutoRefuelToggle>true</showAllowAutoRefuelToggle>
@@ -767,20 +764,28 @@
 			<li>
 				<compClass>CompQuality</compClass>
 			</li>
-			<li Class="CompProperties_Refuelable">
-				<fuelConsumptionRate>3.0</fuelConsumptionRate>
-				<fuelCapacity>20.0</fuelCapacity>
-				<fuelConsumptionPerTickInRain>0.045</fuelConsumptionPerTickInRain>
+			<li Class="SK.CompFueled_Properties">
+				<operatingTemp>300</operatingTemp>
+				<fireDrawOffset>(0,0,0)</fireDrawOffset>
+				<fireDrawScale>0.4</fireDrawScale>
+				<fuelDrawOffset>(0,0.1,0.01)</fuelDrawOffset>
+				<fuelDrawScale>0.7</fuelDrawScale>
+				<fuelCapacity>20</fuelCapacity>
+				<burnFuelMultiplier>8.6</burnFuelMultiplier>
+				<canAutoBurn>true</canAutoBurn>
+				<smokeEnabled>false</smokeEnabled>
+				<effectOnWeather>true</effectOnWeather>
+				<smokeDensity>0</smokeDensity>
 				<fuelFilter>
 					<thingDefs>
 						<li>Kindling</li>
+						<li>Tallow</li>
 					</thingDefs>
 					<categories>
 						<li>Wooden</li>
-					</categories>
+						<li>Woody</li>
+					</categories>  
 				</fuelFilter>
-				<destroyOnNoFuel>false</destroyOnNoFuel>
-				<showAllowAutoRefuelToggle>true</showAllowAutoRefuelToggle>
 			</li>
 			<li Class="CompProperties_Glower">
 				<glowRadius>8</glowRadius>
@@ -821,6 +826,9 @@
 				</offsets>
 			</li>
 		</comps>
+		<inspectorTabs>
+			<li>SK.ITab_Fuel</li>
+		</inspectorTabs>
 		<building>
 			<uninstallWork>150</uninstallWork>
 		</building>
@@ -881,9 +889,6 @@
 					<thingDefs>
 						<li>Kindling</li>
 					</thingDefs>
-					<categories>
-						<li>Wooden</li>
-					</categories>
 				</fuelFilter>
 				<destroyOnNoFuel>false</destroyOnNoFuel>
 				<showAllowAutoRefuelToggle>true</showAllowAutoRefuelToggle>


### PR DESCRIPTION
- Torches only use kindling as their fuel (coz they take the closest item that is in the filter and adding them a complicated fuel system like for fire bowl would be an overdo)
- Fire bowls use SK fuel system with filters and search range to push their role as a lasting light source (and to retain some flexibility that torches were stripped of)