### PR TITLE
Recultivated soil is no longer sowable without terraforming

### DIFF
--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_Quarried.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_Quarried.xml
@@ -84,10 +84,9 @@
 			<li>Light</li>
 			<li>Medium</li>
 			<li>Heavy</li>
-			<li>GrowSoil</li>
 		</affordances>
 		<generatedFilth>Filth_Dirt</generatedFilth>
-		<fertility>0.7</fertility>
+		<fertility>0.3</fertility>
 		<takeFootprints>True</takeFootprints>
 		<filthAcceptanceMask>
 			<li>Unnatural</li>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/TerrainDef/Terrain_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/TerrainDef/Terrain_SK.xml
@@ -5,7 +5,7 @@
 
 	<QRY_QuarriedGround.label>Разрабатываемая поверхность</QRY_QuarriedGround.label>
 	<QRY_QuarriedGroundWall.label>Разрабатываемая поверхность</QRY_QuarriedGroundWall.label>
-	<QRY_ReclaimedSoil.label>Мелиорированная почва</QRY_ReclaimedSoil.label>
+	<QRY_ReclaimedSoil.label>Восстановленная почва</QRY_ReclaimedSoil.label>
 
 	<Pile.label>Груда горной породы</Pile.label>
 	<Pile.description>Груда горной породы.</Pile.description>


### PR DESCRIPTION
Восстановленную карьерную почву теперь нельзя разметить для посадок