### PR TITLE
Tails unification update

### DIFF
--- a/Mods/Core_SK/Defs/BodyParts/BodyParts_Orassan.xml
+++ b/Mods/Core_SK/Defs/BodyParts/BodyParts_Orassan.xml
@@ -298,8 +298,8 @@
 						</capacities>
 						<power>17</power>
 						<cooldownTime>1.3</cooldownTime>
-						<armorPenetrationBlunt>0.4</armorPenetrationBlunt>
-						<armorPenetrationSharp>0.6</armorPenetrationSharp>
+						<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						<armorPenetrationSharp>6</armorPenetrationSharp>
 					</li>
 				</tools>
 			</li>
@@ -442,7 +442,7 @@
 			<Medicine>11</Medicine>
 		</skillRequirements>	
 		<appliedOnFixedBodyParts>
-			<li>Tail</li> 
+			<li>Tail</li>
 		</appliedOnFixedBodyParts>
 		<addsHediff>CyberneticTail</addsHediff>
 		<researchPrerequisite>Bionics</researchPrerequisite>

--- a/Mods/RatkinRaceHSK/Defs/HediffDefs/Hediffs_Local_AddedParts.xml
+++ b/Mods/RatkinRaceHSK/Defs/HediffDefs/Hediffs_Local_AddedParts.xml
@@ -14,7 +14,7 @@
 		</addedPartProps>
 	</HediffDef>
 
-	<HediffDef ParentName="AddedBodyPartBase">
+<!-- 	<HediffDef ParentName="AddedBodyPartBase">
 		<defName>RK_BionicTail</defName>
 		<label>bionic tail(ratkin)</label>
 		<description>An advanced artificial tail. It also has a small AI that automatically balances the user's missing.</description>
@@ -24,7 +24,7 @@
 			<solid>true</solid>
 			<partEfficiency>1.25</partEfficiency>
 		</addedPartProps>
-	</HediffDef>
+	</HediffDef> -->
 
 	<HediffDef ParentName="AddedBodyPartBase">
 		<defName>RK_FakeTail</defName>

--- a/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_PlayerSK.xml
+++ b/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_PlayerSK.xml
@@ -80,7 +80,7 @@
 			</subOptionsChooseOne>
 		</inventoryOptions>
 		<techHediffsRequired>
-			<li>RK_BionicTail</li>
+			<li>BionicTail</li>
 		</techHediffsRequired>
 		<apparelAllowHeadgearChance>1</apparelAllowHeadgearChance>
 		<skills>

--- a/Mods/RatkinRaceHSK/Defs/RecipeDefs/Recipes_Surgery_Installations.xml
+++ b/Mods/RatkinRaceHSK/Defs/RecipeDefs/Recipes_Surgery_Installations.xml
@@ -64,7 +64,7 @@
 	</RecipeDef>
 
 	
-	<RecipeDef ParentName="SurgeryFlesh">
+<!-- 	<RecipeDef ParentName="SurgeryFlesh">
 		<defName>RK_InstallBionicTail</defName>
 		<label>install bionic tail</label>
 		<description>Install a bionic tail.</description>
@@ -104,6 +104,6 @@
 			<li>RK_RatTail</li>
 		</appliedOnFixedBodyParts>
 		<addsHediff>RK_BionicTail</addsHediff>
-	</RecipeDef>
+	</RecipeDef> -->
 	
 </Defs>

--- a/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
@@ -589,9 +589,14 @@
 			</hediffGiverSets>
 		</race>
 		<recipes>   
-			<li>RK_InstallBionicTail</li>
+			<!-- <li>RK_InstallBionicTail</li> -->
 			<li>RK_InstallFakeEar</li>
 			<li>RK_InstallFakeTail</li>
+			<li>InstallClothTail</li>
+			<li>InstallPlasteelClaws</li>
+			<li>InstallBionicTail</li>
+			<li>InstallCyberneticTail</li>
+			<li>InstallOrassanTail</li>
 		</recipes>
 	</AlienRace.ThingDef_AlienRace>
 </Defs>

--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Weapon.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Weapon.xml
@@ -1231,7 +1231,7 @@
 				<power>7</power>
 				<cooldownTime>1.5</cooldownTime>
 				<chanceFactor>1.5</chanceFactor>
-				<armorPenetrationSharp>3</armorPenetrationSharp>
+				<armorPenetrationBlunt>3</armorPenetrationBlunt>
 				<linkedBodyPartsGroup>Stock</linkedBodyPartsGroup>
 			</li>
 			<li Class="CombatExtended.ToolCE">

--- a/Mods/RatkinRaceHSK/Defs/Things_ItemDefs/Items_BodyParts.xml
+++ b/Mods/RatkinRaceHSK/Defs/Things_ItemDefs/Items_BodyParts.xml
@@ -47,7 +47,7 @@
 		</techHediffsTags>
 	</ThingDef>
 	
-	<ThingDef ParentName="BodyPartBionicBase">
+<!-- 	<ThingDef ParentName="BodyPartBionicBase">
 		<defName>RK_BionicTail</defName>
 		<label>bionic ratkin tail</label>
 		<description>An advanced artificial tail. It also has a small AI that automatically balances the user's missing.</description>
@@ -76,6 +76,6 @@
 		<techHediffsTags>
 			<li>Advanced</li>
 		</techHediffsTags>
-	</ThingDef>
+	</ThingDef> -->
 
 </Defs>

--- a/Mods/RatkinRaceHSK/Patches/Bodies/Bodies_Ratkin.xml
+++ b/Mods/RatkinRaceHSK/Patches/Bodies/Bodies_Ratkin.xml
@@ -289,4 +289,13 @@
     </value>
   </Operation>
 
+  <!-- ========== Tails unification ========== -->
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/RecipeDef[defName="InstallOrassanTail" or defName="InstallClothTail" or defName="InstallBionicTail" or defName="InstallCyberneticTail"]/appliedOnFixedBodyParts</xpath>
+    <value>
+      <li>RK_RatTail</li>
+    </value>
+  </Operation>
+
 </Patch>


### PR DESCRIPTION
1 removed ratkin bionic tail. Added ability to use other tails and claws in ratkin's surgery recipes (bionics and cybernetics too);
2 fixed armor penetration of advanced claws (very low value);
3 fixed ratkin shotgun stock (=blunt dmg) armor penetration (sharp -> blunt).

1 бионический хвост раткинов был упразднен. Добавлена возможность имплантировать раткинам все прочие хвосты и когти (в том числе бионические и кибернетические);
2 исправлено бронепробитие у продвинутых когтей (очень низкие значения);
3 исправлено бронепробитие в ближнем бою у дробовика раткинов (удар прикладом использовал не тот тип бронепробития).