### PR TITLE
Stats, tools and saltpeter pit params update

### DIFF
--- a/Mods/Core_SK/Defs/StatDefs/Stats_Pawns_WorkGeneral_FishIndustry.xml
+++ b/Mods/Core_SK/Defs/StatDefs/Stats_Pawns_WorkGeneral_FishIndustry.xml
@@ -20,12 +20,8 @@
 		</skillNeedFactors>
 		<capacityFactors>
 			<li>
-				<capacity>Consciousness</capacity>
-				<weight>1</weight>
-			</li>
-			<li>
 				<capacity>Manipulation</capacity>
-				<weight>0.8</weight>
+				<weight>1</weight>
 			</li>
 			<li>
 				<capacity>Sight</capacity>

--- a/Mods/Core_SK/Defs/StatDefs/Stats_Pawns_WorkRecipes.xml
+++ b/Mods/Core_SK/Defs/StatDefs/Stats_Pawns_WorkRecipes.xml
@@ -26,16 +26,12 @@
 		</skillNeedFactors>
 		<capacityFactors>
 			<li>
-				<capacity>Consciousness</capacity>
-				<weight>1</weight>
-			</li>
-			<li>
 				<capacity>Sight</capacity>
 				<weight>0.2</weight>
 			</li>
 			<li>
 				<capacity>Manipulation</capacity>
-				<weight>0.9</weight>
+				<weight>1</weight>
 			</li>
 		</capacityFactors>
 	</StatDef>
@@ -134,11 +130,18 @@
 		<statFactors>
 			<li>WorkSpeedGlobal</li>
 		</statFactors>
+		<skillNeedFactors>
+			<li Class="SkillNeed_BaseBonus">
+				<skill>Crafting</skill>
+				<baseValue>0.7</baseValue>
+				<bonusPerLevel>0.04</bonusPerLevel>
+			</li>
+		</skillNeedFactors>
 		<capacityFactors>
 			<li>
 				<capacity>Sight</capacity>
 				<weight>0.6</weight>
-				<max>1</max>
+				<max>1.1</max>
 			</li>
 			<li>
 				<capacity>Manipulation</capacity>
@@ -158,6 +161,13 @@
 		<statFactors>
 			<li>WorkSpeedGlobal</li>
 		</statFactors>
+		<skillNeedFactors>
+			<li Class="SkillNeed_BaseBonus">
+				<skill>Crafting</skill>
+				<baseValue>0.6</baseValue>
+				<bonusPerLevel>0.05</bonusPerLevel>
+			</li>
+		</skillNeedFactors>
 		<capacityFactors>
 			<li>
 				<capacity>Sight</capacity>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -2024,8 +2024,8 @@
 					<li>
 						<recipeDef>Make_Nitre_Body</recipeDef>
 						<temperatureSafe>
-							<min>10</min>
-							<max>30</max>
+							<min>5</min>
+							<max>35</max>
 						</temperatureSafe>
 						<temperatureIdeal>
 							<min>10</min>
@@ -2042,8 +2042,8 @@
 					<li>
 						<recipeDef>Make_Nitre_Mush</recipeDef>
 						<temperatureSafe>
-							<min>10</min>
-							<max>30</max>
+							<min>5</min>
+							<max>35</max>
 						</temperatureSafe>
 						<temperatureIdeal>
 							<min>10</min>
@@ -2058,8 +2058,8 @@
 					<li MayRequire="Dubwise.DubsBadHygiene">
 						<recipeDef>Make_Nitre_Fecal</recipeDef>
 						<temperatureSafe>
-							<min>10</min>
-							<max>30</max>
+							<min>5</min>
+							<max>35</max>
 						</temperatureSafe>
 						<temperatureIdeal>
 							<min>10</min>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Items/Items_Tools.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Items/Items_Tools.xml
@@ -85,7 +85,7 @@
 					<li Class="SurvivalToolsLite.SurvivalToolProperties">
 						<baseWorkStatFactors>
 							<ConstructionSpeed>1</ConstructionSpeed>
-							<SmithingSpeed>1.2</SmithingSpeed>
+							<SmithingSpeed>1</SmithingSpeed>
 						</baseWorkStatFactors>
 						<defaultSurvivalToolAssignmentTags>
 							<li>Constructor</li>
