### PR TITLE
Fixed embrasures incorrect displaying with wooden and stony materials (always looks like made from metal)

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Defences.xml
@@ -232,8 +232,8 @@
 		<defName>Embrasure</defName>
 		<label>embrasure</label>
 		<graphicData>
-			<texPath>Things/Building/Embrasure/Embrasure_Atlas_Smooth</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
+			<texPath>Things/Building/Embrasure</texPath>
+			<graphicClass>Graphic_Appearances</graphicClass>
 			<linkType>CornerFiller</linkType>
 			<linkFlags>
 				<li>Wall</li>


### PR DESCRIPTION
Fixed embrasures incorrect displaying with wooden and stony materials (always looks like made from metal).

![image](https://user-images.githubusercontent.com/62516232/119539830-19ccb900-bda6-11eb-9bcc-475827b5b5a7.png)

Исправлено некорректное отображение амбразур из деревянных и каменных материалов (всегда выглядели как сделанные из металла).