### PR TITLE
Some infused tweaks and fixes

### DIFF
--- a/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
@@ -5076,7 +5076,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.6</multiplier>
+          <multiplier>1.75</multiplier>
         </value>
       </li>
     </stats>

--- a/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
@@ -18,7 +18,7 @@
       <li>
         <key>MarketValue</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
     </stats>
@@ -38,13 +38,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.45</offset>
+          <offset>0.3</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.15</offset>
+          <offset>0.1</offset>
         </value>
       </li>
       <li>
@@ -80,13 +80,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.15</offset>
+          <offset>0.1</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.45</offset>
+          <offset>0.3</offset>
         </value>
       </li>
       <li>
@@ -356,7 +356,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.02</multiplier>
+          <multiplier>1.01</multiplier>
         </value>
       </li>
       <li>
@@ -452,7 +452,7 @@
       <li>
         <key>MeleeHitChance</key>
         <value>
-          <multiplier>1.02</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
     </stats>
@@ -470,7 +470,7 @@
       <li>
         <key>MeleeWeapon_CooldownMultiplier</key>
         <value>
-          <multiplier>0.98</multiplier>
+          <multiplier>0.97</multiplier>
         </value>
       </li>
     </stats>
@@ -488,7 +488,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.10</multiplier>
+          <multiplier>1.1</multiplier>
         </value>
       </li>
     </stats>
@@ -665,13 +665,6 @@
           <multiplier>1.04</multiplier>
         </value>
       </li>
-      <!--      <li>
-      <key>MechanoidOperationSuccessChance</key>
-      <value>
-      <multiplier>1.04</multiplier>
-      </value>
-      </li>
-      -->
       <li>
         <key>WorkSpeedGlobal</key>
         <value>
@@ -746,7 +739,7 @@
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.975</multiplier>
+          <multiplier>.97</multiplier>
         </value>
       </li>
     </stats>
@@ -947,7 +940,7 @@
       <li>
         <key>MarketValue</key>
         <value>
-          <multiplier>1.30</multiplier>
+          <multiplier>1.15</multiplier>
         </value>
       </li>
     </stats>
@@ -966,13 +959,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.9</offset>
+          <offset>0.6</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.3</offset>
+          <offset>0.2</offset>
         </value>
       </li>
       <li>
@@ -1008,13 +1001,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.3</offset>
+          <offset>0.2</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.9</offset>
+          <offset>0.6</offset>
         </value>
       </li>
       <li>
@@ -1284,7 +1277,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.04</multiplier>
+          <multiplier>1.02</multiplier>
         </value>
       </li>
       <li>
@@ -1380,7 +1373,7 @@
       <li>
         <key>MeleeHitChance</key>
         <value>
-          <multiplier>1.04</multiplier>
+          <multiplier>1.1</multiplier>
         </value>
       </li>
     </stats>
@@ -1398,7 +1391,7 @@
       <li>
         <key>MeleeWeapon_CooldownMultiplier</key>
         <value>
-          <multiplier>0.96</multiplier>
+          <multiplier>0.95</multiplier>
         </value>
       </li>
     </stats>
@@ -1416,7 +1409,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.10</multiplier>
+          <multiplier>1.2</multiplier>
         </value>
       </li>
     </stats>
@@ -1440,7 +1433,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.10</multiplier>
+          <multiplier>1.1</multiplier>
         </value>
       </li>
       <li>
@@ -1536,7 +1529,7 @@
       <li>
         <key>MeleeWeapon_CooldownMultiplier</key>
         <value>
-          <multiplier>1.40</multiplier>
+          <multiplier>1.4</multiplier>
         </value>
       </li>
       <li>
@@ -1593,13 +1586,6 @@
           <multiplier>1.08</multiplier>
         </value>
       </li>
-      <!--      <li>
-      <key>MechanoidOperationSuccessChance</key>
-      <value>
-      <multiplier>1.04</multiplier>
-      </value>
-      </li>
-      -->
       <li>
         <key>WorkSpeedGlobal</key>
         <value>
