### PR TITLE
Some alpha tweaks and fixes

### DIFF
--- a/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
@@ -196,7 +196,7 @@
 		</alienRace>
 		<statBases>
 			<Mass>80</Mass>
-			<MarketValue>6000</MarketValue>
+			<MarketValue>8000</MarketValue>
 			<MoveSpeed>4.4</MoveSpeed>
 			<Flammability>1.0</Flammability>
 			<ComfyTemperatureMin>-40</ComfyTemperatureMin>
@@ -340,6 +340,7 @@
 			</hediffGiverSets>
 		</race>
 		<recipes Inherit="false">
+			<li>AdministerMechSerumHealer</li>
 			<li>ChJAndroidRepairKit</li>
 			<li>Euthanize</li>
 		</recipes>

--- a/Mods/Androids/Defs/HediffDefs/Hediffs_AndroidLike.xml
+++ b/Mods/Androids/Defs/HediffDefs/Hediffs_AndroidLike.xml
@@ -11,7 +11,7 @@
 		<stages>
 			<li>
 				<statFactors>
-					<IncomingDamageFactor>0.80</IncomingDamageFactor>
+					<IncomingDamageFactor>0.85</IncomingDamageFactor>
 				</statFactors>
 				<statOffsets>
 					<CarryingCapacity>+15</CarryingCapacity>
@@ -19,11 +19,11 @@
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<offset>0.40</offset>
+						<offset>0.20</offset>
 					</li>
 					<li>
 						<capacity>Manipulation</capacity>
-						<offset>0.40</offset>
+						<offset>0.20</offset>
 					</li>
 					<li>
 						<capacity>Moving</capacity>

--- a/Mods/Androids/Defs/HediffDefs/Hediffs_AndroidLike.xml
+++ b/Mods/Androids/Defs/HediffDefs/Hediffs_AndroidLike.xml
@@ -11,7 +11,7 @@
 		<stages>
 			<li>
 				<statFactors>
-					<IncomingDamageFactor>0.85</IncomingDamageFactor>
+					<IncomingDamageFactor>0.80</IncomingDamageFactor>
 				</statFactors>
 				<statOffsets>
 					<CarryingCapacity>+15</CarryingCapacity>
@@ -19,11 +19,11 @@
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<offset>0.20</offset>
+						<offset>0.40</offset>
 					</li>
 					<li>
 						<capacity>Manipulation</capacity>
-						<offset>0.20</offset>
+						<offset>0.40</offset>
 					</li>
 					<li>
 						<capacity>Moving</capacity>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/Laserbeam.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/Laserbeam.xml
@@ -75,14 +75,14 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef> <!-- <damageDef>LaserBurn</damageDef> -->
+			<damageDef>LaserBurn</damageDef>
 			<damageAmountBase>14</damageAmountBase>
-            <armorPenetrationSharp>16.5</armorPenetrationSharp>
-            <armorPenetrationBlunt>0.001</armorPenetrationBlunt> <!-- The overall pressure exerted by a laser beam striking something is, unsuprisingly, negligable. -->
+            		<armorPenetrationSharp>16.5</armorPenetrationSharp>
+            		<armorPenetrationBlunt>7.6</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
-	<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletRed">
+	<ThingDef Class="CombatExtended.Lasers.LaserBeamDefCE" ParentName="LaserBulletWhite">
 		<defName>Bullet_Laserbeam_Stable</defName>
 		<label>Laser beam (Stable)</label>
 		<graphicData>
@@ -90,10 +90,10 @@
 			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageDef>Bullet</damageDef>  <!-- <damageDef>Optic</damageDef> -->
+			<damageDef>Optic</damageDef>
 			<damageAmountBase>16</damageAmountBase>
-            <armorPenetrationSharp>18.25</armorPenetrationSharp>
-            <armorPenetrationBlunt>0.001</armorPenetrationBlunt>
+            		<armorPenetrationSharp>18.25</armorPenetrationSharp>
+            		<armorPenetrationBlunt>8.4</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Skynet_SK/Defs/HediffDefs/Hediffs_AddedParts_Skynet.xml
+++ b/Mods/Skynet_SK/Defs/HediffDefs/Hediffs_AddedParts_Skynet.xml
@@ -22,7 +22,7 @@
 						</capacities>
 						<power>28</power>
 						<cooldownTime>1.15</cooldownTime>
-						<armorPenetration>0.35</armorPenetration>
+						<armorPenetrationBlunt>28</armorPenetrationBlunt>
 					</li>
 				</tools>
 			</li>
@@ -58,8 +58,9 @@
 						</capacities>
 						<power>32</power>
 						<cooldownTime>1.25</cooldownTime>
-						<armorPenetration>0.4</armorPenetration>
 						<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
+						<armorPenetrationSharp>14</armorPenetrationSharp>
+						<armorPenetrationBlunt>9</armorPenetrationBlunt>
 					</li>
 				</tools>
 			</li>


### PR DESCRIPTION
1 corrected new laser params;
2 added missed armor penetration param to terminator's spike arm and jackhammer arm;
3 increased andriod pawn market value (6000->8000);
4 added missed administer mech serum healer recipe to android pawn.

1 скорректированы параметры новых лазеров;
2 добавлено пропущенное бронепробитие для терминаторских руки-молота и руки-шипа;
3 увеличена базовая рыночная стоимость андроидов с 6000 до 8000;
4 добавлен пропущенный рецепт возможности использования сыворотки исцеления на андроидов через операции.