### PR TITLE
Replaced spacer components to ultra one for all spaceship parts

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Ship.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Ship.xml
@@ -63,7 +63,7 @@
 		<costList>
 			<BiosyntheticMaterial>15</BiosyntheticMaterial>
 			<MagneticMaterial>15</MagneticMaterial>
-			<ComponentSpacer>15</ComponentSpacer>
+			<ComponentUltra>15</ComponentUltra>
 			<AdvMechanism>5</AdvMechanism>
 		</costList>
 		<building>
@@ -131,7 +131,7 @@
 		<costList>
 			<Glass>25</Glass>
 			<BiosyntheticMaterial>20</BiosyntheticMaterial>
-			<ComponentSpacer>8</ComponentSpacer>
+			<ComponentUltra>8</ComponentUltra>
 			<Microchips>2</Microchips>
 		</costList>
 		<constructionSkillPrerequisite>16</constructionSkillPrerequisite>
@@ -176,7 +176,7 @@
 		<costStuffCount>50</costStuffCount>
 		<costList>
 			<MagneticMaterial>20</MagneticMaterial>
-			<ComponentSpacer>7</ComponentSpacer>
+			<ComponentUltra>7</ComponentUltra>
 			<BioMicrochips>2</BioMicrochips>
 			<AIPersonaCore>1</AIPersonaCore>
 		</costList>
@@ -224,7 +224,7 @@
 		<costList>
 			<MagneticMaterial>30</MagneticMaterial>
 			<BiosyntheticMaterial>20</BiosyntheticMaterial>
-			<ComponentSpacer>6</ComponentSpacer>
+			<ComponentUltra>6</ComponentUltra>
 			<AdvMechanism>8</AdvMechanism>
 			<Microchips>5</Microchips>
 		</costList>
@@ -284,7 +284,7 @@
 		<costStuffCount>100</costStuffCount>
 		<costList>
 			<MagneticMaterial>20</MagneticMaterial>
-			<ComponentSpacer>8</ComponentSpacer>
+			<ComponentUltra>8</ComponentUltra>
 			<BiosyntheticMaterial>15</BiosyntheticMaterial>
 			<AdvMechanism>15</AdvMechanism>
 		</costList>
@@ -325,7 +325,7 @@
 		</comps>
 		<costList>
 			<MagneticMaterial>15</MagneticMaterial>
-			<ComponentSpacer>6</ComponentSpacer>
+			<ComponentUltra>6</ComponentUltra>
 			<Microchips>4</Microchips>
 		</costList>
 		<designationHotKey>Misc5</designationHotKey>


### PR DESCRIPTION
Cuz all spaceship parts requires ultra component research but all parts uses only spacer components to build (old research tree legacy):

![image](https://user-images.githubusercontent.com/62516232/129075513-15780e9a-2f92-411b-85e0-34886a26f9d1.png)

Постройка всех деталей космического корабля теперь требует ультра компоненты вместо высокотехнологичных.
Связано с тем, что для постройки частей корабля требуется исследование ультра компонентов, но в самом корабле они почему-то не используются (наследие пред. дерева исследований).