### PR TITLE
Some terrain tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/BiomeDefs/Biomes_Temperate.xml
+++ b/Mods/Core_SK/Defs/BiomeDefs/Biomes_Temperate.xml
@@ -360,6 +360,11 @@
 					<li>
 						<terrain>MarshyTerrain</terrain>
 						<min>0.32</min>
+						<max>0.91</max>
+					</li>
+					<li>
+						<terrain>Marsh</terrain>
+						<min>0.91</min>
 						<max>999</max>
 					</li>
 				</thresholds>

--- a/Mods/Core_SK/Defs/SK.ObjectsSpawnsDefs/ObjectsSpawnsDefs.xml
+++ b/Mods/Core_SK/Defs/SK.ObjectsSpawnsDefs/ObjectsSpawnsDefs.xml
@@ -57,7 +57,7 @@
 		<defName>ObjectSpawn_Cairn</defName>
 		<thingDef>Cairn</thingDef>
 		<stuff>
-			<li>BlocksGranite</li>
+			<li>BlocksLimestone</li>
 		</stuff>
 		<allowOnWaterBiome>false</allowOnWaterBiome>
 		<allowOnWater>false</allowOnWater>		

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorCarpet.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorCarpet.xml
@@ -6,7 +6,7 @@
 	<TerrainDef Name="CarpetSK_FloorBase" ParentName="SK_FloorBase" Abstract="True">
 		<designationCategory>Floors</designationCategory>
 		<constructEffect>ConstructDirt</constructEffect>
-		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+		<terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
 		<pathCost>0</pathCost>
 		<fertility>0</fertility>
 		<statBases>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
@@ -13,7 +13,7 @@
 		<fertility>0</fertility>
 		<constructEffect>ConstructWood</constructEffect>
 		<burnedDef>BurnedWoodPlankFloor</burnedDef>
-		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+		<terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
 			<tags>
       <li>Floor</li>
     </tags>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_Floors_SK.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_Floors_SK.xml
@@ -15,7 +15,7 @@
 		<designationCategory>Floors</designationCategory>
 		<fertility>0</fertility>
 		<constructEffect>ConstructDirt</constructEffect>
-		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 		<tags>
 			<li>Floor</li>
 		</tags>
@@ -60,6 +60,7 @@ Beauty: 1.</description>
 		<researchPrerequisites>
 			<li>Concrete_floor_C1</li>
 		</researchPrerequisites>
+		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
 	</TerrainDef>
 
 	<TerrainDef ParentName="SK_FloorBase">
@@ -82,6 +83,7 @@ Beauty: 1.</description>
 		<researchPrerequisites>
 			<li>Concrete_floor_C1</li>
 		</researchPrerequisites>
+		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
 	</TerrainDef>
 
 	<TerrainDef ParentName="SK_FloorBase">

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
@@ -12,7 +12,7 @@
 		<fertility>0</fertility>
 		<constructEffect>ConstructWood</constructEffect>
 		<burnedDef>BurnedWoodPlankFloor</burnedDef>
-		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+		<terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
 	</TerrainDef>
 
 	<!-- ================= Floors ================= -->

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings.xml
@@ -150,6 +150,7 @@
 		<placeWorkers>
 			<li>PlaceWorker_PreventInteractionSpotOverlap</li>
 		</placeWorkers>
+		<useStuffTerrainAffordance>true</useStuffTerrainAffordance>
 	</ThingDef>
 
 	<ThingDef Name="BuildingFueled" ParentName="WorkTable" Abstract="True">

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -229,7 +229,6 @@
 			<li>Pemmican</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>3</constructionSkillPrerequisite>
-		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 	</ThingDef>
 
 	<ThingDef ParentName="WorkTable">

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Production.xml
@@ -159,6 +159,7 @@
 			<li>PlaceWorker_ShowFacilitiesConnections</li>
 			<li>PlaceWorker_ReportWorkSpeedPenalties</li>
 		</placeWorkers>
+		<useStuffTerrainAffordance>false</useStuffTerrainAffordance>
 		<researchPrerequisites>
 			<li>Food_0</li>
 		</researchPrerequisites>
