### PR TITLE
Some night vision and fish tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/BodyParts/BodyParts_Bionic.xml
+++ b/Mods/Core_SK/Defs/BodyParts/BodyParts_Bionic.xml
@@ -596,6 +596,7 @@
 		</graphicData>
 		<statBases>
 			<Mass>0.3</Mass>
+			<NightVisionEfficiency_Implant>0.3</NightVisionEfficiency_Implant>
 		</statBases>
 		<costList>
 			<Biomatter>20</Biomatter>
@@ -629,6 +630,13 @@
 			<partEfficiency>1.2</partEfficiency>
 			<betterThanNatural>true</betterThanNatural>
 		</addedPartProps>
+		<stages>
+			<li>
+				<statOffsets>
+					<NightVisionEfficiency_Implant>0.3</NightVisionEfficiency_Implant>
+				</statOffsets>
+			</li>
+		</stages>
 	</HediffDef>
 
 	<RecipeDef ParentName="SK_SurgeryFlesh">

--- a/Mods/Core_SK/Defs/BodyParts/BodyParts_Cybernetic.xml
+++ b/Mods/Core_SK/Defs/BodyParts/BodyParts_Cybernetic.xml
@@ -178,6 +178,7 @@
 			<MarketValue>3600</MarketValue>
 			<Mass>0.3</Mass>
 			<MaxHitPoints>60</MaxHitPoints>
+			<NightVisionEfficiency_Implant>0.5</NightVisionEfficiency_Implant>
 		</statBases>
 		<costList>
 			<ComponentUltra>2</ComponentUltra>
@@ -207,6 +208,9 @@
 		</addedPartProps>
 		<stages>
 			<li>
+				<statOffsets>
+					<NightVisionEfficiency_Implant>0.5</NightVisionEfficiency_Implant>
+				</statOffsets>
 				<capMods>
 					<li>
 						<capacity>Sight</capacity>

--- a/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Races_Animal_Fish.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_FishIndustry/Races_Animal_Fish.xml
@@ -4,6 +4,7 @@
 	<ThingDef ParentName="BaseAnimalPawn" Name="FishThingBase" Abstract="True">
 		<statBases>
 			<LeatherAmount>25</LeatherAmount>
+			<MeatAmount>70</MeatAmount>
 		</statBases>
 		<race>
 			<thinkTreeMain>Animal</thinkTreeMain>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Exotic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Exotic.xml
@@ -22,6 +22,7 @@
 			<GermResistance>0.45</GermResistance>
 			<GermContainment>0.15</GermContainment>
 			<FilthRate>26</FilthRate>
+			<NightVisionEfficiency>0.6</NightVisionEfficiency>
 		</statBases>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">
@@ -262,6 +263,7 @@
 			<GermResistance>0.3</GermResistance>
 			<GermContainment>0.2</GermContainment>
 			<FilthRate>24</FilthRate>
+			<NightVisionEfficiency>0.5</NightVisionEfficiency>
 		</statBases>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">
@@ -498,6 +500,7 @@
 			<GermResistance>1.0</GermResistance>
 			<GermContainment>1.0</GermContainment>
 			<FilthRate>28</FilthRate>
+			<NightVisionEfficiency>1</NightVisionEfficiency>
 		</statBases>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">
@@ -717,6 +720,7 @@
 			<GermResistance>0.33</GermResistance>
 			<GermContainment>0.2</GermContainment>
 			<FilthRate>25</FilthRate>
+			<NightVisionEfficiency>0.6</NightVisionEfficiency>
 		</statBases>
 		<verbs>
 			<li Class="CombatExtended.VerbPropertiesCE">
@@ -1272,6 +1276,7 @@
 			<GermResistance>0.75</GermResistance>
 			<GermContainment>0.25</GermContainment>
 			<FilthRate>48</FilthRate>
+			<NightVisionEfficiency>1</NightVisionEfficiency>
 		</statBases>
 		<tickerType>Normal</tickerType>
 		<tools>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
@@ -35,6 +35,7 @@
 			<ArmorRating_Heat>2.00</ArmorRating_Heat>
 			<GermResistance>1.0</GermResistance>
 			<GermContainment>1.0</GermContainment>
+			<NightVisionEfficiency>0.6</NightVisionEfficiency>
 		</statBases>
 		<receivesSignals>true</receivesSignals>
 		<race>
@@ -273,6 +274,7 @@
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.22</MeleeParryChance>
+			<NightVisionEfficiency>0.9</NightVisionEfficiency>
 		</statBases>
 		<tools>
 			<li Class="CombatExtended.ToolCE">
@@ -366,6 +368,7 @@
 			<MeleeDodgeChance>0.1</MeleeDodgeChance>
 			<MeleeCritChance>0.15</MeleeCritChance>
 			<MeleeParryChance>0.22</MeleeParryChance>