@@ -1870,7 +1856,7 @@
       <li>
         <key>MarketValue</key>
         <value>
-          <multiplier>1.45</multiplier>
+          <multiplier>1.3</multiplier>
         </value>
       </li>
     </stats>
@@ -1889,13 +1875,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>1.35</offset>
+          <offset>0.9</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.45</offset>
+          <offset>0.3</offset>
         </value>
       </li>
       <li>
@@ -1931,13 +1917,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.45</offset>
+          <offset>0.3</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>1.35</offset>
+          <offset>0.9</offset>
         </value>
       </li>
       <li>
@@ -2207,7 +2193,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.06</multiplier>
+          <multiplier>1.03</multiplier>
         </value>
       </li>
       <li>
@@ -2303,7 +2289,7 @@
       <li>
         <key>MeleeHitChance</key>
         <value>
-          <multiplier>1.06</multiplier>
+          <multiplier>1.15</multiplier>
         </value>
       </li>
     </stats>
@@ -2339,7 +2325,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.3</multiplier>
         </value>
       </li>
     </stats>
@@ -2588,7 +2574,7 @@
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.90</multiplier>
+          <multiplier>.92</multiplier>
         </value>
       </li>
     </stats>
@@ -2607,13 +2593,13 @@
       <li>
         <key>HuntingStealth</key>
         <value>
-          <multiplier>1.4</multiplier>
+          <multiplier>1.3</multiplier>
         </value>
       </li>
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.04</multiplier>
+          <multiplier>1.03</multiplier>
         </value>
       </li>
     </stats>
@@ -2787,7 +2773,7 @@
       <li>
         <key>MarketValue</key>
         <value>
-          <multiplier>1.75</multiplier>
+          <multiplier>1.45</multiplier>
         </value>
       </li>
     </stats>
@@ -2806,13 +2792,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>2.25</offset>
+          <offset>1.5</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.75</offset>
+          <offset>0.5</offset>
         </value>
       </li>
       <li>
@@ -2842,13 +2828,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.75</offset>
+          <offset>0.5</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>2.25</offset>
+          <offset>1.5</offset>
         </value>
       </li>
       <li>
@@ -3052,7 +3038,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.10</multiplier>
+          <multiplier>1.08</multiplier>
         </value>
       </li>
     </stats>
@@ -3112,7 +3098,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.10</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
       <li>
@@ -3184,7 +3170,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.05</multiplier>
+          <multiplier>1.04</multiplier>
         </value>
       </li>
       <li>
@@ -3208,7 +3194,7 @@
       <li>
         <key>MeleeHitChance</key>
         <value>
-          <multiplier>1.10</multiplier>
+          <multiplier>1.2</multiplier>
         </value>
       </li>
     </stats>
@@ -3244,7 +3230,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.5</multiplier>
+          <multiplier>1.4</multiplier>
         </value>
       </li>
     </stats>
@@ -3268,7 +3254,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.2</multiplier>
         </value>
       </li>
       <li>
@@ -3292,7 +3278,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.2</multiplier>
         </value>
       </li>
       <li>
@@ -3474,13 +3460,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>.95</multiplier>
+          <multiplier>.975</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.95</multiplier>
+          <multiplier>.975</multiplier>
         </value>
       </li>
     </stats>
@@ -3499,7 +3485,7 @@
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.80</multiplier>
+          <multiplier>.88</multiplier>
         </value>
       </li>
     </stats>
@@ -3518,13 +3504,13 @@
       <li>
         <key>HuntingStealth</key>
         <value>
-          <multiplier>1.6</multiplier>
+          <multiplier>1.4</multiplier>
         </value>
       </li>
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.08</multiplier>
+          <multiplier>1.04</multiplier>
         </value>
       </li>
     </stats>
