### PR TITLE
Some tweaks and fixes

### DIFF
--- a/Mods/Armor Racks/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Armor Racks/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
@@ -1,0 +1,7 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<LanguageData>
+
+	<SubCategory_ArmorRacksHSK.label>стойки</SubCategory_ArmorRacksHSK.label> 
+	<SubCategory_ArmorRacksHSK.description>Стойки для одежды и некоторых других предметов.</SubCategory_ArmorRacksHSK.description> 
+
+</LanguageData>

--- a/Mods/Armor Racks/Patches/DesignationSubCategoriesPatch.xml
+++ b/Mods/Armor Racks/Patches/DesignationSubCategoriesPatch.xml
@@ -1,0 +1,19 @@
+﻿<Patch>
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs</xpath>
+		<value>
+			<ArchitectSense.DesignationSubCategoryDef>
+				<defName>SubCategory_ArmorRacksHSK</defName>
+				<label>armor racks</label>
+				<description>Armor racks for apparel and some other stuff.</description>
+				<defNames>
+					<li>ArmorRacks_ArmorRack</li>
+					<li>ArmorRacks_MechanizedArmorRack</li>
+					<li>ArmorRacks_MendingArmorRack</li>
+				</defNames>
+				<designationCategory>LWM_DS_Storage</designationCategory>
+				<debug>false</debug>
+			</ArchitectSense.DesignationSubCategoryDef>
+		</value>
+	</Operation>
+</Patch>

--- a/Mods/Core_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Core_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
@@ -114,10 +114,12 @@
 	<ArchitectSense.DesignationSubCategoryDef>
 		<defName>SubCategory_SpecialBeds</defName>
 		<label>special beds</label>
-		<description>A simple bed for one pawn.</description>
+		<description>A special beds for some various needs.</description>
 		<defNames>
 			<li>SleepingSpot</li>
 			<li>DoubleSleepingSpot</li>
+			<li MayRequire="Ludeon.RimWorld.Ideology">SlabBed</li>
+			<li MayRequire="Ludeon.RimWorld.Ideology">SlabDoubleBed</li>
 			<li>BagBed</li>
 			<li>GuestBed</li>
 			<li>prison_single_bed_RT</li>
@@ -235,6 +237,19 @@
 			<li>MilleniumCouch</li>
 			<li>EggArmchair</li>
 			<li>PodChair</li>
+		</defNames>
+		<designationCategory>Furniture</designationCategory>
+		<debug>false</debug>
+	</ArchitectSense.DesignationSubCategoryDef>
+
+	<ArchitectSense.DesignationSubCategoryDef MayRequire="Ludeon.RimWorld.Royalty">
+		<defName>SubCategory_RoyaltyStuff</defName>
+		<label>royalty stuff</label>
+		<description>Drapes, thrones for royalty person.</description>
+		<defNames>
+			<li>Throne</li>
+			<li>GrandThrone</li>
+			<li>Drape</li>
 		</defNames>
 		<designationCategory>Furniture</designationCategory>
 		<debug>false</debug>
@@ -471,6 +486,7 @@
 			<li>GlowstoneLamp</li>
 			<li>OutdoorGroundLamp</li>
 			<li>Lighting_PathLamp</li>
+			<li MayRequire="Ludeon.RimWorld.Royalty">Brazier</li>
 		</defNames>
 		<designationCategory>Accessories</designationCategory>
 		<debug>false</debug>
@@ -488,6 +504,23 @@
 			<li>CeilingLamp</li>
 			<li>WallLamp</li>
 			<li>Lighting_WallLight</li>
+		</defNames>
+		<designationCategory>Accessories</designationCategory>
+		<debug>false</debug>
+	</ArchitectSense.DesignationSubCategoryDef>
+
+	<ArchitectSense.DesignationSubCategoryDef MayRequire="Ludeon.RimWorld.Ideology">
+		<defName>SubCategory_DarkLamps</defName>
+		<label>dark lamps</label>
+		<description>Lamp that lights an area with dark light.</description>
+		<defNames>
+			<li>Darktorch</li>
+			<li>DarktorchFungus</li>
+			<li>Darklamp</li>
+			<li>CeilingDarkLamp</li>
+			<li>StandingDarkLampLEDnormal</li>
+			<li>CeilingLEDDarkLamp</li>
+			<li>DarklightBrazier</li>
 		</defNames>
 		<designationCategory>Accessories</designationCategory>
 		<debug>false</debug>

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Breach.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Breach.xml
@@ -45,7 +45,7 @@
 		<defName>Mech_Termite_Breach</defName>
 		<label>termite</label>
 		<race>Mech_Termite</race>
-		<combatPower>110</combatPower>
+		<combatPower>470</combatPower>
 		<lifeStages>
 			<li>
 				<bodyGraphicData>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -688,6 +688,70 @@
 		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
 	</ThingDef>
 
