### PR TITLE
Cultist trait update and fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThoughtDefs/Extratraits/Thoughts_Exotic.xml
+++ b/Mods/Core_SK/Defs/ThoughtDefs/Extratraits/Thoughts_Exotic.xml
@@ -11,29 +11,29 @@
 	</requiredTraits>
     <stages>
       <li>
-        <label>psychic soothe (medium)</label>
+        <label>psychic soothe</label>
         <description>It's like a calming voice at the back of my mind, soothing me, settling my nerves.</description>
-        <baseMoodEffect>15</baseMoodEffect>
+        <baseMoodEffect>16</baseMoodEffect>
       </li>
       <li>
-        <label>psychic drone (low)</label>
+        <label>low psychic drone</label>
         <description>It's like a scratching at the back of my mind. A voice, whispering. I can only make out a few words, and I recognize the song calling to me.</description>
-        <baseMoodEffect>7</baseMoodEffect>
+        <baseMoodEffect>12</baseMoodEffect>
       </li>
       <li>
-        <label>psychic drone (medium)</label>
+        <label>moderate psychic drone</label>
         <description>I feel like the voice could be coming from just around the corner.</description>
-        <baseMoodEffect>15</baseMoodEffect>
+        <baseMoodEffect>22</baseMoodEffect>
       </li>
       <li>
-        <label>psychic drone (high)</label>
+        <label>high psychic drone</label>
         <description>The voice is serene and comforting</description>
-        <baseMoodEffect>25</baseMoodEffect>
+        <baseMoodEffect>30</baseMoodEffect>
       </li>
       <li>
-        <label>psychic drone (extreme)</label>
+        <label>extreme psychic drone</label>
         <description>My heart pounds and I'm sweating. The call has found me.</description>
-        <baseMoodEffect>50</baseMoodEffect>
+        <baseMoodEffect>40</baseMoodEffect>
       </li>
     </stages>
   </ThoughtDef>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThoughtDef/Thoughts_Exotic.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThoughtDef/Thoughts_Exotic.xml
@@ -1,15 +1,15 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
-	<PsychicDroneCultist.stages.0.label>психическое успокоение (среднее)</PsychicDroneCultist.stages.0.label>
+	<PsychicDroneCultist.stages.0.label>умиротворение</PsychicDroneCultist.stages.0.label>
 	<PsychicDroneCultist.stages.0.description>Похоже что тихий, успокаивающий голос в подсознании успокаивает меня, приводя в порядок нервную систему.</PsychicDroneCultist.stages.0.description>
-	<PsychicDroneCultist.stages.1.label>психо-дрон (слабый)</PsychicDroneCultist.stages.1.label>
+	<PsychicDroneCultist.stages.1.label>слабый гул</PsychicDroneCultist.stages.1.label>
 	<PsychicDroneCultist.stages.1.description>Как будто кто-то скребётся в глубине сознания. Голос... Он что-то шепчет. Я могу разобрать лишь несколько слов, и эта едва различимая песня зовёт меня.</PsychicDroneCultist.stages.1.description>
-	<PsychicDroneCultist.stages.2.label>психо-зонд (средний)</PsychicDroneCultist.stages.2.label>
+	<PsychicDroneCultist.stages.2.label>средний гул</PsychicDroneCultist.stages.2.label>
 	<PsychicDroneCultist.stages.2.description>Мне кажется источник голосов находится где-то рядом, может даже за тем углом..</PsychicDroneCultist.stages.2.description>
-	<PsychicDroneCultist.stages.3.label>психо-зонд (сильный)</PsychicDroneCultist.stages.3.label>
+	<PsychicDroneCultist.stages.3.label>сильный гул</PsychicDroneCultist.stages.3.label>
 	<PsychicDroneCultist.stages.3.description>Голос громко раздаётся в голове и приносит блаженство.</PsychicDroneCultist.stages.3.description>
-	<PsychicDroneCultist.stages.4.label>психо-зонд (предельный)</PsychicDroneCultist.stages.4.label>
+	<PsychicDroneCultist.stages.4.label>запредельный гул</PsychicDroneCultist.stages.4.label>
 	<PsychicDroneCultist.stages.4.description>Сердце бешено колотится и пот льётся ручьём. Голос нашёл меня!</PsychicDroneCultist.stages.4.description>
 
 

--- a/Mods/Core_SK/Patches/Thoughts_Situation_Special.xml
+++ b/Mods/Core_SK/Patches/Thoughts_Situation_Special.xml
@@ -7,4 +7,26 @@
         </value>
     </Operation>
 
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+			<li Class="PatchOperationTest">
+				<xpath>Defs/ThoughtDef[defName = "PsychicDrone"]/nullifyingTraits</xpath>
+				<success>Invert</success>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThoughtDef[defName = "PsychicDrone"]</xpath>
+				<value>
+					<nullifyingTraits/>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThoughtDef[defName = "PsychicDrone"]/nullifyingTraits</xpath>
+		<value>
+			<li>Cultist</li>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
1 updated cultist trait base mood effect of psychic drones to last vanilla values;
2 fixed the bug that caused both negative and positive psychic drones effect to pawn with cultist trait at same time;
3 updated cultist trait eng and rus translations.

1 актуализировано влияние на настроение психических дронов на пешек с чертой "оккультизм" до последних значений ванильного римворлда;
2 исправлен баг, из-за которого пешка с чертой "оккультизм" получала положительный и отрицательный эффект от пси-дронов одновременно;
3 обновлены переводы черты характера "оккультизм".