@@ -3598,13 +3584,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>.90</multiplier>
+          <multiplier>0.95</multiplier>
         </value>
       </li>
       <li>
         <key>WorkSpeedGlobal</key>
         <value>
-          <multiplier>.90</multiplier>
+          <multiplier>0.9</multiplier>
         </value>
       </li>
       <li>
@@ -3665,13 +3651,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>.93</multiplier>
+          <multiplier>.94</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.93</multiplier>
+          <multiplier>.94</multiplier>
         </value>
       </li>
     </stats>
@@ -3692,7 +3678,7 @@
       <li>
         <key>MarketValue</key>
         <value>
-          <multiplier>2.0</multiplier>
+          <multiplier>1.75</multiplier>
         </value>
       </li>
     </stats>
@@ -3711,13 +3697,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>3.75</offset>
+          <offset>2.5</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>1.2</offset>
+          <offset>0.8</offset>
         </value>
       </li>
       <li>
@@ -3747,13 +3733,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>1.2</offset>
+          <offset>0.8</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>3.75</offset>
+          <offset>2.5</offset>
         </value>
       </li>
       <li>
@@ -3957,7 +3943,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.1</multiplier>
         </value>
       </li>
     </stats>
@@ -4017,7 +4003,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.07</multiplier>
         </value>
       </li>
       <li>
@@ -4089,7 +4075,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.07</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
       <li>
@@ -4113,7 +4099,7 @@
       <li>
         <key>MeleeHitChance</key>
         <value>
-          <multiplier>1.20</multiplier>
+          <multiplier>1.25</multiplier>
         </value>
       </li>
     </stats>
@@ -4197,19 +4183,19 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.5</multiplier>
+          <multiplier>1.25</multiplier>
         </value>
       </li>
       <li>
         <key>ButcheryFleshEfficiency</key>
         <value>
-          <multiplier>1.10</multiplier>
+          <multiplier>1.1</multiplier>
         </value>
       </li>
       <li>
         <key>ButcheryFleshSpeed</key>
         <value>
-          <multiplier>1.20</multiplier>
+          <multiplier>1.2</multiplier>
         </value>
       </li>
       <li>
@@ -4379,13 +4365,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>.90</multiplier>
+          <multiplier>.95</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.90</multiplier>
+          <multiplier>.95</multiplier>
         </value>
       </li>
     </stats>
@@ -4404,7 +4390,7 @@
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.70</multiplier>
+          <multiplier>.84</multiplier>
         </value>
       </li>
     </stats>
@@ -4423,13 +4409,13 @@
       <li>
         <key>HuntingStealth</key>
         <value>
-          <multiplier>1.8</multiplier>
+          <multiplier>1.5</multiplier>
         </value>
       </li>
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.12</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
     </stats>
@@ -4503,13 +4489,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>.85</multiplier>
+          <multiplier>0.9</multiplier>
         </value>
       </li>
       <li>
         <key>WorkSpeedGlobal</key>
         <value>
-          <multiplier>.85</multiplier>
+          <multiplier>0.85</multiplier>
         </value>
       </li>
       <li>
@@ -4570,13 +4556,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>.90</multiplier>
+          <multiplier>.91</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.90</multiplier>
+          <multiplier>.91</multiplier>
         </value>
       </li>
     </stats>
@@ -4597,7 +4583,7 @@
       <li>
         <key>MarketValue</key>
         <value>
-          <multiplier>2.5</multiplier>
+          <multiplier>2</multiplier>
         </value>
       </li>
     </stats>
@@ -4616,13 +4602,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>6</offset>
+          <offset>4</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>1.8</offset>
+          <offset>1.2</offset>
         </value>
       </li>
       <li>
@@ -4652,13 +4638,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>1.8</offset>
+          <offset>1.2</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>6</offset>
+          <offset>4</offset>
         </value>
       </li>
       <li>
@@ -4862,7 +4848,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.12</multiplier>
         </value>
       </li>
     </stats>
