### PR TITLE
Some quests tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/12x64mmCharged.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/12x64mmCharged.xml
@@ -34,6 +34,8 @@
 		  <li>CE_AutoEnableTrade_Sellable</li>
 		</tradeTags>
 		<stackLimit>200</stackLimit>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12x64mmChargedBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/15x65mmDiffusingCharged.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/15x65mmDiffusingCharged.xml
@@ -33,6 +33,8 @@
 		<thingCategories>
 			<li>Ammo15x65mmDiffusingCharged</li>
 		</thingCategories>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="15x65mmDiffusingChargedBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/6x24mmCharged.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/6x24mmCharged.xml
@@ -75,6 +75,9 @@
 		</statBases>
 		<ammoClass>Ionized</ammoClass>
 		<generateAllowChance>0</generateAllowChance>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesTierFour</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/80x256mmFuelCell.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/80x256mmFuelCell.xml
@@ -33,6 +33,8 @@
 		<tradeTags>
 			<li>CE_AutoEnableTrade_Sellable</li>
 		</tradeTags>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="80x256mmFuelBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/9x44mmCharged.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/9x44mmCharged.xml
@@ -34,6 +34,8 @@
 		  <li>CE_AutoEnableTrade_Sellable</li>
 		</tradeTags>
 		<stackLimit>300</stackLimit>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x44mmChargedBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/AmmoBases.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/AmmoBases.xml
@@ -57,6 +57,8 @@
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="NeolithicAmmoBase" ParentName="AmmoBase" Abstract="True">
 		<techLevel>Neolithic</techLevel>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="SpacerSmallAmmoBase" ParentName="SmallAmmoBase" Abstract="True">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/45ACP.xml
@@ -49,6 +49,9 @@
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_45ACP_FMJ</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesTierOne</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="45ACPBase">
@@ -79,6 +82,9 @@
 		<ammoClass>HollowPoint</ammoClass>
 		<generateAllowChance>0.25</generateAllowChance>
 		<cookOffProjectile>Bullet_45ACP_HP</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesTierTwo</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/303British.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/303British.xml
@@ -79,6 +79,9 @@
 		<ammoClass>HollowPoint</ammoClass>
 		<generateAllowChance>0.2</generateAllowChance>
 		<cookOffProjectile>Bullet_303British_HP</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesTierOne</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<!-- ================== Projectiles ================== -->

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x39mmSoviet.xml
@@ -64,6 +64,9 @@
 		<ammoClass>ArmorPiercing</ammoClass>
 		<generateAllowChance>0.3</generateAllowChance>
 		<cookOffProjectile>Bullet_762x39mmSoviet_AP</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesTierThree</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x39mmSovietBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/81mmMortar.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Shell/81mmMortar.xml
@@ -130,6 +130,8 @@
 			<Mass>4.1</Mass>
 			<Bulk>13.34</Bulk>
 		</statBases>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBaseCraftableBase">
@@ -148,6 +150,8 @@
 			<Mass>4.1</Mass>
 			<Bulk>13.34</Bulk>
 		</statBases>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="81mmMortarShellBase">

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Art.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Art.xml
@@ -495,6 +495,8 @@
 		<recipeMaker>
 			<researchPrerequisite>Art_B1</researchPrerequisite>
 		</recipeMaker>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef ParentName="SK_SculptureBase">
@@ -527,6 +529,8 @@
 		<recipeMaker>
 			<researchPrerequisite>Art_B1</researchPrerequisite>
 		</recipeMaker>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef ParentName="SK_SculptureBase">
@@ -561,6 +565,8 @@
 		<recipeMaker>
 			<researchPrerequisite>Art_B1</researchPrerequisite>
 		</recipeMaker>
+		<thingSetMakerTags Inherit="false">
+		</thingSetMakerTags>
 	</ThingDef>
 
 
@@ -636,8 +642,6 @@
 	</ThingDef>
 
 
-
-
 	<ThingDef ParentName="SK_SculptureBase">
 		<defName>GlowstoneArt</defName>
 		<label>glowstone sculpture</label>
@@ -685,6 +689,5 @@
 			<researchPrerequisite>Art_B2</researchPrerequisite>
 		</recipeMaker>
 	</ThingDef>
-
 
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
@@ -112,6 +112,9 @@
 			<optimalityOffsetFeedingAnimals>-5</optimalityOffsetFeedingAnimals>
 		</ingestible>
 		<allowedArchonexusCount>40</allowedArchonexusCount>
