### PR TITLE
Fixed research infuses bug

### DIFF
--- a/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
@@ -194,7 +194,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.02</offset>
+          <multiplier>1.02</multiplier>
         </value>
       </li>
     </stats>
@@ -332,7 +332,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.02</offset>
+          <multiplier>1.02</multiplier>
         </value>
       </li>
       <li>
@@ -1122,7 +1122,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.04</offset>
+          <multiplier>1.04</multiplier>
         </value>
       </li>
     </stats>
@@ -1260,7 +1260,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.04</offset>
+          <multiplier>1.04</multiplier>
         </value>
       </li>
       <li>
@@ -2045,7 +2045,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.06</offset>
+          <multiplier>1.06</multiplier>
         </value>
       </li>
     </stats>
@@ -2183,7 +2183,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.06</offset>
+          <multiplier>1.06</multiplier>
         </value>
       </li>
       <li>
@@ -2950,7 +2950,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.10</offset>
+          <multiplier>1.10</multiplier>
         </value>
       </li>
     </stats>
@@ -3088,7 +3088,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.10</offset>
+          <multiplier>1.10</multiplier>
         </value>
       </li>
       <li>
@@ -3855,7 +3855,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.15</offset>
+          <multiplier>1.15</multiplier>
         </value>
       </li>
     </stats>
@@ -3993,7 +3993,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.15</offset>
+          <multiplier>1.15</multiplier>
         </value>
       </li>
       <li>
@@ -4760,7 +4760,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.30</offset>
+          <multiplier>1.30</multiplier>
         </value>
       </li>
     </stats>
@@ -4952,7 +4952,7 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <offset>1.25</offset>
+          <multiplier>1.25</multiplier>
         </value>
       </li>
       <li>


### PR DESCRIPTION
It's gave offset instead of multiplier (for example +102% instead x1.02).

Был чистый бонус вместо множителя (т.е. +102%, а не х1.02)