### PR TITLE
Triple launcher tweaks

### DIFF
--- a/Mods/CombatExtended/Languages/Russian/DefInjected/CombatExtended.AmmoSetDefs/Sets.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/CombatExtended.AmmoSetDefs/Sets.xml
@@ -41,6 +41,8 @@
 
 	<AmmoSet_RPG7Grenade.label>РПГ-7 граната</AmmoSet_RPG7Grenade.label>
 
+	<AmmoSet_RPG7TripleGrenade.label>РПГ-7 граната «Тройка»</AmmoSet_RPG7TripleGrenade.label>
+
 	<AmmoSet_81mmMortarShell.label>81 мм миномётная мина</AmmoSet_81mmMortarShell.label>
 
 	<AmmoSet_90mmCannonShell.label>90 мм артиллерийский снаряд</AmmoSet_90mmCannonShell.label>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rocket/RPG7.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rocket/RPG7.xml
@@ -20,6 +20,18 @@
 		</ammoTypes>
 	</CombatExtended.AmmoSetDef>
 
+	<!-- ==================== AmmoSet for Triple rocket launcher ========================== -->
+
+	<CombatExtended.AmmoSetDef>
+		<defName>AmmoSet_RPG7TripleGrenade</defName>
+		<label>RPG-7 Grenades triple</label>
+		<ammoTypes>
+			<Ammo_RPG7Grenade_HEAT>Bullet_RPG7TripleGrenade_HEAT</Ammo_RPG7Grenade_HEAT>
+			<Ammo_RPG7Grenade_Thermobaric>Bullet_RPG7TripleGrenade_Thermobaric</Ammo_RPG7Grenade_Thermobaric>
+			<Ammo_RPG7Grenade_Frag>Bullet_RPG7TripleGrenade_Frag</Ammo_RPG7Grenade_Frag>
+		</ammoTypes>
+	</CombatExtended.AmmoSetDef>
+
 	<!-- ==================== Ammo ========================== -->
 
 	<ThingDef Class="CombatExtended.AmmoDef" Name="RPG7GrenadeBase" ParentName="AmmoBase" Abstract="True">
@@ -167,6 +179,88 @@
 				<fragments>
 					<Fragment_Large>25</Fragment_Large>
 					<Fragment_Small>40</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<!-- ================== Triple rocket only ================== -->
+
+	<ThingDef Class="CombatExtended.AmmoDef" Name="TripleRocketGrenade" ParentName="BaseRPG7Grenade" Abstract="true">
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<pelletCount>3</pelletCount>
+			<spreadMult>16.67</spreadMult>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="TripleRocketGrenade">
+		<defName>Bullet_RPG7TripleGrenade_HEAT</defName>
+		<label>RPG-7 small grenade (HEAT)</label>
+		<thingClass>SK.ProjectileCE_Bullet_RL</thingClass>
+		<graphicData>
+			<texPath>Things/Projectile/RPG/HEAT</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>0.5</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bullet</damageDef>
+			<damageAmountBase>135</damageAmountBase>
+			<armorPenetrationSharp>330</armorPenetrationSharp>
+			<armorPenetrationBlunt>30</armorPenetrationBlunt>
+			<soundExplode>MortarBomb_Explode</soundExplode>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_ExplosiveCE">
+				<damageAmountBase>120</damageAmountBase>
+				<explosiveDamageType>Bomb</explosiveDamageType>
+				<explosiveRadius>1.8</explosiveRadius>
+				<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
+			</li>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>3</Fragment_Large>
+					<Fragment_Small>10</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="TripleRocketGrenade">
+		<defName>Bullet_RPG7TripleGrenade_Thermobaric</defName>
+		<label>RPG-7 small grenade (Thermobaric)</label>
+		<graphicData>
+			<texPath>Things/Projectile/RPG/Thermobaric</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>0.5</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<explosionRadius>3</explosionRadius>
+			<damageDef>Thermobaric</damageDef>
+			<damageAmountBase>90</damageAmountBase>
+			<armorPenetrationSharp>0</armorPenetrationSharp>
+			<armorPenetrationBlunt>0</armorPenetrationBlunt>
+			<ai_IsIncendiary>true</ai_IsIncendiary>
+		</projectile>
+	</ThingDef>
+
+	<ThingDef Class="CombatExtended.AmmoDef" ParentName="TripleRocketGrenade">
+		<defName>Bullet_RPG7TripleGrenade_Frag</defName>
+		<label>RPG-7 small grenade (Frag)</label>
+		<graphicData>
+			<texPath>Things/Projectile/RPG/Frag</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>0.5</drawSize>
+		</graphicData>
+		<projectile Class="CombatExtended.ProjectilePropertiesCE">
+			<damageDef>Bomb</damageDef>
+			<damageAmountBase>80</damageAmountBase>
+			<explosionRadius>1.5</explosionRadius>
+		</projectile>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>13</Fragment_Large>
+					<Fragment_Small>20</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Launchers.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Launchers.xml
@@ -545,7 +545,7 @@
             <li Class="CombatExtended.VerbPropertiesCE">
                 <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                 <hasStandardCommand>true</hasStandardCommand>
-                <defaultProjectile>Bullet_RPG7Grenade_HEAT</defaultProjectile>
+                <defaultProjectile>Bullet_RPG7TripleGrenade_HEAT</defaultProjectile>
 				<!--<forcedMissRadius>3</forcedMissRadius>-->
 				<circularError>1</circularError>
                 <warmupTime>2.5</warmupTime>
@@ -569,9 +569,9 @@
                 <aiUseBurstMode>FALSE</aiUseBurstMode>
             </li>
             <li Class="CombatExtended.CompProperties_AmmoUser">
-                <magazineSize>3</magazineSize>
-                <reloadTime>10</reloadTime>
-                <ammoSet>AmmoSet_RPG7Grenade</ammoSet>
+                <magazineSize>1</magazineSize>
+                <reloadTime>7.5</reloadTime>
+                <ammoSet>AmmoSet_RPG7TripleGrenade</ammoSet>
             </li>
         </comps>
     </ThingDef>

--- a/Mods/Dubs-Bad-Hygiene/Defs/DesignationSubCategoryDefs/SubCategories_dubs.xml
+++ b/Mods/Dubs-Bad-Hygiene/Defs/DesignationSubCategoryDefs/SubCategories_dubs.xml
@@ -157,7 +157,7 @@
 		<description>Buildings that dont fit other areas.</description>
 		<defNames>
 			<li>BurnPit</li>
-			<li MayRequire="HSK.HolyBasin">HolyBasin</li>
+			<li>HolyBasin</li>
 			<li>WashingMachine</li>
 			<li>KitchenSink</li>
 			<li>BiosolidsComposter</li>


### PR DESCRIPTION
1 R3 Blast-Rocket Launcher now divide one RPG-7 shot to three smaller and weaker one (shooting with three rocket simultaneously);
2 fixed holy basin sub category.

1 Ракетница «Тройка» при выстреле разделяет один крупный снаряд на три меньших осколка (стреляет тремя ослабленными ракетами одновременно);
2 исправлено некорректное расположение священного стирального тазика с включенной гигиеной (возвращен в категорию "Разное").