### PR TITLE
Returned litterSizeCurve and lifeStageAges param without inheriting

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingDefs_Races/Races_Rakinlike.xml
@@ -566,6 +566,38 @@
 			<baseHungerRate>0.9</baseHungerRate>
 			<foodType>OmnivoreHuman</foodType>
 			<gestationPeriodDays>21</gestationPeriodDays>
+			<litterSizeCurve Inherit="false">
+				<points>
+					<li>(0.5, 0)</li>
+					<li>(1, 0.30)</li>
+					<li>(2, 0.40)</li>
+					<li>(3, 0.10)</li>
+					<li>(4, 0.20)</li>
+					<li>(5, 0)</li>
+				</points>
+			</litterSizeCurve>
+			<lifeStageAges Inherit="false">
+				<li>
+					<def>HumanlikeBaby</def>
+					<minAge>0</minAge>
+				</li>
+				<li>
+					<def>HumanlikeToddler</def>
+					<minAge>1.2</minAge>
+				</li>
+				<li>
+					<def>HumanlikeChild</def>
+					<minAge>4</minAge>
+				</li>
+				<li>
+					<def>HumanlikeTeenager</def>
+					<minAge>11</minAge>
+				</li>
+				<li>
+					<def>HumanlikeAdult</def>
+					<minAge>16</minAge>
+				</li>
+			</lifeStageAges>
 			<soundMeleeHitPawn>Pawn_Melee_Punch_HitPawn</soundMeleeHitPawn>
 			<soundMeleeHitBuilding>Pawn_Melee_Punch_HitBuilding</soundMeleeHitBuilding>
 			<soundMeleeMiss>Pawn_Melee_Punch_Miss</soundMeleeMiss>


### PR DESCRIPTION
It's should help preventing spawn ratkins without ears in raids.

Возвращены параметры litterSizeCurve и lifeStageAges без наследования. Должно помочь предотвратить появление раткинов без ушей в рейдах.