### PR TITLE
Some tank cannons and centipedes tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/120mmCannon.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/120mmCannon.xml
@@ -121,16 +121,16 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>330</damageAmountBase>
+			<damageAmountBase>480</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>600</armorPenetrationSharp>
-			<armorPenetrationBlunt>50.005</armorPenetrationBlunt>
+			<armorPenetrationBlunt>60</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>205</damageAmountBase>
+				<damageAmountBase>175</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveRadius>3.0</explosiveRadius>
+				<explosiveRadius>1.8</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -153,7 +153,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>270</damageAmountBase>
-			<explosionRadius>2.8</explosionRadius>
+			<explosionRadius>3.8</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
@@ -161,8 +161,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>37</Fragment_Large>
-					<Fragment_Small>55</Fragment_Small>
+					<Fragment_Large>55</Fragment_Large>
+					<Fragment_Small>37</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/90mmCannon.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/90mmCannon.xml
@@ -119,16 +119,16 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bullet</damageDef>
-			<damageAmountBase>258</damageAmountBase>
+			<damageAmountBase>405</damageAmountBase>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<armorPenetrationSharp>500</armorPenetrationSharp>
-			<armorPenetrationBlunt>38.005</armorPenetrationBlunt>
+			<armorPenetrationBlunt>50</armorPenetrationBlunt>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_ExplosiveCE">
-				<damageAmountBase>140</damageAmountBase>
+				<damageAmountBase>130</damageAmountBase>
 				<explosiveDamageType>Bomb</explosiveDamageType>
-				<explosiveRadius>2.8</explosiveRadius>
+				<explosiveRadius>1.3</explosiveRadius>
 				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			</li>
 			<li Class="CombatExtended.CompProperties_Fragments">
@@ -151,7 +151,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Bomb</damageDef>
 			<damageAmountBase>200</damageAmountBase>
-			<explosionRadius>2.4</explosionRadius>
+			<explosionRadius>3.3</explosionRadius>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<ai_IsIncendiary>true</ai_IsIncendiary>
@@ -159,8 +159,8 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Large>35</Fragment_Large>
-					<Fragment_Small>55</Fragment_Small>
+					<Fragment_Large>49</Fragment_Large>
+					<Fragment_Small>35</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Mods/Core_SK/Patches/Bodies/Bodies_Mechanoid/AdjustCentipedeRingsCoverage.xml
+++ b/Mods/Core_SK/Patches/Bodies/Bodies_Mechanoid/AdjustCentipedeRingsCoverage.xml
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/coverage</xpath>
+    <value>
+      <coverage>0.5</coverage>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/BodyDef[defName = "MechanicalCentipede"]/corePart/parts/li[def="MechanicalCentipedeBodySecondRing"]/parts/li[def = "MechanicalCentipedeBodyThirdRing"]/parts/li[def = "MechanicalCentipedeBodyFourthRing"]/parts/li[def = "MechanicalCentipedeBodyFifthRing"]/parts/li[def = "MechanicalCentipedeBodySixthRing"]/coverage</xpath>
+    <value>
+      <coverage>0.4</coverage>
+    </value>
+  </Operation>
+
+</Patch>


### PR DESCRIPTION
1 sligtly corrected centipeded coverages of fifth and sixth rings (the value was very high, which made the Sentipeda's butt more likely to hit than its front);
2 corrected 90 and 120 mm tank shells param. HE and HEAT ammo had non-correct params (HEAT had more explosive radius than HE and non-high direct hit damage, which contradicts its description. HE just had a low explosive radius and small amount of large fragments. Fixed).

1 немного скорректирована степень покрытия пятого и шестого колец гусеницы (сентипеды) (значения были немного завышенными и вероятность попасть по заду сентипеды была выше, чем по её переду);
2 скорректированы параметры 90 и 120 мм танковых снарядов. HE и HEAT имели некорректные параметры (у HEAT радиус взрыва больше, чем у HE, а урон при прямом попадании невысок, что противоречит его описанию. У HE просто низкий радиус взрыва и мало крупных осколков. Поправлено).