### PR TITLE
Some traits tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/TraitDefs/Expanded Traits.xml
+++ b/Mods/Core_SK/Defs/TraitDefs/Expanded Traits.xml
@@ -74,9 +74,6 @@
 			<li>SlowLearner</li>
 			<li>TooSmart</li>
 		</conflictingTraits>
-		<requiredWorkTags>
-			<li>Intellectual</li>
-		</requiredWorkTags>
 	</TraitDef>	
 
 	<TraitDef>
@@ -200,6 +197,9 @@
 			<li>Constitution</li>
 			<li>Dodging</li>
 		</conflictingTraits>
+		<requiredWorkTags>
+			<li>Violent</li>
+		</requiredWorkTags>
 	</TraitDef> 
 
 	<TraitDef>
@@ -240,6 +240,9 @@
 				<statOffsets>
 					<MentalBreakThreshold>-0.05</MentalBreakThreshold>
 				</statOffsets>
+				<allowedMeditationFocusTypes>
+					<li>Minimal</li>
+				</allowedMeditationFocusTypes>
 			</li>
 		</degreeDatas>
 		<conflictingTraits>
@@ -284,6 +287,9 @@
 			<li>Psychopath</li>
 			<li>Naive</li>
 		</conflictingTraits>
+		<requiredWorkTags>
+			<li>Violent</li>
+		</requiredWorkTags>
 	</TraitDef>
 
 	<TraitDef>
@@ -340,6 +346,9 @@
 			<li>Villian</li>
 			<li>Numb</li>
 		</conflictingTraits>
+		<requiredWorkTags>
+			<li>Social</li>
+		</requiredWorkTags>
 	</TraitDef>	
 
 	<TraitDef>
@@ -450,6 +459,9 @@
 			<li>Paranoid</li>
 			<li>Villian</li>
 		</conflictingTraits>
+		<requiredWorkTags>
+			<li>Social</li>
+		</requiredWorkTags>
 	</TraitDef>
 
 	<TraitDef>
@@ -589,6 +601,9 @@
 			<li>Brawler</li>
 			<li>PsychicSensitivity</li>
 		</conflictingTraits>
+		<requiredWorkTags>
+			<li>Social</li>
+		</requiredWorkTags>
 	</TraitDef>
 
 
@@ -645,6 +660,9 @@
 			<li>Introvert</li>
 			<li>Numb</li>
 		</conflictingTraits>
+		<requiredWorkTags>
+			<li>Social</li>
+		</requiredWorkTags>
 	</TraitDef>
 
 	<TraitDef>
@@ -687,6 +705,9 @@
 			<li>PsychicSensitivity</li>
 			<li>Nerves</li>
 		</conflictingTraits>
+		<requiredWorkTags>
+			<li>Social</li>
+		</requiredWorkTags>
 	</TraitDef>
 
 	<TraitDef>
@@ -706,7 +727,6 @@
 				<allowedMeditationFocusTypes>
 					<li>Morbid</li>
 				</allowedMeditationFocusTypes>
-
 			</li>
 		</degreeDatas>
 		<conflictingTraits>
@@ -761,7 +781,7 @@
 
 	<TraitDef>
 		<defName>Allergic</defName>
-		<commonality>0.2</commonality>
+		<commonality>0.25</commonality>
 		<degreeDatas>
 			<li>
 				<label>animal hater</label>
@@ -787,7 +807,7 @@
 
 	<TraitDef>
 		<defName>Photophobia</defName>
-		<commonality>0.2</commonality>
+		<commonality>0.3</commonality>
 		<degreeDatas>
 			<li>
 				<label>photophobic</label>

--- a/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
+++ b/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
@@ -3,7 +3,7 @@
 
 	<TraitDef>
 		<defName>Aesthete</defName>
-		<commonality>0.3</commonality>
+		<commonality>0.35</commonality>
 		<degreeDatas>
 			<li>
 				<label>aesthete</label>
@@ -23,7 +23,7 @@
 
 	<TraitDef>
 		<defName>Bipolar</defName>
-		<commonality>0.2</commonality>
+		<commonality>0.25</commonality>
 		<degreeDatas>
 			<li>
 				<label>bipolar</label>
@@ -38,7 +38,7 @@
 
 	<TraitDef>
 		<defName>BrownThumb</defName>
-		<commonality>0.85</commonality>
+		<commonality>0.75</commonality>
 		<degreeDatas>
 			<li>
 				<label>brown thumb</label>