+	<ThingDef MayRequire="Ludeon.RimWorld.Ideology" ParentName="SK_LampBase">
+		<defName>CeilingDarkLamp</defName>
+		<label>ceiling dark lamp</label>
+		<thingClass>SK.Building_Lamp</thingClass>
+		<graphicData>
+			<texPath>Things/Building/Furniture/Lights/CeilingLamp</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shadowData>
+				<volume>(0.2, 0.2, 0.2)</volume>
+				<offset>(0,0,0)</offset>
+			</shadowData>
+			<shaderType>Transparent</shaderType>
+		</graphicData>
+		<minifiedDef>MinifiedThing</minifiedDef>
+		<statBases>
+			<MaxHitPoints>35</MaxHitPoints>
+			<WorkToBuild>320</WorkToBuild>
+			<Beauty>10</Beauty>
+			<Bulk>8</Bulk>
+			<Mass>2</Mass>
+			<StyleDominance MayRequire="Ludeon.RimWorld.Ideology">3</StyleDominance>
+		</statBases>
+		<tickerType>Rare</tickerType>
+		<description>A ceiling lamp that lights an area with dark light. People need light to move and work at full speed. Must be placed under a roof. Requires 30 W.</description>
+		<costList>
+			<Glass>5</Glass>
+			<ComponentIndustrial>2</ComponentIndustrial>
+			<ElectronicComponents>1</ElectronicComponents>
+		</costList>
+		<building>
+			<uninstallWork>800</uninstallWork>
+			<isEdifice>false</isEdifice>
+			<canBuildNonEdificesUnder>true</canBuildNonEdificesUnder>
+		</building>
+		<clearBuildingArea>false</clearBuildingArea>
+		<comps>
+			<li Class="CompProperties_Flickable"/>
+			<li Class="CompProperties_Power">
+				<compClass>CompPowerTrader</compClass>
+				<basePowerConsumption>30</basePowerConsumption>
+				<shortCircuitInRain>true</shortCircuitInRain>
+				<soundPowerOn>Power_OnSmall</soundPowerOn>
+				<soundPowerOff>Power_OffSmall</soundPowerOff>
+			</li>
+			<li Class="CompProperties_Glower">
+				<glowRadius>7</glowRadius>
+				<glowColor>(78,226,229,0)</glowColor>
+			</li>
+			<li Class="SK.CompProperties_RestrictedPlacement">
+				<compClass>SK.CompRestrictedPlacement</compClass>
+			</li>
+		</comps>
+		<placeWorkers>
+			<li>SK.PlaceWorker_OnlyUnderRoof</li>
+		</placeWorkers>
+		<filthLeaving>Filth_BrokenGlass</filthLeaving>
+		<leaveResourcesWhenKilled>false</leaveResourcesWhenKilled>
+		<rotatable>false</rotatable>
+		<researchPrerequisites>
+			<li>Light_C2</li>
+		</researchPrerequisites>
+		<constructionSkillPrerequisite>6</constructionSkillPrerequisite>
+	</ThingDef>
+
 
 	<!--======================================WallLights======================================-->
 

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Lighting_LED.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Lighting_LED.xml
@@ -342,7 +342,113 @@
 		<filthLeaving>Filth_BrokenGlass</filthLeaving>
 		<leaveResourcesWhenKilled>false</leaveResourcesWhenKilled>
 		<rotatable>false</rotatable>
-		<constructionSkillPrerequisite>8</constructionSkillPrerequisite>
+	</ThingDef>
+
+	<ThingDef MayRequire="Ludeon.RimWorld.Ideology" ParentName="SK_StandingLampLED">
+		<defName>StandingDarkLampLEDnormal</defName>
+		<label>standing LED dark lamp (normal)</label>
+		<description>A standing LED lamp that lights an area. Requires 7 W.</description>
+		<thingClass>SK.Building_Lamp</thingClass>
+		<graphicData>
+			<texPath>Things/Building/Furniture/Lights/lamp</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>(1.15)</drawSize>
+			<shadowData>
+				<volume>(0.3, 0.6, 0.3)</volume>
+				<offset>(0,0,-0.1)</offset>
+			</shadowData>
+			<damageData>
+				<rect>(0.2,0.2,0.6,0.6)</rect>
+			</damageData>
+		</graphicData>
+		<statBases>
+			<MaxHitPoints>100</MaxHitPoints>
+			<WorkToBuild>1320</WorkToBuild>
+			<Bulk>15</Bulk>
+			<Mass>4</Mass>
+		</statBases>
+		<costList>
+			<Plastic>12</Plastic>
+			<Glass>7</Glass>
+			<ComponentIndustrial>3</ComponentIndustrial>
+			<ElectronicComponents>1</ElectronicComponents>
+			<Electronics>1</Electronics>
+		</costList>
+		<comps Inherit="False">
+			<li Class="CompProperties_Flickable"/>
+			<li Class="CompProperties_Power">
+				<compClass>CompPowerTrader</compClass>
+				<basePowerConsumption>7</basePowerConsumption>
+				<shortCircuitInRain>false</shortCircuitInRain>
+				<soundPowerOn>Power_OnSmall</soundPowerOn>
+				<soundPowerOff>Power_OffSmall</soundPowerOff>
+			</li>
+			<li Class="CompProperties_Glower">
+				<glowRadius>9</glowRadius>
+				<glowColor>(78,226,229,0)</glowColor>
+			</li>
+		</comps>
+	</ThingDef>
+	
+	<ThingDef MayRequire="Ludeon.RimWorld.Ideology" ParentName="SK_StandingLampLED">
+		<defName>CeilingLEDDarkLamp</defName>
+		<label>ceiling LED dark lamp</label>
+		<thingClass>SK.Building_Lamp</thingClass>
+		<graphicData>
+			<texPath>Things/Building/Furniture/Lights/CeilingLamp</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<shadowData>
+				<volume>(0.2, 0.2, 0.2)</volume>
+				<offset>(0,0,0)</offset>
+			</shadowData>
+			<shaderType>Transparent</shaderType>
+		</graphicData>
+		<minifiedDef>MinifiedThing</minifiedDef>
+		<statBases>
+			<MaxHitPoints>35</MaxHitPoints>
+			<WorkToBuild>360</WorkToBuild>
+			<Beauty>10</Beauty>
+			<Bulk>7</Bulk>
+			<Mass>2</Mass>
+		</statBases>
+		<tickerType>Rare</tickerType>
+		<description>A ceiling LED lamp that lights an area. People need light to move and work at full speed. Must be placed under a roof. Requires 7 W.</description>
+		<costList>
+			<Plastic>10</Plastic>
+			<Glass>7</Glass>
+			<ComponentIndustrial>3</ComponentIndustrial>
+			<ElectronicComponents>1</ElectronicComponents>
+			<Electronics>1</Electronics>
+		</costList>
+		<building>
+			<uninstallWork>800</uninstallWork>
+			<isEdifice>false</isEdifice>
+			<canBuildNonEdificesUnder>true</canBuildNonEdificesUnder>
+		</building>
+		<clearBuildingArea>false</clearBuildingArea>
+		<comps Inherit="False">
+			<li Class="CompProperties_Flickable"/>
+			<li Class="CompProperties_Power">
+				<compClass>CompPowerTrader</compClass>
+				<basePowerConsumption>7</basePowerConsumption>
+				<shortCircuitInRain>true</shortCircuitInRain>
+				<soundPowerOn>Power_OnSmall</soundPowerOn>
+				<soundPowerOff>Power_OffSmall</soundPowerOff>
+			</li>
+			<li Class="CompProperties_Glower">
+				<glowRadius>7</glowRadius>
+				<glowColor>(78,226,229,0)</glowColor>
+			</li>
+			<li Class="SK.CompProperties_RestrictedPlacement">
+				<compClass>SK.CompRestrictedPlacement</compClass>
+			</li>
+		</comps>
+		<placeWorkers>
+			<li>SK.PlaceWorker_OnlyUnderRoof</li>
+		</placeWorkers>
+		<filthLeaving>Filth_BrokenGlass</filthLeaving>
+		<leaveResourcesWhenKilled>false</leaveResourcesWhenKilled>
+		<rotatable>false</rotatable>
 	</ThingDef>
 
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mechanoid.xml
@@ -452,8 +452,8 @@
 		<statBases>
 			<MoveSpeed>2.2</MoveSpeed>
 			<PsychicSensitivity>0.75</PsychicSensitivity>