+		<thingSetMakerTags>
+			<li>HSKhumanitarianSuppliesTierThree</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<!--<ThingDef ParentName="SK_MealBase">

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Canned.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Canned.xml
@@ -318,8 +318,9 @@
 			<li Class="CompProperties_FoodPoisonable" />
 		</comps>
 		<stackLimit>150</stackLimit>
+		<thingSetMakerTags>
+			<li>HSKhumanitarianSuppliesTierOne</li>
+		</thingSetMakerTags>
 	</ThingDef>
-	
-
 
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Medical.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Medical.xml
@@ -63,6 +63,9 @@
 				<daysToRotStart>150</daysToRotStart>
 			</li>
 		</comps>
+		<thingSetMakerTags>
+			<li>HSKhumanitarianSuppliesTierTwo</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 
@@ -97,6 +100,9 @@
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>
+		<thingSetMakerTags>
+			<li>HSKhumanitarianSuppliesTierThree</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef ParentName="MealBeverage">

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Synthetic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Synthetic.xml
@@ -33,6 +33,10 @@
 			<li Class="SK.SyntheticMealExtension">
 			</li>
 		</modExtensions>
+		<thingSetMakerTags>
+			<li>HSKhumanitarianSuppliesTierTwo</li>
+			<li>HSKhumanitarianSuppliesTierFour</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef ParentName="ResBase">

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Medicine.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Medicine.xml
@@ -37,6 +37,9 @@
 			</li>
 		</comps>
 		<allowedArchonexusCount>20</allowedArchonexusCount>
+		<thingSetMakerTags>
+			<li>HSKhumanitarianSuppliesTierOne</li>
+		</thingSetMakerTags>
 	</ThingDef>
 	
 	<ThingDef ParentName="SK_ResourceBase">
@@ -95,6 +98,9 @@
 			<li>Medicine</li>
 		</thingCategories>
 		<allowedArchonexusCount>10</allowedArchonexusCount>
+		<thingSetMakerTags>
+			<li>HSKhumanitarianSuppliesTierFour</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Chargeblasters.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Chargeblasters.xml
@@ -70,6 +70,7 @@
         </smeltProducts>
 		<thingSetMakerTags>
 			<li>RewardStandardHighFreq</li>
+			<li>HSKCombatSuppliesTierFour</li>
 		</thingSetMakerTags>
     </ThingDef>
 	<!-- R6 SPLITTER -->

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
@@ -240,6 +240,9 @@
             <AdvRifle_Component>1</AdvRifle_Component>
             <Weapon_Parts>5</Weapon_Parts>
         </smeltProducts>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesTierThree</li>
+		</thingSetMakerTags>
     </ThingDef>
 	<!-- TAVOR TAR-21 -->
     <ThingDef ParentName="BaseGun_LongBarreled">

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SMGs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_SMGs.xml
@@ -526,6 +526,9 @@
             <Weapon_Parts>3</Weapon_Parts>
 			<Plastic>3</Plastic>
         </smeltProducts>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesTierTwo</li>
+		</thingSetMakerTags>
     </ThingDef>
     <!-- LUGER M4 -->
     <ThingDef ParentName="BaseGun_LongBarreled">

--- a/Mods/Core_SK/Patches/ThingSetMakerDefs/ThingSetMakers_RewardPatches.xml
+++ b/Mods/Core_SK/Patches/ThingSetMakerDefs/ThingSetMakers_RewardPatches.xml
@@ -12,7 +12,6 @@
 					</thingDefs>
 				</value>
 			</li>
-
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingSetMakerDef[defName = "Reward_ItemsStandard"]/root/options/li[1]/thingSetMaker/options</xpath>
 				<value>
@@ -31,9 +30,89 @@
 					</li>
 				</value>
 			</li>