@@ -4880,7 +4866,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.3</multiplier>
+          <multiplier>1.12</multiplier>
         </value>
       </li>
     </stats>
@@ -4898,7 +4884,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.45</multiplier>
+          <multiplier>1.15</multiplier>
         </value>
       </li>
     </stats>
@@ -4976,7 +4962,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.25</multiplier>
+          <multiplier>1.1</multiplier>
         </value>
       </li>
       <li>
@@ -5048,7 +5034,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.12</multiplier>
+          <multiplier>1.07</multiplier>
         </value>
       </li>
       <li>
@@ -5090,7 +5076,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>2.5</multiplier>
+          <multiplier>1.6</multiplier>
         </value>
       </li>
     </stats>
@@ -5114,13 +5100,13 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.25</multiplier>
+          <multiplier>1.3</multiplier>
         </value>
       </li>
       <li>
         <key>MeleeWeapon_CooldownMultiplier</key>
         <value>
-          <multiplier>0.84</multiplier>
+          <multiplier>0.9</multiplier>
         </value>
       </li>
     </stats>
@@ -5138,7 +5124,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.25</multiplier>
+          <multiplier>1.3</multiplier>
         </value>
       </li>
       <li>
@@ -5261,13 +5247,6 @@
           <multiplier>1.50</multiplier>
         </value>
       </li>
-      <!--      <li>
-      <key>MechanoidOperationSuccessChance</key>
-      <value>
-      <multiplier>1.04</multiplier>
-      </value>
-      </li>
-      -->
       <li>
         <key>WorkSpeedGlobal</key>
         <value>
@@ -5314,13 +5293,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>.85</multiplier>
+          <multiplier>0.9</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.85</multiplier>
+          <multiplier>0.9</multiplier>
         </value>
       </li>
     </stats>
@@ -5339,7 +5318,7 @@
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.50</multiplier>
+          <multiplier>.78</multiplier>
         </value>
       </li>
     </stats>
@@ -5358,13 +5337,13 @@
       <li>
         <key>HuntingStealth</key>
         <value>
-          <multiplier>2.0</multiplier>
+          <multiplier>1.6</multiplier>
         </value>
       </li>
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.20</multiplier>
+          <multiplier>1.06</multiplier>
         </value>
       </li>
     </stats>
@@ -5438,13 +5417,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>.75</multiplier>
+          <multiplier>0.85</multiplier>
         </value>
       </li>
       <li>
         <key>WorkSpeedGlobal</key>
         <value>
-          <multiplier>.75</multiplier>
+          <multiplier>0.75</multiplier>
         </value>
       </li>
       <li>
@@ -5505,13 +5484,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>.75</multiplier>
+          <multiplier>.88</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>.75</multiplier>
+          <multiplier>.88</multiplier>
         </value>
       </li>
     </stats>

--- a/Mods/Infused_SK/Defs/InfusionDefs/MedievalAmplified.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/MedievalAmplified.xml
@@ -51,7 +51,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.05</multiplier>
+          <multiplier>1.03</multiplier>
         </value>
       </li>
     </stats>
@@ -94,7 +94,7 @@
       <li>
         <key>HuntingStealth</key>
         <value>
-          <multiplier>2.0</multiplier>
+          <multiplier>2</multiplier>
         </value>
       </li>
     </stats>
@@ -130,13 +130,13 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.45</offset>
+          <offset>0.3</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.45</offset>
+          <offset>0.3</offset>
         </value>
       </li>
     </stats>
@@ -243,7 +243,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.10</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
     </stats>
@@ -297,13 +297,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.75</offset>
+          <offset>0.5</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.75</offset>
+          <offset>0.5</offset>
         </value>
       </li>
     </stats>
@@ -453,7 +453,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.07</multiplier>
         </value>
       </li>
     </stats>
@@ -549,13 +549,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>1.15</offset>
+          <offset>0.8</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>1.15</offset>
+          <offset>0.8</offset>
         </value>
       </li>
     </stats>