-			<ArmorRating_Blunt>1.35</ArmorRating_Blunt>
-			<ArmorRating_Sharp>1.2</ArmorRating_Sharp>
+			<ArmorRating_Blunt>7.8</ArmorRating_Blunt>
+			<ArmorRating_Sharp>5.6</ArmorRating_Sharp>
 			<MeleeDodgeChance>0.15</MeleeDodgeChance>
 			<MeleeCritChance>0.05</MeleeCritChance>
 			<MeleeParryChance>0.15</MeleeParryChance>
@@ -465,10 +465,9 @@
 					<li>Blunt</li>
 				</capacities>
 				<power>17</power>
-				<cooldownTime>2.2</cooldownTime>
+				<cooldownTime>2.6</cooldownTime>
 				<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
-				<armorPenetrationSharp>0</armorPenetrationSharp>
-				<armorPenetrationBlunt>1.875</armorPenetrationBlunt>
+				<armorPenetrationBlunt>12</armorPenetrationBlunt>
 				<ensureLinkedBodyPartsGroupAlwaysUsable>true</ensureLinkedBodyPartsGroupAlwaysUsable>
 			</li>
 		</tools>

--- a/Mods/Core_SK/Ideology/Patches/HediffDefs/Hediffs_Casts.xml
+++ b/Mods/Core_SK/Ideology/Patches/HediffDefs/Hediffs_Casts.xml
@@ -1,0 +1,19 @@
+<Patch>
+
+	<Operation Class="PatchOperationSequence">
+		<success>Normal</success>
+		<operations>
+			<!-- Production command patches -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/HediffDef[defName="ProductionCommandBuff"]/stages/li[1]/statOffsets</xpath>
+				<value>
+					<SmithingSpeed>0.2</SmithingSpeed>
+					<TailoringSpeed>0.2</TailoringSpeed>
+					<StonecuttingSpeed>0.2</StonecuttingSpeed>
+					<ElectronicCraftingSpeed>0.1</ElectronicCraftingSpeed>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>

--- a/Mods/Core_SK/Ideology/Patches/PreceptDefs/Precepts_Role.xml
+++ b/Mods/Core_SK/Ideology/Patches/PreceptDefs/Precepts_Role.xml
@@ -1,0 +1,31 @@
+<Patch>
+
+	<Operation Class="PatchOperationSequence">
+		<success>Normal</success>
+		<operations>
+			<!-- Production specialist patches -->
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/PreceptDef[defName="IdeoRole_ProductionSpecialist"]/roleEffects</xpath>
+				<value>
+				  <li Class="RoleEffect_PawnStatOffset">
+					<statDef>SmithingSpeed</statDef>
+					<modifier>0.5</modifier>
+				  </li>
+				  <li Class="RoleEffect_PawnStatOffset">
+					<statDef>TailoringSpeed</statDef>
+					<modifier>0.5</modifier>
+				  </li>
+				  <li Class="RoleEffect_PawnStatOffset">
+					<statDef>StonecuttingSpeed</statDef>
+					<modifier>0.5</modifier>
+				  </li>
+				  <li Class="RoleEffect_PawnStatOffset">
+					<statDef>ElectronicCraftingSpeed</statDef>
+					<modifier>0.25</modifier>
+				  </li>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>

--- a/Mods/Core_SK/Ideology/Patches/TerrainDefs/Terrain_Floors.xml
+++ b/Mods/Core_SK/Ideology/Patches/TerrainDefs/Terrain_Floors.xml
@@ -1,0 +1,63 @@
+﻿<Patch>
+	<!-- Ideology floor bases patches -->
+	<Operation Class="PatchOperationSequence">
+		<success>Normal</success>
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TerrainDef[@Name="IdeoStoneTileBase"]/statBases/Beauty</xpath>
+				<value>
+					<Beauty>6</Beauty>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TerrainDef[@Name="IdeoCarpetBase"]/statBases/Beauty</xpath>
+				<value>
+					<Beauty>8</Beauty>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+	<!-- Ideology styles floor patches -->
+	<Operation Class="PatchOperationSequence">
+		<success>Normal</success>
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TerrainDef[defName="Plates_Spikecore"]/statBases/Beauty</xpath>
+				<value>
+					<Beauty>6</Beauty>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TerrainDef[defName="Plates_Spikecore"]/costList/Steel</xpath>
+				<value>
+					<Plasteel>12</Plasteel>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TerrainDef[defName="Boards_Totemic"]/statBases/Beauty</xpath>
+				<value>
+					<Beauty>6</Beauty>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TerrainDef[defName="Boards_Totemic"]/costList/WoodLog</xpath>
+				<value>
+					<WoodPlank>20</WoodPlank>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TerrainDef[defName="Tile_Transhumanist"]/statBases/Beauty</xpath>
+				<value>
+					<Beauty>6</Beauty>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/TerrainDef[defName="Tile_Transhumanist"]/costList/Steel</xpath>
+				<value>
+					<Plasteel>12</Plasteel>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>