@@ -198,7 +198,7 @@
 							<ConstructionSpeed>1.3</ConstructionSpeed>
 							<PlantHarvestingSpeed>1.3</PlantHarvestingSpeed>
 							<PlantSowingSpeed>1.2</PlantSowingSpeed>
-							<SmithingSpeed>1.5</SmithingSpeed>
+							<SmithingSpeed>1.3</SmithingSpeed>
 						</baseWorkStatFactors>
 						<defaultSurvivalToolAssignmentTags>
 							<li>Constructor</li>
@@ -237,7 +237,7 @@
 					<li Class="SurvivalToolsLite.SurvivalToolProperties">
 						<baseWorkStatFactors>
 							<ConstructionSpeed>1.2</ConstructionSpeed>
-							<SmithingSpeed>1.4</SmithingSpeed>
+							<SmithingSpeed>1.2</SmithingSpeed>
 						</baseWorkStatFactors>
 						<defaultSurvivalToolAssignmentTags>
 							<li>Crafter</li>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Alloys_Hightech.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Alloys_Hightech.xml
@@ -27,6 +27,7 @@
                     <DiggingSpeed>1.15</DiggingSpeed>
                     <MiningYieldDigging>1.2</MiningYieldDigging>
                     <ConstructionSpeed>1.6</ConstructionSpeed>
+					<SmithingSpeed>1.2</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -43,6 +44,7 @@
                     <DiggingSpeed>1.45</DiggingSpeed>
                     <MiningYieldDigging>1.4</MiningYieldDigging>
                     <ConstructionSpeed>1.45</ConstructionSpeed>
+					<SmithingSpeed>1.4</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -59,6 +61,7 @@
                     <DiggingSpeed>1.2</DiggingSpeed>
                     <MiningYieldDigging>1.3</MiningYieldDigging>
                     <ConstructionSpeed>1.5</ConstructionSpeed>
+					<SmithingSpeed>1.25</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -75,6 +78,7 @@
                     <DiggingSpeed>1.6</DiggingSpeed>
                     <MiningYieldDigging>1.7</MiningYieldDigging>
                     <ConstructionSpeed>0.9</ConstructionSpeed>
+					<SmithingSpeed>1.55</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -91,6 +95,7 @@
                     <DiggingSpeed>1.35</DiggingSpeed>
                     <MiningYieldDigging>1.5</MiningYieldDigging>
                     <ConstructionSpeed>1.65</ConstructionSpeed>
+					<SmithingSpeed>1.35</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -107,6 +112,7 @@
                     <DiggingSpeed>1.4</DiggingSpeed>
                     <MiningYieldDigging>1.5</MiningYieldDigging>
                     <ConstructionSpeed>1.7</ConstructionSpeed>
+					<SmithingSpeed>1.5</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -123,6 +129,7 @@
                     <DiggingSpeed>1.7</DiggingSpeed>
                     <MiningYieldDigging>1.6</MiningYieldDigging>
                     <ConstructionSpeed>1.5</ConstructionSpeed>
+					<SmithingSpeed>1.6</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
@@ -11,6 +11,7 @@
                     <DiggingSpeed>0.7</DiggingSpeed>
                     <MiningYieldDigging>0.6</MiningYieldDigging>
                     <ConstructionSpeed>1.2</ConstructionSpeed>
+					<SmithingSpeed>0.75</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -27,6 +28,7 @@
                     <DiggingSpeed>0.9</DiggingSpeed>
                     <MiningYieldDigging>1.1</MiningYieldDigging>
                     <ConstructionSpeed>0.9</ConstructionSpeed>
+					<SmithingSpeed>1.1</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -43,6 +45,7 @@
                     <DiggingSpeed>1</DiggingSpeed>
                     <MiningYieldDigging>1</MiningYieldDigging>
                     <ConstructionSpeed>1</ConstructionSpeed>
+					<SmithingSpeed>1</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -59,6 +62,7 @@
                     <DiggingSpeed>1.05</DiggingSpeed>
                     <MiningYieldDigging>1.1</MiningYieldDigging>
                     <ConstructionSpeed>1.05</ConstructionSpeed>
+					<SmithingSpeed>1.07</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -75,6 +79,7 @@
                     <DiggingSpeed>1.05</DiggingSpeed>
                     <MiningYieldDigging>1.1</MiningYieldDigging>
                     <ConstructionSpeed>1.1</ConstructionSpeed>
