### PR TITLE
Tzar canon and 200-pounder fix

### DIFF
--- a/Mods/HMC Vile's Pre-Industrial/Defs/ThingDefs_Weapons/Ammo/TurretAmmo/200Pounder.xml
+++ b/Mods/HMC Vile's Pre-Industrial/Defs/ThingDefs_Weapons/Ammo/TurretAmmo/200Pounder.xml
@@ -110,7 +110,7 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>50</speed>
+			<speed>65</speed>
 			<soundExplode>MortarBomb_Explode</soundExplode>
 			<flyOverhead>true</flyOverhead>
 			<dropsCasings>true</dropsCasings>

--- a/Mods/HMC Vile's Pre-Industrial/Defs/ThingDefs_Weapons/Ammo/TurretAmmo/TsarGrapeshot.xml
+++ b/Mods/HMC Vile's Pre-Industrial/Defs/ThingDefs_Weapons/Ammo/TurretAmmo/TsarGrapeshot.xml
@@ -27,11 +27,11 @@
 			<shaderType>TransparentPostLight</shaderType>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<speed>60</speed>
+			<speed>80</speed>
 			<soundExplode>Explosion</soundExplode>
 			<flyOverhead>true</flyOverhead>
 			<dropsCasings>false</dropsCasings>
-			<gravityFactor>20</gravityFactor>
+			<gravityFactor>16</gravityFactor>
 			<pelletCount>16</pelletCount>
 			<spreadMult>110</spreadMult>
 			


### PR DESCRIPTION
Projectiles now can reach canons' maximum range instead of landing halfway through