### PR TITLE
Fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -674,7 +674,7 @@
 			</li>
 			<li Class="SK.CompProperties_HeatPusherAdvanced">
 				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>3.5</heatPerSecond>
+				<heatPerSecond>4</heatPerSecond>
 				<heatPushMaxTemperature>23</heatPushMaxTemperature>
 			</li>
 			<li Class="SK.CompProperties_FireOverlayMod">
@@ -792,8 +792,8 @@
 			</li>
 			<li Class="SK.CompProperties_HeatPusherAdvanced">
 				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>5</heatPerSecond>
-				<heatPushMaxTemperature>30</heatPushMaxTemperature>
+				<heatPerSecond>3.5</heatPerSecond>
+				<heatPushMaxTemperature>23</heatPushMaxTemperature>
 			</li>
 			<li Class="SK.CompProperties_FireOverlayMod">
 				<fireSize>0.5</fireSize>
@@ -898,8 +898,8 @@
 			</li>
 			<li Class="SK.CompProperties_HeatPusherAdvanced">
 				<compClass>SK.CompHeatPusherAdvanced</compClass>
-				<heatPerSecond>8</heatPerSecond>
-				<heatPushMaxTemperature>30</heatPushMaxTemperature>
+				<heatPerSecond>4</heatPerSecond>
+				<heatPushMaxTemperature>23</heatPushMaxTemperature>
 			</li>
 			<li Class="SK.CompProperties_FireOverlayMod">
 				<fireSize>0.4</fireSize>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Exotic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Exotic.xml
@@ -322,7 +322,7 @@
 				<armorPenetrationSharp>4.7</armorPenetrationSharp>
 				<armorPenetrationBlunt>13</armorPenetrationBlunt>
 			</li>
-			<li Class="CombatExtended.ToolCE">
+			<!-- <li Class="CombatExtended.ToolCE">
 				<capacities>
 					<li>Flame</li>
 				</capacities>
@@ -331,7 +331,7 @@
 				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 				<armorPenetrationSharp>7</armorPenetrationSharp>
 				<armorPenetrationBlunt>13</armorPenetrationBlunt>
-			</li>
+			</li> -->
 			<li Class="CombatExtended.ToolCE">
 				<label>head</label>
 				<capacities>


### PR DESCRIPTION
- Sky rolled back old fueled lightning changes, but only for standard torches. Brought them all in line with normal torch with a small boost to generated temp for open fire torches
- Wyverns burn their prey and can't eat, poor wyverns (the same probably happens with a fenix too, but no food for this pyromaniac today)