--- a/Mods/Core_SK/Ideology/Patches/ThingDefs_Buildings/Buildings_Ideo.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingDefs_Buildings/Buildings_Ideo.xml
@@ -40,6 +40,14 @@
 					</costList>
 				</value>
 			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="Darklamp"]</xpath>
+				<value>
+					<researchPrerequisites>
+						<li>Light_C1</li>
+					</researchPrerequisites>
+				</value>
+			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="Darklamp"]/graphicData</xpath>
 				<value>

--- a/Mods/Core_SK/Ideology/Patches/ThingDefs_Buildings/Buildings_Misc.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingDefs_Buildings/Buildings_Misc.xml
@@ -67,6 +67,25 @@
 					</costList>
 				</value>
 			</li>
+			<!-- Slab beds patches -->
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SlabBed"]/costStuffCount</xpath>
+				<value>
+					<costStuffCount>60</costStuffCount>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SlabDoubleBed"]/costStuffCount</xpath>
+				<value>
+					<costStuffCount>120</costStuffCount>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="SlabBed" or defName="SlabDoubleBed"]/statBases/ImmunityGainSpeedFactor</xpath>
+				<value>
+					<ImmunityGainSpeedFactor>1</ImmunityGainSpeedFactor>
+				</value>
+			</li>
 			<!-- Autobong patches -->
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingDef[defName="Autobong"]/costList</xpath>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
@@ -27,7 +27,7 @@
 	<!-- Furniture -->
 	
 	<SubCategory_SpecialBeds.label>спец кровати</SubCategory_SpecialBeds.label> 
-	<SubCategory_SpecialBeds.description>Кровати со специальным назначением для одного человека - спальные мешки и гостевые кровати.</SubCategory_SpecialBeds.description>
+	<SubCategory_SpecialBeds.description>Кровати со специальным назначением - спальные мешки и гостевые кровати.</SubCategory_SpecialBeds.description>
 	
 	<SubCategory_StandartBeds.label>обычные кровати</SubCategory_StandartBeds.label> 
 	<SubCategory_StandartBeds.description>Обычные кровати для одного человека.</SubCategory_StandartBeds.description> 
@@ -49,6 +49,9 @@
 	
 	<SubCategory_ComfortableSeats.label>удобные стулья</SubCategory_ComfortableSeats.label> 
 	<SubCategory_ComfortableSeats.description>Стулья и кресла с повышенным комфортом.</SubCategory_ComfortableSeats.description> 
+	
+	<SubCategory_RoyaltyStuff.label>седалища знати</SubCategory_RoyaltyStuff.label> 
+	<SubCategory_RoyaltyStuff.description>Троны и ширмы для знатных особ.</SubCategory_RoyaltyStuff.description> 
 	
 	<SubCategory_TablesN.label>начальные столы</SubCategory_TablesN.label> 
 	<SubCategory_TablesN.description>Обеденные столы.</SubCategory_TablesN.description> 
@@ -101,6 +104,9 @@
 	
 	<SubCategory_Lamps.label>электрические лампы</SubCategory_Lamps.label> 
 	<SubCategory_Lamps.description>Лампы для освещения окружающей территории.</SubCategory_Lamps.description> 
+	
+	<SubCategory_DarkLamps.label>тусклые светильники</SubCategory_DarkLamps.label> 
+	<SubCategory_DarkLamps.description>Лампы и светильники для освещения окружающей территории тусклым светом. Освещаемая область и потребление ресурсов ниже, чем у нетусклых аналогов.</SubCategory_DarkLamps.description> 
 
 	<SubCategory_LEDLamps.label>светодиодные лампы</SubCategory_LEDLamps.label> 
 	<SubCategory_LEDLamps.description>Светодиодные лампы для освещения окружающей территории.</SubCategory_LEDLamps.description> 

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingDef/Buildings_Accessories.xml
@@ -50,6 +50,9 @@
 	<CeilingLamp.label>Потолочная лампа</CeilingLamp.label>
 	<CeilingLamp.description>Лампа для потолка, которая освещает большую площадь.\nНужна энергия.\nПотребляемая мощность: 80 W</CeilingLamp.description>	
 	
+	<CeilingDarkLamp.label>Тусклая потолочная лампа</CeilingDarkLamp.label>
+	<CeilingDarkLamp.description>Лампа для потолка, которая освещает некоторую площадь тусклым светом.\nНужна энергия.\nПотребляемая мощность: 30 W</CeilingDarkLamp.description>	
+	
 	<!--====================================== WallLights ======================================-->
 
 	<BowlLamp.label>Чаша для огня</BowlLamp.label> 
@@ -92,7 +95,13 @@
 	<StandingLampLEDlarge.description>Светодиодная напольная лампа для освещения большой площади.\nНужна энергия.\nПотребляемая мощность: 15 W</StandingLampLEDlarge.description>
 
 	<CeilingLEDLamp.label>Потолочная cветодиодная лампа</CeilingLEDLamp.label>