-
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingSetMakerDef[defName = "Reward_ItemsStandard"]/root/options/li[1]/thingSetMaker/options/li[8]/weight</xpath>
+				<value>
+					<weight>8</weight>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingSetMakerDef[defName = "Reward_ItemsStandard"]/root/options/li[1]/thingSetMaker/options</xpath>
+				<value>
+					<li>
+						<weight>0.5</weight>
+						<thingSetMaker Class="ThingSetMaker_RandomOption">
+							<options>
+							  <!-- Some simple and usefull sets. -->
+							  <li>
+								<weight>2</weight>
+								<thingSetMaker Class="ThingSetMaker_MarketValue">
+								  <fixedParams>
+									<allowNonStackableDuplicates>False</allowNonStackableDuplicates>
+									<filter>
+										<thingSetMakerTagsToAllow>
+											<li>HSKCombatSuppliesTierOne</li>
+											<li>HSKhumanitarianSuppliesTierOne</li>
+										</thingSetMakerTagsToAllow>
+									</filter>
+									<minSingleItemMarketValuePct>0.01</minSingleItemMarketValuePct>
+								  </fixedParams>
+								</thingSetMaker>
+							  </li>
+							  <li>
+								<weight>1</weight>
+								<thingSetMaker Class="ThingSetMaker_MarketValue">
+								  <fixedParams>
+									<allowNonStackableDuplicates>False</allowNonStackableDuplicates>
+									<filter>
+										<thingSetMakerTagsToAllow>
+											<li>HSKCombatSuppliesTierTwo</li>
+											<li>HSKhumanitarianSuppliesTierTwo</li>
+										</thingSetMakerTagsToAllow>
+									</filter>
+									<minSingleItemMarketValuePct>0.01</minSingleItemMarketValuePct>
+								  </fixedParams>
+								</thingSetMaker>
+							  </li>
+							  <li>
+								<weight>0.5</weight>
+								<thingSetMaker Class="ThingSetMaker_MarketValue">
+								  <fixedParams>
+									<allowNonStackableDuplicates>False</allowNonStackableDuplicates>
+									<filter>
+										<thingSetMakerTagsToAllow>
+											<li>HSKCombatSuppliesTierThree</li>
+											<li>HSKhumanitarianSuppliesTierThree</li>
+										</thingSetMakerTagsToAllow>
+									</filter>
+									<minSingleItemMarketValuePct>0.01</minSingleItemMarketValuePct>
+								  </fixedParams>
+								</thingSetMaker>
+							  </li>
+							  <li>
+								<weight>0.25</weight>
+								<thingSetMaker Class="ThingSetMaker_MarketValue">
+								  <fixedParams>
+									<allowNonStackableDuplicates>False</allowNonStackableDuplicates>
+									<filter>
+										<thingSetMakerTagsToAllow>
+											<li>HSKCombatSuppliesTierFour</li>
+											<li>HSKhumanitarianSuppliesTierFour</li>
+										</thingSetMakerTagsToAllow>
+									</filter>
+									<minSingleItemMarketValuePct>0.01</minSingleItemMarketValuePct>
+								  </fixedParams>
+								</thingSetMaker>
+							  </li>
+							</options>
+						</thingSetMaker>
+					</li>
+				</value>
+			</li>
 		</operations>
 	</Operation>
-
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="ReinforcedBarrel"]/thingSetMakerTags</xpath>
+	</Operation>
 </Patch>
 

--- a/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/Apparel_Psychic_Patch.xml
+++ b/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/Apparel_Psychic_Patch.xml
@@ -198,5 +198,14 @@
 			<GermContainment>0.04</GermContainment>
 		</value>
 	</Operation>
-
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[@Name="PsychicApparelBase"]/thingSetMakerTags</xpath>
+	</Operation>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[@Name="PsychicApparelBase"]</xpath>
+		<value>
+			<thingSetMakerTags Inherit="false">
+			</thingSetMakerTags>
+		</value>
+	</Operation>
 </Patch>

--- a/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
+++ b/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/Weapons_Melee.xml
@@ -120,6 +120,10 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_Warhammer"]/thingSetMakerTags</xpath>
+	</Operation>
+
 	<!-- ========== Psycast Staff ========== -->
 
 	<Operation Class="PatchOperationReplace">
@@ -175,6 +179,14 @@
 						<DrawSize>1.2,1.2</DrawSize>
 					</li>
 				</modExtensions>
+			</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="MeleeWeapon_PsyfocusStaff"]</xpath>
+			<value>
+				<thingSetMakerTags Inherit="false">
+				</thingSetMakerTags>
 			</value>
 	</Operation>
 


### PR DESCRIPTION
1 reduced eltex stuffs spawn chance as quests reward;
2 removed some non-using ammo from quest rewards;
3 removed some art from quest rewards (like potteries and urns);
4 removed medieval warhammer from quest rewards;
5 added few sets rewards as quest reward.

1 уменьшена вероятность появления предметов из эльтекса в качестве награды за задания;
2 убраны неиспользуемые игровым оружием боеприпасы из наград за выполнения заданий;
3 убраны некоторые произведения искусства из наград за выполнения заданий (урны и гончарные изделия);
4 удален средневековый боевой молот из наград за выполнения заданий;
5 добавлено несколько наборов в качестве награды за задания.