@@ -687,7 +687,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.09</multiplier>
         </value>
       </li>
     </stats>
@@ -712,7 +712,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.20</multiplier>
+          <multiplier>1.2</multiplier>
         </value>
       </li>
     </stats>
@@ -749,7 +749,7 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>0.82</multiplier>
+          <multiplier>0.85</multiplier>
         </value>
       </li>
     </stats>
@@ -815,13 +815,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>1.8</offset>
+          <offset>1.2</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>1.8</offset>
+          <offset>1.2</offset>
         </value>
       </li>
     </stats>
@@ -863,7 +863,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.1</multiplier>
         </value>
       </li>
     </stats>
@@ -905,13 +905,13 @@
       <li>
         <key>MeleeHitChance</key>
         <value>
-          <multiplier>1.18</multiplier>
+          <multiplier>1.15</multiplier>
         </value>
       </li>
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>2.5</multiplier>
+          <multiplier>1.5</multiplier>
         </value>
       </li>
     </stats>
@@ -948,7 +948,7 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>0.76</multiplier>
+          <multiplier>0.8</multiplier>
         </value>
       </li>
     </stats>
@@ -1056,13 +1056,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>3.75</offset>
+          <offset>2.5</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>3.75</offset>
+          <offset>2.5</offset>
         </value>
       </li>
     </stats>
@@ -1116,7 +1116,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.1</multiplier>
         </value>
       </li>
     </stats>
@@ -1141,7 +1141,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.25</multiplier>
+          <multiplier>1.3</multiplier>
         </value>
       </li>
     </stats>
@@ -1184,7 +1184,7 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>0.7</multiplier>
+          <multiplier>0.75</multiplier>
         </value>
       </li>
     </stats>
@@ -1202,13 +1202,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>4.95</offset>
+          <offset>3.3</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>4.95</offset>
+          <offset>3.3</offset>
         </value>
       </li>
     </stats>

--- a/Mods/Infused_SK/Defs/InfusionDefs/MedievalEnchanted.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/MedievalEnchanted.xml
@@ -195,7 +195,7 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.45</offset>
+          <offset>0.3</offset>
         </value>
       </li>
     </stats>
@@ -213,7 +213,7 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.45</offset>
+          <offset>0.3</offset>
         </value>
       </li>
     </stats>
@@ -249,13 +249,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.75</offset>
+          <offset>0.5</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.75</offset>
+          <offset>0.5</offset>
         </value>
       </li>
     </stats>
@@ -275,7 +275,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.03</multiplier>
+          <multiplier>1.02</multiplier>
         </value>
       </li>
       <li>
@@ -391,7 +391,7 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>1.05</offset>
+          <offset>0.7</offset>
         </value>
       </li>
     </stats>
@@ -409,7 +409,7 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>1.05</offset>
+          <offset>0.7</offset>
         </value>
       </li>
     </stats>
@@ -459,7 +459,7 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>0.95</multiplier>
+          <multiplier>0.97</multiplier>
         </value>
       </li>
     </stats>
@@ -716,13 +716,13 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>0.9</multiplier>
+          <multiplier>0.94</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>0.93</multiplier>
+          <multiplier>0.94</multiplier>
         </value>
       </li>
       <li>
@@ -1075,7 +1075,7 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>1.5</offset>
+          <offset>1</offset>
         </value>
       </li>
     </stats>
@@ -1093,7 +1093,7 @@
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>1.5</offset>
+          <offset>1</offset>
         </value>
       </li>
     </stats>
@@ -1111,13 +1111,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>1.05</offset>
+          <offset>0.7</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>1.05</offset>
+          <offset>0.7</offset>
         </value>
       </li>
     </stats>
@@ -1287,19 +1287,19 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
       <li>
         <key>MeleeWeapon_CooldownMultiplier</key>
         <value>
-          <multiplier>0.82</multiplier>
+          <multiplier>0.9</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>0.82</multiplier>
+          <multiplier>0.9</multiplier>
         </value>
       </li>
     </stats>