-	<CeilingLEDLamp.description>Светодиодная лампа для потолка, которая освещает большую площадь.\nНужна энергия.\nПотребляемая мощность: 10 W</CeilingLEDLamp.description>	
+	<CeilingLEDLamp.description>Светодиодная лампа для потолка, которая освещает небольшую площадь.\nНужна энергия.\nПотребляемая мощность: 10 W</CeilingLEDLamp.description>	
+
+	<StandingDarkLampLEDnormal.label>Тусклая светодиодная лампа</StandingDarkLampLEDnormal.label>
+	<StandingDarkLampLEDnormal.description>Светодиодная напольная лампа для освещения небольшой площади тусклым светом.\nНужна энергия.\nПотребляемая мощность: 7 W</StandingDarkLampLEDnormal.description>
+
+	<CeilingLEDDarkLamp.label>Тусклая потолочная cветодиодная лампа</CeilingLEDDarkLamp.label>
+	<CeilingLEDDarkLamp.description>Светодиодная лампа для потолка, которая освещает небольшую площадь тусклым светом.\nНужна энергия.\nПотребляемая мощность: 7 W</CeilingLEDDarkLamp.description>	
 
 
 	<!-- ============== SQUARE FLOOR LIGHTS ============== -->

--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
@@ -1,8 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingDef Class="NewRatkin.CustomThingDef" Name="RK_ApparelBase" Abstract="True">	
-		<!-- <followStuffColor>false</followStuffColor> -->
+	<ThingDef Class="NewRatkin.CustomThingDef" Name="RK_ApparelBase" Abstract="True">
 		<thingClass>Apparel</thingClass>
 		<category>Item</category>
 		<selectable>True</selectable>
@@ -57,14 +56,7 @@
 		</thingCategories>
 	</ThingDef>
 
-	<!-- <colorGenerator Class="ColorGenerator_Single"> -->
-	<!-- <color>(1,1,1,1)</color> -->
-	<!-- </colorGenerator> -->
 
-
-	<!-- 의류 기본온도저항 추위+4 더위2 -->	
-	<!-- 1티어 -->
-	<!-- 기본 옷 재배속도+5% 요리속도 +5% -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_ApronSkirt</defName>
 		<label>apron skirt</label>
@@ -72,7 +64,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_ApronSkirt</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<statBases>
 			<MaxHitPoints>65</MaxHitPoints>
@@ -131,9 +122,7 @@
             <researchPrerequisite>Ratkin_Apparel_B1</researchPrerequisite>
         </recipeMaker>
 	</ThingDef>
-	
-	<!-- MildCoat -->
-	
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_MildCoat</defName>
 		<label>mild coat</label>
@@ -196,8 +185,7 @@
             <researchPrerequisite>Ratkin_Apparel_B1</researchPrerequisite>
         </recipeMaker>
 	</ThingDef>
-	<!-- 더위저항 +12 -->
-	<!-- 여름드레스 더위저항 +7 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_SummerDress</defName>
 		<label>summer dress</label>
@@ -205,7 +193,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_SummerDress</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<statBases>
 			<MaxHitPoints>50</MaxHitPoints>
@@ -258,7 +245,7 @@
             <researchPrerequisite>Ratkin_Apparel_B2</researchPrerequisite>
         </recipeMaker>
 	</ThingDef>
-	<!-- 여름모자 더위저항 +5 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_StrawHat</defName>
 		<label>Straw Hat</label>
@@ -266,7 +253,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_StrawHat</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<Hay>30</Hay>
@@ -289,6 +275,7 @@
 			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>						
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>
@@ -318,8 +305,6 @@
         </recipeMaker>
 	</ThingDef>
 
-	<!-- 추위저항15 -->
-	<!-- 머플러 추위저항 +4 -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_Muffler</defName>
 		<label>muffler</label>
@@ -380,7 +365,7 @@
             <researchPrerequisite>Ratkin_Apparel_B1</researchPrerequisite>
         </recipeMaker>
 	</ThingDef>
-	<!-- 가디건 추위저항 +6 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_Cardigan</defName>
 		<label>cardigan</label>
@@ -439,33 +424,11 @@
 				<li>Shell</li>
 			</layers>
 		</apparel>
-<!-- 		<colorGenerator Class="ColorGenerator_Options">
-			<options>
-				<li>
-					<weight>10</weight>
-					<only>(0.33,0.33,0.33,1)</only>
-				</li>
-				<li>
-					<weight>10</weight>
-					<only>(0.65,0.65,0.65,1)</only>
-				</li>
-				<li>
-					<weight>6</weight>
-					<min>(0.3,0.3,0.3,1)</min>
-					<max>(0.5,0.5,0.5,1)</max>
-				</li>
-				<li>
-					<weight>10</weight>
-					<only>(0.9,0.9,0.9,1)</only>
-				</li>
-			</options>
-		</colorGenerator> -->
-		<!-- <followStuffColor>true</followStuffColor> -->
         <recipeMaker>
             <researchPrerequisite>Ratkin_Apparel_B2</researchPrerequisite>
         </recipeMaker>
 	</ThingDef>
-	<!-- 털모자 추위저항 +5 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_WoolenHat</defName>
 		<label>woolen hat</label>
@@ -499,6 +462,7 @@
 			<GermContainment>0.05</GermContainment>
 		</equippedStatOffsets>						
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>			
@@ -528,7 +492,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_CrossBack</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costStuffCount>35</costStuffCount>
 		<stuffCategories>
@@ -551,7 +514,6 @@
 			<EquipDelay>1.6</EquipDelay>
 		</statBases>
 		<equippedStatOffsets>
-			<!-- <SurvivalToolCarryCapacity>1</SurvivalToolCarryCapacity> -->		
 			<CarryingCapacity>15</CarryingCapacity>
 			<CarryBulk>20</CarryBulk>
 			<MoveSpeed>-0.06</MoveSpeed>
@@ -560,6 +522,7 @@
 			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>Shoulders</li>
 			</bodyPartGroups>
@@ -583,10 +546,6 @@
         </recipeMaker>
 	</ThingDef>
 
