### PR TITLE
Fixed commode of death bug.

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture_Beds.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Furniture_Beds.xml
@@ -28,7 +28,7 @@
 					<!--				<li>ClutterLockerA</li> -->
 					<li>JournalTable</li>
 					<li>HolographicCell</li>
-					<li>Commode</li>
+					<!--<li>Commode</li>--> <!--Dont forget to enable CompProperties_Facility in Commode def, if you want enable it again-->
 					<!--					<li>Storage_Locker</li>-->
 					<li>medieval_surg_washpan</li>  
 					<li>medieval_surg_instruments</li>


### PR DESCRIPTION
Commode has been removed from bed linkable facilities since it does not have any buffs to bed properties.
And now it cannot break your game interface.

[RUS}
Комод исключён из списка построек, влияющих на кровати.
Ранее у него уже удалены бафы на кровать и теперь он только ломает игру.
Долой безнаказанность комодов.