@@ -1317,13 +1317,13 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>0.82</multiplier>
+          <multiplier>0.88</multiplier>
         </value>
       </li>
     </stats>
@@ -1341,7 +1341,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
       <li>
@@ -1362,7 +1362,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.07</multiplier>
         </value>
       </li>
     </stats>
@@ -1569,13 +1569,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>1.8</offset>
+          <offset>1.2</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>1.8</offset>
+          <offset>1.2</offset>
         </value>
       </li>
     </stats>
@@ -1678,7 +1678,7 @@
       <li>
         <key>MeleeWeapon_DamageMultiplier</key>
         <value>
-          <multiplier>1.20</multiplier>
+          <multiplier>1.2</multiplier>
         </value>
       </li>
     </stats>
@@ -1697,7 +1697,7 @@
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>0.67</multiplier>
+          <multiplier>0.85</multiplier>
         </value>
       </li>
     </stats>
@@ -1727,7 +1727,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.07</multiplier>
         </value>
       </li>
     </stats>
@@ -1745,13 +1745,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>3.75</offset>
+          <offset>2.5</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>3.75</offset>
+          <offset>2.5</offset>
         </value>
       </li>
     </stats>
@@ -1769,13 +1769,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>0.18</offset>
+          <offset>1.8</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>0.18</offset>
+          <offset>1.8</offset>
         </value>
       </li>
       <li>
@@ -1800,7 +1800,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.07</multiplier>
         </value>
       </li>
       <li>
@@ -1831,19 +1831,19 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.07</multiplier>
         </value>
       </li>
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>0.82</multiplier>
+          <multiplier>0.9</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>0.82</multiplier>
+          <multiplier>0.9</multiplier>
         </value>
       </li>
     </stats>
@@ -1951,13 +1951,13 @@
       <li>
         <key>ArmorRating_Sharp</key>
         <value>
-          <offset>4.95</offset>
+          <offset>3.3</offset>
         </value>
       </li>
       <li>
         <key>ArmorRating_Blunt</key>
         <value>
-          <offset>4.95</offset>
+          <offset>3.3</offset>
         </value>
       </li>
       <li>
@@ -1969,7 +1969,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
     </stats>
@@ -1988,7 +1988,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.07</multiplier>
         </value>
       </li>
       <li>
@@ -2025,19 +2025,19 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.1</multiplier>
+          <multiplier>1.05</multiplier>
         </value>
       </li>
       <li>
         <key>AimingDelayFactor</key>
         <value>
-          <multiplier>0.6</multiplier>
+          <multiplier>0.88</multiplier>
         </value>
       </li>
       <li>
         <key>RangedWeapon_Cooldown</key>
         <value>
-          <multiplier>0.82</multiplier>
+          <multiplier>0.88</multiplier>
         </value>
       </li>
       <li>
@@ -2079,7 +2079,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.15</multiplier>
+          <multiplier>1.12</multiplier>
         </value>
       </li>
     </stats>
@@ -2097,7 +2097,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.3</multiplier>
+          <multiplier>1.12</multiplier>
         </value>
       </li>
     </stats>
@@ -2115,7 +2115,7 @@
       <li>
         <key>MoveSpeed</key>
         <value>
-          <multiplier>1.45</multiplier>
+          <multiplier>1.15</multiplier>
         </value>
       </li>
     </stats>


### PR DESCRIPTION
1 decreased market value modifier of industrial infuses (~33%);
2 some infuses tweaks (mainly decreased bonuses to move speed, aiming delay, weapon cooldown and armor rating params. Also corrected some infuses with very high or low values).

1 уменьшен множитель стоимости для индустриальных модификаций (на ~33%);
2 некоторые корректировки модификаций (в основном были ослаблены бонусы на скорость бега, время прицеливания, время между атаками и рейтингом брони. Также скорректированы некоторые модификации ну прямо с очень высокими и низкими значениями).