### PR TITLE
Unarmed damage tweaks and fixes

### DIFF
--- a/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
@@ -221,7 +221,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>8</power>
+				<power>6</power>
 				<cooldownTime>1.2</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<surpriseAttack>
@@ -233,14 +233,14 @@
 					</extraMeleeDamages>
 				</surpriseAttack>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
-				<armorPenetrationBlunt>2</armorPenetrationBlunt>
+				<armorPenetrationBlunt>1.8</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>right fist</label>
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>8</power>
+				<power>6</power>
 				<cooldownTime>1.2</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<surpriseAttack>
@@ -252,18 +252,18 @@
 					</extraMeleeDamages>
 				</surpriseAttack>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
-				<armorPenetrationBlunt>2</armorPenetrationBlunt>
+				<armorPenetrationBlunt>1.8</armorPenetrationBlunt>
 			</li>
 			<li Class="CombatExtended.ToolCE">
 				<label>head</label>
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>3</power>
+				<power>6</power>
 				<cooldownTime>2.4</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<chanceFactor>0.2</chanceFactor>
-				<armorPenetrationBlunt>2.2</armorPenetrationBlunt>
+				<armorPenetrationBlunt>2</armorPenetrationBlunt>
 				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 			</li>
 		</tools>

--- a/Mods/AsariRace/Defs/ThingDefs_Races/Races_Asari.xml
+++ b/Mods/AsariRace/Defs/ThingDefs_Races/Races_Asari.xml
@@ -156,7 +156,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>8</power>
+				<power>6</power>
 				<cooldownTime>1.3</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -167,7 +167,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>8</power>
+				<power>6</power>
 				<cooldownTime>1.3</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -178,7 +178,7 @@
 				<capacities>
 					<li>Bite</li>
 				</capacities>
-				<power>7</power>
+				<power>6</power>
 				<cooldownTime>2</cooldownTime>
 				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 				<chanceFactor>0.3</chanceFactor>

--- a/Mods/CombatExtended/Defs/Stats/Stats_Pawns_Combat.xml
+++ b/Mods/CombatExtended/Defs/Stats/Stats_Pawns_Combat.xml
@@ -307,7 +307,7 @@
       <li Class="SkillNeed_BaseBonus">
         <skill>Melee</skill>
         <baseValue>0.00</baseValue>
-        <bonusPerLevel>0.50</bonusPerLevel>
+        <bonusPerLevel>0.40</bonusPerLevel>
       </li>
     </skillNeedOffsets>
     <capacityFactors>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Humanlike.xml
@@ -311,7 +311,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>6</power>
+				<power>4</power>
 				<cooldownTime>1.26</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -322,7 +322,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>6</power>
+				<power>4</power>
 				<cooldownTime>1.26</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -333,7 +333,7 @@
 				<capacities>
 					<li>Bite</li>
 				</capacities>
-				<power>7</power>
+				<power>4</power>
 				<cooldownTime>2</cooldownTime>
 				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 				<chanceFactor>0.3</chanceFactor>
@@ -347,7 +347,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>5</power>
+				<power>4</power>
 				<cooldownTime>1.75</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<chanceFactor>0.2</chanceFactor>
@@ -655,7 +655,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>7</power>
+				<power>5</power>
 				<cooldownTime>1.2</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -666,7 +666,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>7</power>
+				<power>5</power>
 				<cooldownTime>1.2</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -677,7 +677,7 @@
 				<capacities>
 					<li>Bite</li>
 				</capacities>
-				<power>7</power>
+				<power>5</power>
 				<cooldownTime>2</cooldownTime>
 				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 				<chanceFactor>0.3</chanceFactor>
@@ -691,7 +691,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>6</power>
+				<power>5</power>
 				<cooldownTime>1.6</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<chanceFactor>0.2</chanceFactor>
@@ -1083,7 +1083,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>7</power>
+				<power>5</power>
 				<cooldownTime>1.3</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -1102,7 +1102,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>7</power>
+				<power>5</power>
 				<cooldownTime>1.3</cooldownTime>
 				<chanceFactor>0.5</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -1121,7 +1121,7 @@
 				<capacities>
 					<li>Bite</li>
 				</capacities>
-				<power>9</power>
+				<power>7</power>
 				<cooldownTime>2</cooldownTime>
 				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 				<chanceFactor>0.3</chanceFactor>