-
-	<!-- 의류 기본온도저항 추위+5 더위3 -->
-	<!-- 2티어 -->
-	<!-- 가방  운반용량 +20 -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_Backpack</defName>
 		<label>backpack</label>
@@ -594,7 +553,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_Backpack</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker>
 			<researchPrerequisite>Ratkin_Apparel_B2</researchPrerequisite>
@@ -619,7 +577,6 @@
 			<EquipDelay>2</EquipDelay>
 		</statBases>
 		<equippedStatOffsets>
-			<!-- <SurvivalToolCarryCapacity>1</SurvivalToolCarryCapacity> -->
 			<CarryingCapacity>20</CarryingCapacity>
 			<CarryBulk>25</CarryBulk>
 			<MoveSpeed>-0.09</MoveSpeed>
@@ -628,6 +585,7 @@
 			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>Shoulders</li>
 			</bodyPartGroups>
@@ -647,7 +605,6 @@
 		</apparel>
 	</ThingDef>
 
-	<!-- 작업복  재단 속도 +10% 요리속도 +5% 재배속도 5% 언스킬드속도 +5% 동물수집속도 +5%-->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_WorkerWear</defName>
 		<label>Ratkin worker outfit</label>
@@ -655,7 +612,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_WorkerWear</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<statBases>
 			<MaxHitPoints>70</MaxHitPoints>
@@ -677,7 +633,6 @@
 			<li>Leathery</li>
 		</stuffCategories>	
 		<equippedStatOffsets>
-			<!-- <SurvivalToolCarryCapacity>1</SurvivalToolCarryCapacity> -->
 			<CarryBulk>18</CarryBulk>
 			<MoveSpeed>0.04</MoveSpeed>
 			<WorkSpeedGlobal>0.05</WorkSpeedGlobal>
@@ -715,7 +670,7 @@
 			<researchPrerequisite>Ratkin_Apparel_B2</researchPrerequisite>
 		</recipeMaker>
 	</ThingDef>
-	<!-- 작업모  식중독 예방 +5% 동물채집량 +5% -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_Coif</defName>
 		<label>coif</label>
@@ -723,7 +678,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_Coif</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costStuffCount>30</costStuffCount>
 		<stuffCategories>
@@ -753,6 +707,7 @@
 			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>
@@ -773,7 +728,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 연구가운 연구 속도 +10% 수술속도 +5% 치료속도 +5% 약조리속도 +5% 제약속도 +5%-->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_ResearchGown</defName>
 		<label>research gown</label>
@@ -781,7 +735,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_ResearchGown</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<Cloth>25</Cloth>
@@ -852,7 +805,7 @@
 			<researchPrerequisite>Ratkin_Apparel_C1</researchPrerequisite>
 		</recipeMaker>
 	</ThingDef>
-	<!-- 공돌이 수술 성공률 +5% 치료품질 +5%-->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_ResearchGlasses</defName>
 		<label>ratkin glasses</label>
@@ -860,7 +813,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_ResearchGlasses</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<ComponentIndustrial>3</ComponentIndustrial>
@@ -892,6 +844,7 @@
 			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 				<li>Eyes</li>
@@ -916,7 +869,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 탐험복 이동속도 +0.2 더위저항 +10 스탤스효과 +7% 조련확률 +5% 훈련확률 +5% 근접회피 +5%-->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_ExplorerWear</defName>
 		<label>explorer wear</label>
@@ -924,7 +876,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_ExplorerWear</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker>
 			<researchPrerequisite>Ratkin_Apparel_C1</researchPrerequisite>
@@ -990,7 +941,7 @@
 			</tags>
 		</apparel>
 	</ThingDef>
-	<!-- 탐험모 이동속도+0.1 더위저항 +10 스탤스효과 +3% -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_ExplorerHat</defName>
 		<label>explorer hat</label>
@@ -998,7 +949,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_ExplorerHat</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costStuffCount>35</costStuffCount>
 		<stuffCategories>
@@ -1028,6 +978,7 @@
 			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>
@@ -1050,7 +1001,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 쉐프복 요리속도 +15% 해체속도 +5% -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_ChefSuit</defName>
 		<label>chef suit</label>
@@ -1058,7 +1008,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_ChefSuit</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker>
 			<researchPrerequisite>Ratkin_Apparel_C1</researchPrerequisite>
@@ -1121,7 +1070,7 @@
 			</tags>
 		</apparel>
 	</ThingDef>
-	<!-- 쉐프모자 식중독예방 +12% -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_ChefHat</defName>
 		<label>chef hat</label>
@@ -1129,7 +1078,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_ChefHat</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<Cloth>15</Cloth>
@@ -1163,6 +1111,7 @@
 			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>
@@ -1185,7 +1134,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 정원복 수확속도 +15% 수확량 +5% 근접정확도 +5% 근접회피 +10% 이동속도 +0.1 -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_GaurdenUniform</defName>
 		<label>gaurden uniform</label>
@@ -1193,7 +1141,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_GardenWear</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<Plasteel>35</Plasteel>
@@ -1263,7 +1210,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 겨울외투 사회적영향력 5% 추위저항 +35 -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_WinterRobe</defName>
 		<label>winter robe</label>
@@ -1271,7 +1217,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_WinterRobe</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker>
 			<researchPrerequisite>Ratkin_Apparel_C1</researchPrerequisite>
@@ -1334,10 +1279,6 @@
 		</apparel>
 	</ThingDef>
 
-
-	<!-- 의류 기본온도저항 추위+7 더위+5 -->
-	<!-- 3티어 -->
-	<!-- 군용가방 +30 내구도 +20 -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_OutdoorBackpack</defName>
 		<label>ratkin outdoor backpack</label>
@@ -1345,7 +1286,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_OutdoorBackpack</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker>
 			<researchPrerequisite>Ratkin_Apparel_C1</researchPrerequisite>
