### PR TITLE
Some light tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets.xml
@@ -1,7 +1,6 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-
 	<ThingDef Name="BaseTurretGun" ParentName="SK_BaseGun" Abstract="True">
 		<soundInteract>Interact_Rifle</soundInteract>
 		<weaponTags>
@@ -12,7 +11,7 @@
 		<tradeability>None</tradeability>
 		<destroyOnDrop>True</destroyOnDrop>
 		<menuHidden>True</menuHidden>
-
+		<generateAllowChance>0</generateAllowChance>
 	</ThingDef>
 
 	<ThingDef ParentName="BaseTurretGun" Name="BaseGun_Turret" Abstract="True">
@@ -31,7 +30,6 @@
 			</li>
 		</comps>
 	</ThingDef>
-
 
 	<ThingDef Name="BaseArtilleryGun" Abstract="True">
 		<category>Item</category>

--- a/Mods/HMC weapon pack – USSR/Defs/ThingDefs_Weapons/Weapons_Shotguns.xml
+++ b/Mods/HMC weapon pack – USSR/Defs/ThingDefs_Weapons/Weapons_Shotguns.xml
@@ -53,10 +53,15 @@
             <li Class="CombatExtended.CompProperties_AmmoUser">
                 <magazineSize>2</magazineSize>
 				<reloadOneAtATime>true</reloadOneAtATime>
-                <reloadTime>1.1</reloadTime>
+                <reloadTime>1.25</reloadTime>
                 <ammoSet>AmmoSet_12Gauge</ammoSet>
             </li>
         </comps>
+	<modExtensions>
+		<li Class="CombatExtended.GunDrawExtension">
+			<DrawSize>1.25</DrawSize>
+		</li>
+	</modExtensions>
         <smeltProducts>
             <Shotgun_Component>1</Shotgun_Component>
             <Weapon_Parts>1</Weapon_Parts>


### PR DESCRIPTION
1 removed any chances to spawn pawn with turret's gun (pawns from other race mod (Revia race for example));
2 increased Toz-34 draw size (~25%) and reload time from 1.1 to 1.25 sec.

1 убрана возможность спавна пешек с орудиями от турелей (такое встречалось с пешками из других модов (например, Revia Race));
2 увеличены визуальные размеры дедушкиного ружья (на ~25%) и время перезарядки с 1.1 до 1.25 сек.