### PR TITLE
Small fix M60E4 draw size (got wrong the length and width multiplier params)

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
@@ -471,7 +471,7 @@
         </comps>
 	<modExtensions>
 	    <li Class="CombatExtended.GunDrawExtension">
-		<DrawSize>1.1,1.2</DrawSize>
+		<DrawSize>1.2,1.1</DrawSize>
 	    </li>
 	</modExtensions>
         <smeltProducts>


### PR DESCRIPTION
Немного поправил отрисовку M60E4 (перепутал множители длины и ширины местами).