+					<SmithingSpeed>1.1</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -91,6 +96,7 @@
                     <DiggingSpeed>1.2</DiggingSpeed>
                     <MiningYieldDigging>1.1</MiningYieldDigging>
                     <ConstructionSpeed>1.1</ConstructionSpeed>
+					<SmithingSpeed>1.2</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -107,6 +113,7 @@
                     <DiggingSpeed>1.15</DiggingSpeed>
                     <MiningYieldDigging>1.15</MiningYieldDigging>
                     <ConstructionSpeed>1.2</ConstructionSpeed>
+					<SmithingSpeed>1.15</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -123,6 +130,7 @@
                     <DiggingSpeed>1.3</DiggingSpeed>
                     <MiningYieldDigging>1.3</MiningYieldDigging>
                     <ConstructionSpeed>0.85</ConstructionSpeed>
+					<SmithingSpeed>1.3</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>
@@ -139,6 +147,7 @@
                     <DiggingSpeed>1.4</DiggingSpeed>
                     <MiningYieldDigging>1.4</MiningYieldDigging>
                     <ConstructionSpeed>1.3</ConstructionSpeed>
+					<SmithingSpeed>1.4</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
@@ -11,6 +11,7 @@
 					<DiggingSpeed>0.83</DiggingSpeed>
 					<MiningYieldDigging>0.9</MiningYieldDigging>
 					<ConstructionSpeed>0.83</ConstructionSpeed>
+					<SmithingSpeed>0.9</SmithingSpeed>
 				</toolStatFactors>
 			</li>
 		</value>
@@ -40,6 +41,7 @@
 					<DiggingSpeed>0.8</DiggingSpeed>
 					<MiningYieldDigging>0.9</MiningYieldDigging>
 					<ConstructionSpeed>0.8</ConstructionSpeed>
+					<SmithingSpeed>0.95</SmithingSpeed>
 				</toolStatFactors>
 			</li>
 		</value>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Ore.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Ore.xml
@@ -10,6 +10,7 @@
 					<PlantSowingSpeed>0.9</PlantSowingSpeed>
                     <MiningYieldDigging>0.9</MiningYieldDigging>
                     <DiggingSpeed>1.1</DiggingSpeed>
+					<SmithingSpeed>0.9</SmithingSpeed>
                 </toolStatFactors>
             </li>
         </value>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Stuff.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Stuff.xml
@@ -30,35 +30,6 @@
     </Operation>
 
     <Operation Class="PatchOperationAddModExtension">
-        <xpath>Defs/ThingDef[defName="Plasteel"]</xpath>
-        <value>
-            <li Class="SurvivalToolsLite.StuffPropsTool">
-                <toolStatFactors>
-                    <TreeFellingSpeed>1.3</TreeFellingSpeed>
-                    <PlantHarvestingSpeed>1.3</PlantHarvestingSpeed>
-					<PlantSowingSpeed>1.3</PlantSowingSpeed>
-                </toolStatFactors>
-            </li>
-        </value>
-    </Operation>
-
-    <Operation Class="PatchOperationAddModExtension">
-        <xpath>Defs/ThingDef[defName="WoodLog"]</xpath>
-        <value>
-            <li Class="SurvivalToolsLite.StuffPropsTool">
-                <toolStatFactors>
-                    <TreeFellingSpeed>0.6</TreeFellingSpeed>
-                    <PlantHarvestingSpeed>0.6</PlantHarvestingSpeed>
-					<PlantSowingSpeed>0.6</PlantSowingSpeed>
-                    <DiggingSpeed>0.6</DiggingSpeed>
-                    <MiningYieldDigging>0.8</MiningYieldDigging>
-                    <ConstructionSpeed>0.6</ConstructionSpeed>
-                </toolStatFactors>
-            </li>
-        </value>
-    </Operation>
-
-    <Operation Class="PatchOperationAddModExtension">
         <xpath>Defs/ThingDef[defName="Uranium"]</xpath>
         <value>
             <li Class="SurvivalToolsLite.StuffPropsTool">
@@ -66,21 +37,6 @@
                     <DiggingSpeed>1.3</DiggingSpeed>
                     <MiningYieldDigging>1.1</MiningYieldDigging>
                     <ConstructionSpeed>1.3</ConstructionSpeed>