+			<NightVisionEfficiency>0.7</NightVisionEfficiency>
 		</statBases>
 		<tools>
 			<li Class="CombatExtended.ToolCE">

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_MechanoidZeon.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_MechanoidZeon.xml
@@ -84,6 +84,7 @@
 			<MeleeParryChance>0.2</MeleeParryChance>
 			<SmokeSensitivity>0</SmokeSensitivity>
 			<MaxHitPoints>1000</MaxHitPoints>
+			<NightVisionEfficiency>1</NightVisionEfficiency>
 		</statBases>
 		<tools>
 			<li Class="CombatExtended.ToolCE">

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mutant.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mutant.xml
@@ -36,6 +36,7 @@
 			<MeleeDodgeChance>0.12</MeleeDodgeChance>
 			<MeleeCritChance>0.1</MeleeCritChance>
 			<MeleeParryChance>0.14</MeleeParryChance>
+			<NightVisionEfficiency>0.2</NightVisionEfficiency>
 		</statBases>
 		<tools>
 			<li Class="CombatExtended.ToolCE">

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Blasters.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Blasters.xml
@@ -85,6 +85,7 @@
 			<RangedWeapon_Cooldown>1.15</RangedWeapon_Cooldown>
 			<Bulk>10.20</Bulk>
 			<Mass>3.50</Mass>
+			<NightVisionEfficiency_Weapon>0.7</NightVisionEfficiency_Weapon>
 		</statBases>
 		<soundInteract>ShotM3Predator</soundInteract>
 		<techLevel>Spacer</techLevel>
@@ -151,6 +152,7 @@
 			<RangedWeapon_Cooldown>0.8</RangedWeapon_Cooldown>
 			<Bulk>11.10</Bulk>
 			<Mass>3.70</Mass>
+			<NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 		</statBases>
 		<soundInteract>ShotN7Hurricane</soundInteract>
 		<weaponTags>
@@ -222,6 +224,7 @@
 			<RangedWeapon_Cooldown>0.72</RangedWeapon_Cooldown>
 			<Bulk>11.50</Bulk>
 			<Mass>5.20</Mass>
+			<NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 		</statBases>
 		<weaponTags>
 			<li>ADS1</li>
@@ -292,6 +295,7 @@
 			<RangedWeapon_Cooldown>0.76</RangedWeapon_Cooldown>
 			<Bulk>12.50</Bulk>
 			<Mass>5.50</Mass>
+			<NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
 		</statBases>
 		<weaponTags>
 			<li>ADS2</li>
@@ -362,6 +366,7 @@
 			<RangedWeapon_Cooldown>1.15</RangedWeapon_Cooldown>
 			<Bulk>12.40</Bulk>
 			<Mass>4.30</Mass>
+			<NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
 		</statBases>
 		<soundInteract>ShotM8Avenger</soundInteract>
 		<weaponTags>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Chargeblasters.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Chargeblasters.xml
@@ -18,6 +18,7 @@
             <RangedWeapon_Cooldown>0.65</RangedWeapon_Cooldown>
             <Bulk>11.00</Bulk>
             <Mass>3.60</Mass>
+			<NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
         </statBases>
         <weaponTags>
             <li>ADR2</li>
@@ -89,6 +90,7 @@
             <RangedWeapon_Cooldown>0.87</RangedWeapon_Cooldown>
             <Bulk>13.00</Bulk>
             <Mass>4.90</Mass>
+			<NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
         </statBases>
         <weaponTags>
             <li>ADR3</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Lasers.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Lasers.xml
@@ -31,6 +31,7 @@
             <RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
             <Bulk>10.50</Bulk>
             <Mass>3.65</Mass>
+			<NightVisionEfficiency_Weapon>0.8</NightVisionEfficiency_Weapon>
         </statBases>
         <verbs>
             <li Class="CombatExtended.VerbPropertiesCE">
@@ -96,6 +97,7 @@
             <RangedWeapon_Cooldown>0.7</RangedWeapon_Cooldown>
             <Bulk>11.10</Bulk>
             <Mass>3.65</Mass>
+			<NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
         </statBases>
         <verbs>
             <li Class="CombatExtended.VerbPropertiesCE">
@@ -165,6 +167,7 @@
             <RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
             <Bulk>11.10</Bulk>
             <Mass>3.65</Mass>
+			<NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
         </statBases>
         <soundInteract>InteractLaser</soundInteract>
         <verbs>
@@ -235,6 +238,7 @@
             <RangedWeapon_Cooldown>0.9</RangedWeapon_Cooldown>
             <Bulk>12.00</Bulk>
             <Mass>4.40</Mass>
+			<NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
         </statBases>
         <soundInteract>InteractLaser</soundInteract>
         <verbs>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Launchers.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Launchers.xml