@@ -1380,6 +1320,7 @@
 			<GermContainment>0.03</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>Shoulders</li>
 			</bodyPartGroups>
@@ -1397,7 +1338,7 @@
 			</tags>
 		</apparel>
 	</ThingDef>
-	<!-- 제복 사회적영향력 +5% 근접회피찬스 5% 정신임계점 +5% 고통임계점 +10% 날카로움방어 좋은수준-->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" Name="RK_OrderBase" ParentName="RK_ApparelMakeableBase" Abstract="True">
 		<label>ratkin order uniform</label>
 		<description>랫킨식 제식 전투복입니다. 랫킨식 전투에 유리하도록 디자인된 의류입니다. 착용자에게 약간의 고양감을 주어 강인한 전투원으로 만들어줍니다.</description>
@@ -1488,7 +1429,7 @@
 			<wornGraphicPath>Apparel/RK_OrderUniformB</wornGraphicPath>
 		</apparel>
 	</ThingDef>
-	<!-- 방탄모자 조준속도 +10% 사격정확도 +5% 날카로움방어 좋은수준-->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_BulletProofHelmet</defName>
 		<label>Ratkin military helmet</label>
@@ -1496,7 +1437,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_BulletProofHelmet</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<DevilstrandCloth>25</DevilstrandCloth>
@@ -1532,6 +1472,7 @@
 			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 				<li>Eyes</li>
@@ -1556,7 +1497,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 플랫칼라코트 사회적영향력 +10% 협상 +10%  -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_FlatColorCoat</defName>
 		<label>flatcolor coat</label>
@@ -1564,7 +1504,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_FlatColorCoat</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<DevilstrandCloth>35</DevilstrandCloth>
@@ -1629,7 +1568,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 프릴원피스 거래가격개선 +10% 협상 +10%  -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_FrillOnepiece</defName>
 		<label>frill onepiece</label>
@@ -1637,7 +1575,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_FrillOnepiece</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<DevilstrandCloth>35</DevilstrandCloth>
@@ -1702,7 +1639,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 코사주 사회적 영향력 10% -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_HairCorsage</defName>
 		<label>hair corsage</label>
@@ -1710,7 +1646,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_HairCorsage</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<DevilstrandCloth>20</DevilstrandCloth>
@@ -1732,6 +1667,7 @@
 			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>
@@ -1754,7 +1690,7 @@
 			<researchPrerequisite>Ratkin_Apparel_C1</researchPrerequisite>
 		</recipeMaker>
 	</ThingDef>
-	<!-- 리본 거래가격 개선 +10% -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_RibbonHairBand</defName>
 		<label>ribbon hair band</label>
@@ -1762,7 +1698,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_RibbonHairBand</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<DevilstrandCloth>20</DevilstrandCloth>
@@ -1784,6 +1719,7 @@
 			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>
@@ -1806,7 +1742,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 수녀복 사회적영향력 +10% 치료속도 +10%  -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_SistersDerss</defName>
 		<label>Sisters Dress</label>
@@ -1814,7 +1749,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_SistersDerss</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<DevilstrandCloth>35</DevilstrandCloth>
@@ -1880,7 +1814,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-	<!-- 수녀모자 치료품질 +10% -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_SistersVeil</defName>
 		<label>Veil</label>
@@ -1888,7 +1821,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_SistersVeil</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<DevilstrandCloth>20</DevilstrandCloth>
@@ -1922,6 +1854,7 @@
 			<GermContainment>0.20</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>
@@ -1945,9 +1878,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-
-	<!-- 번외 -->
-	<!-- 랫킨 귀 헤어밴드 사회적영향력 +5% -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_EarCostume</defName>
 		<label>ratkin ear costume</label>
@@ -1978,6 +1908,7 @@
 			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>
@@ -1997,9 +1928,6 @@
 		</recipeMaker>
 	</ThingDef>
 
-
-	<!-- 적대 세력 한정 -->
-	<!-- 도둑질 보따리 +50 내구도 +20 -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_Sack</defName>
 		<label>ratkin package</label>
@@ -2007,7 +1935,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_Sack</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker Inherit="false">
 		</recipeMaker>
@@ -2037,6 +1964,7 @@
 			<GermContainment>0.01</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>Shoulders</li>
 			</bodyPartGroups>
@@ -2058,7 +1986,6 @@
 		</tradeTags>
 	</ThingDef>
 
-	<!-- 특수 부대 복장-->
 	<ThingDef Class="NewRatkin.CustomThingDef" Name="RK_BattleSuitBase" ParentName="RK_ApparelMakeableBase" Abstract="True">
 		<label>ratkin battlesuit</label>
 		<description>침투에 유리하도록 디자인된 전투복입니다. 극한의 온도상황에서 활동할 수 있도록 설계되어있습니다.</description>
@@ -2158,7 +2085,7 @@
 			<wornGraphicPath>Apparel/RK_BattleSuitB</wornGraphicPath>
 		</apparel>
 	</ThingDef>
-	<!-- 가스마스크-->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" Name="RK_MaskBase" ParentName="RK_HatMakeableBase" Abstract="True">
 		<label>Ratkin mask helmet</label>
 		<description>마스크가 있는 헬멧입니다. 유독성 환경에서도 장시간 활동할 수 있도록 고안되었습니다.</description>
@@ -2257,7 +2184,7 @@
 			</tags>
 		</apparel>
 	</ThingDef>
-	<!-- 특공 머리띠 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_HeadBand</defName>
 		<label>Ratkin head band</label>
@@ -2290,6 +2217,7 @@
 			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>
@@ -2309,7 +2237,6 @@
 		</tradeTags>
 	</ThingDef>
 
-	<!-- 판금 갑옷 높은 날카로움, 둔탁함 방어력, 느려짐-->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_Plate</defName>
 		<label>ratkin plate armor</label>
