### PR TITLE
disabled work rebalancer mod by default (cuz some tps impact from WorkRebalancer.Patches.CompEggLayer_CompTick_Patch:CompTick)

### DIFF
--- a/ModsConfig.xml
+++ b/ModsConfig.xml
@@ -110,7 +110,6 @@
     <li>automatic.incidenttweaker</li>
     <li>chippedchap.blueprinttotalstooltip</li>
     <li>pirateby.ce.extendedloadout</li>
-    <li>pirateby.workrebalancer</li>
     <li>erdelf.moddercredit</li>
     <li>user19990313.runtimegc</li>
     <li>neronix17.wikirim</li>


### PR DESCRIPTION
disabled work rebalancer mod by default (cuz it has some tps impact from WorkRebalancer.Patches.CompEggLayer_CompTick_Patch:CompTick)

![image](https://user-images.githubusercontent.com/62516232/125664718-a03e2736-adac-48bb-9c4b-c5221ec643c8.png)

выключен мод work rebalancer по умолчанию (оказывает некоторое негативное воздействие на тпс из-за одного из патчей + используется в основном для тестов, обычному игроку он ни к чему)