@@ -456,6 +456,7 @@
             <RangedWeapon_Cooldown>2.5</RangedWeapon_Cooldown>
             <Bulk>10</Bulk>
             <Mass>8</Mass>
+			<NightVisionEfficiency_Weapon>0.7</NightVisionEfficiency_Weapon>
         </statBases>
 		<generateCommonality>0.7</generateCommonality>
         <weaponTags>
@@ -526,6 +527,7 @@
             <RangedWeapon_Cooldown>2.3</RangedWeapon_Cooldown>
             <Bulk>10</Bulk>
             <Mass>9</Mass>
+			<NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
         </statBases>
         <tradeability>Sellable</tradeability>
         <destroyOnDrop>false</destroyOnDrop>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Plasma.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Plasma.xml
@@ -87,6 +87,7 @@
             <RangedWeapon_Cooldown>0.75</RangedWeapon_Cooldown>
             <Bulk>10.20</Bulk>
             <Mass>3.50</Mass>
+			<NightVisionEfficiency_Weapon>0.7</NightVisionEfficiency_Weapon>
         </statBases>
         <soundInteract>InteractPlasma</soundInteract>
         <tradeability>Sellable</tradeability>
@@ -157,6 +158,7 @@
             <RangedWeapon_Cooldown>0.88</RangedWeapon_Cooldown>
             <Bulk>11.10</Bulk>
             <Mass>3.70</Mass>
+			<NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
         </statBases>
         <soundInteract>InteractPlasma</soundInteract>
         <tradeability>Sellable</tradeability>
@@ -229,6 +231,7 @@
             <RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
             <Bulk>11.50</Bulk>
             <Mass>5.20</Mass>
+			<NightVisionEfficiency_Weapon>0.4</NightVisionEfficiency_Weapon>
         </statBases>
         <tradeability>Sellable</tradeability>
 		<techLevel>Spacer</techLevel>
@@ -298,6 +301,7 @@
             <RangedWeapon_Cooldown>1.1</RangedWeapon_Cooldown>
             <Bulk>12.40</Bulk>
             <Mass>4.30</Mass>
+			<NightVisionEfficiency_Weapon>0.6</NightVisionEfficiency_Weapon>
         </statBases>
         <soundInteract>InteractPlasma</soundInteract>
         <weaponTags>

--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Weapon.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Weapon.xml
@@ -965,6 +965,7 @@
 			<Bulk>8.0</Bulk>
 			<Mass>4.0</Mass>
 			<WorkToMake>40000</WorkToMake>
+			<NightVisionEfficiency_Weapon>0.5</NightVisionEfficiency_Weapon>
 		</statBases>
 		<equippedStatOffsets>
 			<HuntingStealth>0.1</HuntingStealth>
@@ -1069,6 +1070,7 @@
 			<Bulk>13.0</Bulk>
 			<Mass>10.0</Mass>
 			<WorkToMake>40000</WorkToMake>
+			<NightVisionEfficiency_Weapon>0.3</NightVisionEfficiency_Weapon>
 		</statBases>
 		<equippedStatOffsets>
 			<HuntingStealth>0.05</HuntingStealth>

--- a/Mods/Skynet_SK/Defs/ThingDefs/Races_Skynet.xml
+++ b/Mods/Skynet_SK/Defs/ThingDefs/Races_Skynet.xml
@@ -54,6 +54,7 @@
 			<LeatherAmount>0</LeatherAmount>
 			<MeatAmount>0</MeatAmount>
 			<SmokeSensitivity>0</SmokeSensitivity>
+			<NightVisionEfficiency>0.6</NightVisionEfficiency>
 		</statBases>
 		<race>
 			<foodType>OmnivoreHuman</foodType>
@@ -517,6 +518,7 @@
 			<MeleeDodgeChance>0.22</MeleeDodgeChance>
 			<MeleeCritChance>0.2</MeleeCritChance>
 			<Radiation>0</Radiation>
+			<NightVisionEfficiency>1</NightVisionEfficiency>
 		</statBases>
 		<tools>
 			<li Class="CombatExtended.ToolCE">


### PR DESCRIPTION
1 fixed missed fishes meat amount (used base very high value);
2 added bionic and cybernetic eyes prostheses night vision efficiency bonus;
3 added some high tech weapon night vision efficiency bonus;
4 added night vision efficiency base value to mechanoid's, terminator's and some exotic animal's pawns.

1 добавлено пропущенное количество мяса для рыб (бралось завышенное базовое значение);
2 добавлен бонус эффективности ночного зрения для бионических и кибернетических глазных протезов;
3 добавлен бонус эффективности ночного зрения для некоторого высокотехнологичного оружия;
4 добавлен бонус эффективности ночного зрения для пешек механоидов, терминаторов, огров и некоторых экзотических животных.