### PR TITLE
Fixed arm's prosthesis armor penetration (very low value)

### DIFF
--- a/Mods/Core_SK/Defs/BodyParts/BodyParts_Basic.xml
+++ b/Mods/Core_SK/Defs/BodyParts/BodyParts_Basic.xml
@@ -215,8 +215,8 @@
 						</capacities>
 						<power>10</power>
 						<cooldownTime>1.3</cooldownTime>
-						<armorPenetrationBlunt>0.45</armorPenetrationBlunt>
-						<armorPenetrationSharp>0.25</armorPenetrationSharp>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
+						<armorPenetrationSharp>2</armorPenetrationSharp>
 					</li>
 				</tools>
 			</li>

--- a/Mods/Core_SK/Defs/BodyParts/BodyParts_Bionic.xml
+++ b/Mods/Core_SK/Defs/BodyParts/BodyParts_Bionic.xml
@@ -728,7 +728,7 @@
 						</capacities>
 						<power>14</power>
 						<cooldownTime>1.4</cooldownTime>
-						<armorPenetrationBlunt>1.688</armorPenetrationBlunt>
+						<armorPenetrationBlunt>6</armorPenetrationBlunt>
 						<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
 						<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
 					</li>
@@ -957,8 +957,8 @@
 						</capacities>
 						<power>18</power>
 						<cooldownTime>1.5</cooldownTime>
-						<armorPenetrationSharp>0.8</armorPenetrationSharp>
-						<armorPenetrationBlunt>4</armorPenetrationBlunt>
+						<armorPenetrationSharp>6</armorPenetrationSharp>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
 						<linkedBodyPartsGroup>Blade</linkedBodyPartsGroup>
 						<soundMeleeHit>Pawn_Melee_PowerClaw_Hit</soundMeleeHit>
 						<soundMeleeMiss>Pawn_Melee_PowerClaw_Miss</soundMeleeMiss>

--- a/Mods/Core_SK/Defs/BodyParts/BodyParts_Cybernetic.xml
+++ b/Mods/Core_SK/Defs/BodyParts/BodyParts_Cybernetic.xml
@@ -327,7 +327,7 @@
 						</capacities>
 						<power>18</power>
 						<cooldownTime>1.35</cooldownTime>
-						<armorPenetrationBlunt>1.988</armorPenetrationBlunt>
+						<armorPenetrationBlunt>10</armorPenetrationBlunt>
 						<soundMeleeHit>MeleeHit_BionicPunch</soundMeleeHit>
 						<soundMeleeMiss>MeleeMiss_BionicPunch</soundMeleeMiss>
 					</li>

--- a/Mods/Core_SK/Defs/BodyParts/BodyParts_Simple.xml
+++ b/Mods/Core_SK/Defs/BodyParts/BodyParts_Simple.xml
@@ -564,9 +564,9 @@
 						<capacities>
 							<li>Blunt</li>
 						</capacities>
-						<power>9</power>
+						<power>7</power>
 						<cooldownTime>1.65</cooldownTime>
-						<armorPenetrationBlunt>0.550</armorPenetrationBlunt>
+						<armorPenetrationBlunt>1</armorPenetrationBlunt>
 					</li>
 				</tools>
 			</li>


### PR DESCRIPTION
Исправлено бронепробитие протезов рук. Были слишком низкие значения.