@@ -2317,7 +2244,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_Plate</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
@@ -2396,7 +2322,7 @@
 		</apparel>
 		<followStuffColor>True</followStuffColor>
 	</ThingDef>
-	<!-- 판금 투구 높은 날카로움, 둔탁함 방어력, 느려짐-->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_PlateHelmA</defName>
 		<label>Ratkin plate Helm</label>
@@ -2404,7 +2330,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_PlateHelmet1</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<Plasteel>25</Plasteel>
@@ -2475,7 +2400,7 @@
 		</recipeMaker>
 		<followStuffColor>true</followStuffColor>
 	</ThingDef>
-	<!-- 투구 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_PlateHelmB</defName>
 		<label>Ratkin plate Helm</label>
@@ -2483,7 +2408,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_PlateHelmet2</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<Plasteel>25</Plasteel>
@@ -2555,7 +2479,7 @@
 		</recipeMaker>
 		<followStuffColor>true</followStuffColor>
 	</ThingDef>
-	<!-- 투구 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_PlateHelmC</defName>
 		<label>Ratkin plate Helm</label>
@@ -2563,7 +2487,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_PlateHelmet3</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<Plasteel>25</Plasteel>
@@ -2635,8 +2558,6 @@
 		<followStuffColor>true</followStuffColor>
 	</ThingDef>	
 
-
-	<!-- 목제 방패 -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="Shield_Base">
 		<defName>RK_WoodenShield</defName>
 		<label>ratkin wooden Shield</label>
@@ -2644,7 +2565,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_WoodenShield</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
@@ -2687,6 +2607,7 @@
 			<MeleeParryChance>0.75</MeleeParryChance>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>Torso</li>
 				<li>Shoulders</li>
@@ -2724,7 +2645,6 @@
 		<followStuffColor>True</followStuffColor>
 	</ThingDef>
 
-	<!-- 철제 방패 -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="Shield_Base">
 		<defName>RK_HeavyShield</defName>
 		<label>ratkin heavy Shield</label>
@@ -2732,7 +2652,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_HeavyShield</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker>
 			<unfinishedThingDef>UnfinishedArmor</unfinishedThingDef>
@@ -2782,6 +2701,7 @@
 			<MeleeParryChance>1</MeleeParryChance>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<!-- <bodyPartGroups>
 				<li>Torso</li>
 				<li>Neck</li>
@@ -2825,7 +2745,6 @@
 		<followStuffColor>True</followStuffColor>
 	</ThingDef>
 
-	<!-- 산타외투 -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_SantaRobe</defName>
 		<label>santa robe</label>
@@ -2896,7 +2815,7 @@
 		<tradeTags Inherit="false">
 		</tradeTags>
 	</ThingDef>
-	<!-- 산타 모자 추위저항 +5 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_SantaHat</defName>
 		<label>santa hat</label>
@@ -2938,6 +2857,7 @@
 			<GermContainment>0.04</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>			
@@ -2959,7 +2879,7 @@
 		<tradeTags Inherit="false">
 		</tradeTags>
 	</ThingDef>
-	<!-- 산타 보따리 +50 내구도 +20 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_SantaSack</defName>
 		<label>santa package</label>
@@ -2999,6 +2919,7 @@
 			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>Shoulders</li>
 			</bodyPartGroups>
@@ -3019,7 +2940,6 @@
 		</tradeTags>
 	</ThingDef>
 
-	<!-- 드랍 외투  -->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_WhiteCoat</defName>
 		<label>ratkin white coat</label>
@@ -3086,9 +3006,8 @@
 			</tags>
 		</apparel>
 	</ThingDef>
-	
+
 	<!-- DLC -->
-	<!-- 로열 외투-->
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_ApparelMakeableBase">
 		<defName>RK_RoyalRobe</defName>
 		<label>ratkin royal robe</label>
@@ -3096,7 +3015,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_RoyalRobe</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<recipeMaker>
 			<researchPrerequisite>Ratkin_Apparel_B2</researchPrerequisite>
@@ -3155,8 +3073,7 @@
 			</tags>
 		</apparel>
 	</ThingDef>
-	
-	<!-- 왕관 -->
+
 	<ThingDef Class="NewRatkin.CustomThingDef" ParentName="RK_HatMakeableBase">
 		<defName>RK_RoyalCrown</defName>
 		<label>Ratkin royal crown</label>
@@ -3164,7 +3081,6 @@
 		<graphicData>
 			<texPath>Apparel/RK_RoyalCrown</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-			<!-- <shaderType>CutoutComplex</shaderType> -->
 		</graphicData>
 		<costList>
 			<Plasteel>25</Plasteel>
@@ -3193,6 +3109,7 @@
 			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
 		<apparel>
+			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
 				<li>UpperHead</li>
 			</bodyPartGroups>


### PR DESCRIPTION
1 correted Termite mech params (added more armor and cost points);
2 patched new Ideology floors and some furnitures to HSK materials and params;
3 added nudist tag <countsAsClothingForNudity>false</countsAsClothingForNudity> for some ratkin's apparels;
4 added new dark light sub category for dark torches and lamps;
5 added few simple and LED lamps analogs with dark light;
6 added new Royalty sub category for thrones and drapes;
7 added new armor rack sub category in storage category;
8 added HSK work types to production specialist buff.

1 скорректированы параметры механоида Термита (броня и стоимость);
2 пропатчены параметры новых полов и некоторой мебели;
3 добавлен тег <countsAsClothingForNudity>false</countsAsClothingForNudity> некоторой одежде раткинов для учета идеологии нудизма;
4 добавлена новая подкатегория тусклых светильников для тусклых факелов и ламп;
5 добавлено парочку обычных и светодиодных тусклых аналогов существующих ламп;
6 добавлена новая подкатегория для тронов и ширм Royalty;
7 добавлена новая подкатегория для стоек в категорию хранилищ;
8 добавлены бонусы к типам производственных работ ХСК для роли специалиста по производству и его ауры.