### PR TITLE
Fixed CE inventory bug when Survivle tools lite was disabled 

### DIFF
--- a/Mods/RatkinRaceHSK/Patches/Apparel_STL.xml
+++ b/Mods/RatkinRaceHSK/Patches/Apparel_STL.xml
@@ -1,15 +1,18 @@
 <Patch>
-
-	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
-		<operations>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/ThingDef[defName="RK_CrossBack" or defName="RK_Backpack" or defName="RK_WorkerWear" or defName="RK_OutdoorBackpack" or defName="RK_Sack" or defName="RK_SantaSack"]/equippedStatOffsets</xpath>
-				<value>
-					<SurvivalToolCarryCapacity>1</SurvivalToolCarryCapacity>
-				</value>
-			</li>
-		</operations>
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Survival Tools Lite</li>
+		</mods>
+		<match Class="PatchOperationSequence">
+			<success>Normal</success>
+			<operations>
+				<li Class="PatchOperationAdd">
+					<xpath>Defs/ThingDef[defName="RK_CrossBack" or defName="RK_Backpack" or defName="RK_WorkerWear" or defName="RK_OutdoorBackpack" or defName="RK_Sack" or defName="RK_SantaSack"]/equippedStatOffsets</xpath>
+					<value>
+						<SurvivalToolCarryCapacity>1</SurvivalToolCarryCapacity>
+					</value>
+				</li>
+			</operations>
+		</match>
 	</Operation>
-
 </Patch>


### PR DESCRIPTION
When trying use ratkin's backpacks.

Исправлен баг с отображением инвентаря CE при одновременно выключенном моде Survivle tools lite и использовании рюкзаков раткинов (thx Нея).