@@ -1135,7 +1135,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>6</power>
+				<power>5</power>
 				<cooldownTime>2.6</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<chanceFactor>0.2</chanceFactor>
@@ -1211,7 +1211,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>8</power>
+				<power>6</power>
 				<cooldownTime>1.35</cooldownTime>
 				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -1222,7 +1222,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>8</power>
+				<power>6</power>
 				<cooldownTime>1.35</cooldownTime>
 				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -1233,7 +1233,7 @@
 				<capacities>
 					<li>Bite</li>
 				</capacities>
-				<power>8</power>
+				<power>6</power>
 				<cooldownTime>1.7</cooldownTime>
 				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 				<chanceFactor>0.3</chanceFactor>
@@ -1627,7 +1627,7 @@
 				<capacities>
 					<li>Bite</li>
 				</capacities>
-				<power>10</power>
+				<power>8</power>
 				<cooldownTime>2.6</cooldownTime>
 				<chanceFactor>0.3</chanceFactor>
 				<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
@@ -1648,7 +1648,7 @@
 				<capacities>
 					<li>Scratch</li>
 				</capacities>
-				<power>7</power>
+				<power>5</power>
 				<cooldownTime>1.15</cooldownTime>
 				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -1660,7 +1660,7 @@
 				<capacities>
 					<li>Scratch</li>
 				</capacities>
-				<power>7</power>
+				<power>5</power>
 				<cooldownTime>1.15</cooldownTime>
 				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -1672,7 +1672,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>10</power>
+				<power>8</power>
 				<cooldownTime>2.7</cooldownTime>
 				<chanceFactor>0.6</chanceFactor>
 				<linkedBodyPartsGroup>Tailblunt</linkedBodyPartsGroup>
@@ -1691,7 +1691,7 @@
 				<capacities>
 					<li>Blunt</li>
 				</capacities>
-				<power>6</power>
+				<power>5</power>
 				<cooldownTime>2.75</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 				<chanceFactor>0.15</chanceFactor>

--- a/Mods/RatkinRaceHSK/Patches/ThingDefs_Races/Race_Rakinlike.xml
+++ b/Mods/RatkinRaceHSK/Patches/ThingDefs_Races/Race_Rakinlike.xml
@@ -56,7 +56,7 @@
 						<capacities>
 							<li>Scratch</li>
 						</capacities>
-						<power>4</power>
+						<power>3</power>
 						<cooldownTime>1.11</cooldownTime>
 					  	<chanceFactor>0.45</chanceFactor>
 						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -68,7 +68,7 @@
 						<capacities>
 							<li>Blunt</li>
 						</capacities>
-						<power>4</power>
+						<power>3</power>
 						<cooldownTime>1.2</cooldownTime>
 						<chanceFactor>0.5</chanceFactor>
 						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -79,7 +79,7 @@
 						<capacities>
 							<li>Scratch</li>
 						</capacities>
-						<power>4</power>
+						<power>3</power>
 						<cooldownTime>1.11</cooldownTime>
 					  	<chanceFactor>0.45</chanceFactor>
 						<linkedBodyPartsGroup>RightHand</linkedBodyPartsGroup>
@@ -91,7 +91,7 @@
 						<capacities>
 							<li>Blunt</li>
 						</capacities>
-						<power>4</power>
+						<power>3</power>
 						<cooldownTime>1.2</cooldownTime>
 						<chanceFactor>0.5</chanceFactor>
 						<linkedBodyPartsGroup>LeftHand</linkedBodyPartsGroup>
@@ -102,7 +102,7 @@
 						<capacities>
 							<li>Bite</li>
 						</capacities>
-						<power>7</power>
+						<power>5</power>
 						<cooldownTime>1.32</cooldownTime>
 						<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 						<chanceFactor>0.3</chanceFactor>


### PR DESCRIPTION
1 reduced unarmed damage bonus param scaling by 20%;
2 reduced base unarmed damage value by 1-2.
This changes should help reduce chance some strange melee weapon swaps caused by too high unarmed damage values on not high value of pawn melee skill.

1 уменьшено скалирование бонуса к урону без оружия от навыка ближнего боя на 20%;
2 уменьшен базовый урон без оружия на 1-2 единицы (в зависимости от изначального базового урона).
Изменения должны помочь исправить ситуации (или уменьшить их шанс), когда из-за слишком высокой скорости роста урона без оружия, пешки с невысоким навыком ближнего боя предпочитали использовать кулаки вместо холодного оружия.