### PR TITLE
Fixed BodyDef *body name* has BodyPartRecord of *body part name* whose children have more or equal coverage than 100% (100.00% or more)

### DIFF
--- a/Mods/Arachnophobia_SK/Defs/BodyDefs/ROMA_Bodies.xml
+++ b/Mods/Arachnophobia_SK/Defs/BodyDefs/ROMA_Bodies.xml
@@ -23,7 +23,7 @@
                     <parts>
                         <li>
                             <def>InsectHead</def>
-                            <coverage>0.4</coverage>
+                            <coverage>0.39</coverage>
                             <groups>
                                 <li>HeadAttackTool</li>
                             </groups>

--- a/Mods/Core_SK/Defs/Bodies/Bodies_QuadrupedAnimalWithHoovesAndAntlers.xml
+++ b/Mods/Core_SK/Defs/Bodies/Bodies_QuadrupedAnimalWithHoovesAndAntlers.xml
@@ -99,7 +99,7 @@
 								</li>
 								<li>
 									<def>Nose</def>
-									<coverage>0.1</coverage>
+									<coverage>0.09</coverage>
 								</li>
 								<li>
 									<def>AnimalJaw</def>
@@ -111,7 +111,7 @@
 								<li>
 									<def>Antler</def>
 									<customLabel>antlers</customLabel>
-									<coverage>0.15</coverage>
+									<coverage>0.12</coverage>
 									<groups>
 										<li>Antlers</li>
 									</groups>

--- a/Mods/Core_SK/Defs/Bodies/Bodies_QuadrupedWithPawsTailAndHeartGroup.xml
+++ b/Mods/Core_SK/Defs/Bodies/Bodies_QuadrupedWithPawsTailAndHeartGroup.xml
@@ -106,7 +106,7 @@
 								</li>
 								<li>
 									<def>Nose</def>
-									<coverage>0.1</coverage>
+									<coverage>0.09</coverage>
 								</li>
 								<li>
 									<def>AnimalJaw</def>

--- a/Mods/Core_SK/Patches/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndAntlers.xml
+++ b/Mods/Core_SK/Patches/Bodies/Bodies_Animal_Quadruped/QuadrupedAnimalWithHoovesAndAntlers.xml
@@ -214,7 +214,7 @@
 	<Operation Class="PatchOperationReplace">
   	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndAntlers"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="Skull"]/coverage</xpath>
   	<value>
-    	<coverage>0.3</coverage>
+    	<coverage>0.25</coverage>
   	</value>
 	</Operation>
 
@@ -228,21 +228,21 @@
 	<Operation Class="PatchOperationReplace">
   	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndAntlers"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Eye"]/coverage</xpath>
   	<value>
-    	<coverage>0.08</coverage>
+    	<coverage>0.07</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
   	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndAntlers"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def = "Ear"]/coverage</xpath>
   	<value>
-    	<coverage>0.12</coverage>
+    	<coverage>0.11</coverage>
   	</value>
 	</Operation>
 
 	<Operation Class="PatchOperationReplace">
   	<xpath>Defs/BodyDef[defName = "QuadrupedAnimalWithHoovesAndAntlers"]/corePart/parts/li[def="Neck"]/parts/li[def = "Head"]/parts/li[def="AnimalJaw"]/coverage</xpath>
   	<value>
-    	<coverage>0.2</coverage>
+    	<coverage>0.17</coverage>
   	</value>
 	</Operation>
 


### PR DESCRIPTION
Fixed yellow alert "BodyDef *body name* has BodyPartRecord of *body part name* whose children have more or equal coverage than 100% (100.00% or more (need 99% or less))".

Исправлено жёлтое предупреждение вида "BodyDef *body name* has BodyPartRecord of *body part name* whose children have more or equal coverage than 100% (100.00% или больше)" (из-за некорректных патчей сумма превышала 99%).