@@ -228,6 +229,7 @@
 			<li>Pemmican</li>
 		</researchPrerequisites>
 		<constructionSkillPrerequisite>3</constructionSkillPrerequisite>
+		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 	</ThingDef>
 
 	<ThingDef ParentName="WorkTable">
@@ -2916,6 +2918,7 @@
 				<li>Production</li>
 			</buildingTags>
 		</building>
+		<useStuffTerrainAffordance>false</useStuffTerrainAffordance>
 		<designationHotKey>Misc1</designationHotKey>
 		<placeWorkers>
 			<li>PlaceWorker_ShowFacilitiesConnections</li>
@@ -3413,6 +3416,7 @@
 		<useHitPoints>False</useHitPoints>
 		<size>(1,1)</size>
 		<designationCategory>Production</designationCategory>
+		<useStuffTerrainAffordance>false</useStuffTerrainAffordance>
 		<terrainAffordanceNeeded>SmoothableStone</terrainAffordanceNeeded>
 		<passability>Standable</passability>
 		<interactionCellOffset>(0,0,-1)</interactionCellOffset>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Temperature.xml
@@ -41,6 +41,7 @@
 		</statBases>
 		<size>(1,1)</size>
 		<soundImpactDefault>BulletImpact_Ground</soundImpactDefault>
+		<useStuffTerrainAffordance>false</useStuffTerrainAffordance>
 		<leaveResourcesWhenKilled>false</leaveResourcesWhenKilled>
 		<resourcesFractionWhenDeconstructed>0</resourcesFractionWhenDeconstructed>
 		<placeWorkers>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Ore.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Ore.xml
@@ -385,6 +385,7 @@
 			</categories>
 			<color>(85,118,69)</color>
 			<constructEffect>ConstructMetal</constructEffect>
+			<appearance>Bricks</appearance>
 			<soundImpactStuff>BulletImpact_Metal</soundImpactStuff>
 			<soundMeleeHitSharp>MeleeHit_Stone</soundMeleeHitSharp>
 			<soundMeleeHitBlunt>MeleeHit_Stone</soundMeleeHitBlunt>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Parts.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Parts.xml
@@ -709,6 +709,7 @@
 			</statFactors>
 		</stuffProps>
 		<stackLimit>75</stackLimit>
+		<terrainAffordanceNeeded>Heavy</terrainAffordanceNeeded>
 	</ThingDef>
 
 

--- a/Mods/Fences and Floors_SK/Defs/TerrainDefs/Terrain_Floors.xml
+++ b/Mods/Fences and Floors_SK/Defs/TerrainDefs/Terrain_Floors.xml
@@ -10,7 +10,7 @@
     <designationCategory>Floors</designationCategory>
     <fertility>0</fertility>
     <constructEffect>ConstructDirt</constructEffect>
-    <terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
+    <terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
     <tags>
       <li>Floor</li>
     </tags>

--- a/Mods/SeedsPlease/Defs/ThingDefs/Buildings_Production.xml
+++ b/Mods/SeedsPlease/Defs/ThingDefs/Buildings_Production.xml
@@ -79,6 +79,7 @@
     <building>
       <spawnedConceptLearnOpportunity>BillsTab</spawnedConceptLearnOpportunity>
     </building>
+	<useStuffTerrainAffordance>true</useStuffTerrainAffordance>
     <comps>
       <li Class="CompProperties_AffectedByFacilities">
         <linkableFacilities>


### PR DESCRIPTION
1 added missed marsh terrain type to temperate swamp biome;
2 replaced cairn's base stuff from granite to limestone (cuz granite is boring and op);
3 fixed an issue where some heavy structures and floors could be placed on top of weak soils and bridges;
4 added missed bricks appearance param to jade.

1 добавлен пропущенный болотный тип почвы в умеренный болотный биом;
2 базовый материал каирнов заменен на известняк (гранит приелся, даешь разнообразие!);
3 исправлена ошибка, из-за которой некоторые постройки и полы можно было ставить поверх слабых почв и мостов;
4 добавлен пропущенный параметр внешнего вида для нефрита.