### PR TITLE
NPS SK biomes forageability fixed

### DIFF
--- a/Mods/NPS_SK/Defs/BiomeDefs/BiomeDef_NPS.xml
+++ b/Mods/NPS_SK/Defs/BiomeDefs/BiomeDef_NPS.xml
@@ -11,7 +11,7 @@
 		<settlementSelectionWeight>0.65</settlementSelectionWeight>
 		<movementDifficulty>1</movementDifficulty>
 		<forageability>0.25</forageability>
-		<foragedFood>Plant_Mushroom_Red</foragedFood>
+		<foragedFood>RawAgave</foragedFood>
 		<texture>NPS/World/Biomes/Saltfields</texture>
 		<wildPlantsCareAboutLocalFertility>false</wildPlantsCareAboutLocalFertility>
 		<wildPlantRegrowDays>35</wildPlantRegrowDays>
@@ -1578,7 +1578,7 @@
 		<settlementSelectionWeight>0.2</settlementSelectionWeight>
 		<movementDifficulty>2</movementDifficulty>
 		<forageability>0.12</forageability>
-		<foragedFood>Plant_Mushroom_Red</foragedFood>
+		<foragedFood>RawAgave</foragedFood>
 		<wildPlantRegrowDays>25</wildPlantRegrowDays>
 		<texture>NPS/World/Biomes/Wasteland</texture>
 		<soundsAmbient>


### PR DESCRIPTION
Replaced red mushroom to agave (forage food only) in wasteland and desert and salt fields biomes (cuz first one haven't nutrition value).

Красный гриб заменен на агаву в биомах пустошей и соляных полей (только добыча на глобальной карте) (т.к. красный гриб не имеет питательности и из-за этого караваны могут начать голодать).