@@ -75,6 +75,10 @@
 			<li>Aptitude</li>
 			<li>Rockhound</li>
 		</conflictingTraits>
+		<requiredWorkTypes>
+			<li>Growing</li>
+			<li>PlantCutting</li>
+		</requiredWorkTypes>
 	</TraitDef>
 
 	<TraitDef>
@@ -100,6 +104,7 @@
 		</degreeDatas>
 		<requiredWorkTags>
 			<li>Cooking</li>
+			<li>ManualSkilled</li>
 			<li>Violent</li>
 		</requiredWorkTags>
 		<conflictingTraits>
@@ -112,7 +117,7 @@
 
 	<TraitDef>
 		<defName>Chemist</defName>
-		<commonality>0.3</commonality>
+		<commonality>0.25</commonality>
 		<degreeDatas>
 			<li>
 				<label>chemist</label>
@@ -171,7 +176,7 @@
 
 	<TraitDef>
 		<defName>ColdLover</defName>
-		<commonality>0.4</commonality>
+		<commonality>0.45</commonality>
 		<degreeDatas>
 			<li>
 				<label>cold lover</label>
@@ -189,7 +194,7 @@
 
 	<TraitDef>
 		<defName>DeepSleeper</defName>
-		<commonality>0.4</commonality>
+		<commonality>0.45</commonality>
 		<degreeDatas>
 			<li>
 				<label>deep sleeper</label>
@@ -229,7 +234,7 @@
 
 	<TraitDef>
 		<defName>HeatLover</defName>
-		<commonality>0.5</commonality>
+		<commonality>0.55</commonality>
 		<degreeDatas>
 			<li>
 				<label>heat lover</label>
@@ -247,7 +252,7 @@
 
 	<TraitDef>
 		<defName>Aptitude</defName>
-		<commonality>0.65</commonality>
+		<commonality>0.55</commonality>
 		<degreeDatas>
 			<li>
 				<label>inept</label>
@@ -310,6 +315,10 @@
 			<li>Rockhound</li>
 			<li>Nimble</li>
 		</conflictingTraits>
+		<requiredWorkTags>
+			<li>Crafting</li>
+			<li>ManualSkilled</li>
+		</requiredWorkTags>
 	</TraitDef>
 
 	<TraitDef>
@@ -377,7 +386,7 @@
 
 	<TraitDef>
 		<defName>Eyesight</defName>
-		<commonality>0.45</commonality>
+		<commonality>0.4</commonality>
 		<degreeDatas>
 			<li>
 				<label>near-sighted</label>
@@ -444,7 +453,7 @@
 
 	<TraitDef>
 		<defName>EatingSpeed</defName>
-		<commonality>0.3</commonality>
+		<commonality>0.4</commonality>
 		<degreeDatas>
 			<li>
 				<label>nibbler</label>
@@ -467,7 +476,7 @@
 
 	<TraitDef>
 		<defName>Nyctophobe</defName>
-		<commonality>0.2</commonality>
+		<commonality>0.3</commonality>
 		<degreeDatas>
 			<li>
 				<label>nyctophobe</label>
@@ -757,7 +766,7 @@
 			<li>
 				<label>deadshot</label>
 				<description>{PAWN_nameDef} knows how to handle a firearm, and can shoot both quickly and accurately.</description>
-				<commonality>0.3</commonality>
+				<commonality>0.25</commonality>
 				<degree>2</degree>
 				<statOffsets>
 					<AimingDelayFactor>-0.5</AimingDelayFactor>

--- a/Mods/Core_SK/Patches/TraitDefs_Core_Patch.xml
+++ b/Mods/Core_SK/Patches/TraitDefs_Core_Patch.xml
@@ -461,4 +461,11 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/TraitDef[defName = "Tough"]/commonality</xpath>
+		<value>
+			<commonality>0.75</commonality>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
1 added missed required work tags and required work types to some traits (it could cause some strange situations when pawns had trait with cooking (for example) boost but couldn't cook (backstory restrictions and etc));
2 some commonality and meditation type param lite tweaks.

1 добавлены пропущенные теги и типы работ для некоторых черт характера (их отсутствие могло вызвать ситуации, когда, например, пешка получала черту характера с бонусом к готовке, но готовить не умела (запрет от предыстории, например));
2 некоторые небольшие правки частоты появления черт характера и разрешаемых типов медитации.