-                </toolStatFactors>
-            </li>
-        </value>
-    </Operation>
-
-    <Operation Class="PatchOperationAddModExtension">
-        <xpath>Defs/ThingDef[defName="Jade"]</xpath>
-        <value>
-            <li Class="SurvivalToolsLite.StuffPropsTool">
-                <toolStatFactors>
-                    <TreeFellingSpeed>0.9</TreeFellingSpeed>
-                    <PlantHarvestingSpeed>0.9</PlantHarvestingSpeed>
-					<PlantSowingSpeed>0.9</PlantSowingSpeed>
-                    <MiningYieldDigging>0.9</MiningYieldDigging>
-                    <DiggingSpeed>1.1</DiggingSpeed>
                 </toolStatFactors>
             </li>
         </value>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Wood.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Wood.xml
@@ -11,6 +11,7 @@
 					<DiggingSpeed>0.6</DiggingSpeed>
 					<MiningYieldDigging>0.8</MiningYieldDigging>
 					<ConstructionSpeed>0.6</ConstructionSpeed>
+					<SmithingSpeed>0.7</SmithingSpeed>
 				</toolStatFactors>
 			</li>
 		</value>
@@ -27,6 +28,7 @@
 					<DiggingSpeed>0.5</DiggingSpeed>
 					<MiningYieldDigging>0.7</MiningYieldDigging>
 					<ConstructionSpeed>0.5</ConstructionSpeed>
+					<SmithingSpeed>0.65</SmithingSpeed>
 				</toolStatFactors>
 			</li>
 		</value>
@@ -43,6 +45,7 @@
 					<DiggingSpeed>0.6</DiggingSpeed>
 					<MiningYieldDigging>0.8</MiningYieldDigging>
 					<ConstructionSpeed>0.6</ConstructionSpeed>
+					<SmithingSpeed>0.7</SmithingSpeed>
 				</toolStatFactors>
 			</li>
 		</value>
@@ -59,6 +62,7 @@
 					<DiggingSpeed>0.5</DiggingSpeed>
 					<MiningYieldDigging>0.7</MiningYieldDigging>
 					<ConstructionSpeed>0.5</ConstructionSpeed>
+					<SmithingSpeed>0.65</SmithingSpeed>
 				</toolStatFactors>
 			</li>
 		</value>
@@ -75,6 +79,7 @@
 					<DiggingSpeed>0.5</DiggingSpeed>
 					<MiningYieldDigging>0.7</MiningYieldDigging>
 					<ConstructionSpeed>0.5</ConstructionSpeed>
+					<SmithingSpeed>0.65</SmithingSpeed>
 				</toolStatFactors>
 			</li>
 		</value>
@@ -91,6 +96,7 @@
 					<DiggingSpeed>0.5</DiggingSpeed>
 					<MiningYieldDigging>0.7</MiningYieldDigging>
 					<ConstructionSpeed>0.5</ConstructionSpeed>
+					<SmithingSpeed>0.65</SmithingSpeed>
 				</toolStatFactors>
 			</li>
 		</value>


### PR DESCRIPTION
1 added to tailoring and smithing speed params dependence of сrafting skill (cuz 99,7% of all apparels craft and smithing craft recipes requires some сrafting skill);
2 removed A16-A17 capacity factors legacy from fishing and electronic crafting speed params (consciousness counts twice and pawns get twice bonus);
3 reduced tools base smithing factor (~20%) (120%->100% for hammer for example);
4 added base smithing factors to all resources (like other params);
5 deleted duplicate patches for wood log, steel alloy and jade in survival tools lite mod;
6 expanded saltpeter pit safe temperature from 10-30 to 5-35 (cuz it was similar with ideal temperature and didn't work at all).

1 для навыков шитья и ковки добавлена зависимость от навыка ремесла (т.к. 99,7% всех рецептов ковки и шитья требуют навык ремесла в том или ином кол-ве);
2 убрано наследие А16-А17-версий, из-за которого параметр сознания учитывался дважды в рыбалке и крафте электроники (из-за чего пешки получали двойной бонус к этим типам работы);
3 уменьшен базовый бонус к ковке для всех инструментов на ~20% (например, с 120% до 100% у молотка);
4 всем (ну, почти) материалам добавлен множитель к ковке (как, например, для строительства или рубки деревьев);
5 удалены дублирующие патчи для древесины, стального сплава и нефрита в моде survival tools lite;
6 расширен температурный диапазон селитряницы на 5 градусов (до 5-35, т.к. полностью совпадал с идеальным температурным диапазонам и из-за этого не работал вообще).