### PR TITLE
Some pawns tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Accessories.xml
@@ -570,6 +570,7 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>SpacerMilitary</li>
 				<li>AsariPowerArmor</li>
 				<li>Military</li>
 				<li>BrotherhoodMedium</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Industrial.xml
@@ -60,6 +60,7 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryBasic</li>
 				<li>BrotherhoodLight</li>
 				<li>SectarianLight</li>
 				<li>SectarianMedium</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Armor_Medieval.xml
@@ -225,6 +225,7 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>IndustrialBasic</li>
 				<li>Outlander</li>
 				<li>BanditsLight</li>
 				<li>RenegadesLight</li>
@@ -397,6 +398,7 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>IndustrialBasic</li>
 				<li>Outlander</li>
 				<li>BanditsLight</li>
 				<li>RenegadesLight</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Boots.xml
@@ -113,6 +113,7 @@
 			</layers>
 			<tags>
 				<li>Colonist</li>
+				<li>IndustrialBasic</li>
 				<li>Outlander</li>
 				<li>BanditsLight</li>
 				<li>RenegadesLight</li>
@@ -470,6 +471,7 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>IndustrialAdvanced</li>
 				<li>BrotherhoodLight</li>
 				<li>BrotherhoodScout</li>
 				<li>BrotherhoodMedium</li>
@@ -539,6 +541,7 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryBasic</li>
 				<li>OrassanTacticalSuit</li>
 				<li>BrotherhoodLight</li>
 				<li>BrotherhoodScout</li>
@@ -611,6 +614,7 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>SpacerMilitary</li>
 				<li>SyndicateMedium</li>
 				<li>SyndicateLight</li>
 				<li>OrionScout</li>
@@ -687,6 +691,8 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryAdvanced</li>
+				<li>SpacerMilitary</li>
 				<li>SyndicateMedium</li>
 				<li>SyndicateLight</li>
 				<li>OrionScout</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Industrial.xml
@@ -51,7 +51,7 @@
 			<GermResistance>0.04</GermResistance>
 			<GermContainment>0.02</GermContainment>
 		</equippedStatOffsets>
-		<generateCommonality>2</generateCommonality>
+		<generateCommonality>1.5</generateCommonality>
 		<apparel>
 			<bodyPartGroups>
 				<li>Torso</li>
@@ -66,6 +66,7 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>BrotherhoodMedium</li>
 				<li>SectarianMedium</li>
 				<li>OrassanTacticalSuit</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Fullarmor_Spacer.xml
@@ -77,6 +77,7 @@
 			<tags>
 				<li>Spacer</li>
 				<li>Military</li>
+				<li>SpacerMilitary</li>
 				<li>SyndicateMedium</li>
 				<li>AsariPowerArmor</li>
 				<li>OrionMedium</li>
@@ -715,6 +716,7 @@
 				<li>Shell</li>
 			</layers>
 			<tags>
+				<li>SpacerMilitary</li>
 				<li>SyndicateScout</li>
 				<li>OrionScout</li>
 			</tags>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Gloves.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Gloves.xml
@@ -124,6 +124,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialBasic</li>
 				<li>Outlander</li>
 				<li>BanditsLight</li>
 				<li>RenegadesLight</li>
@@ -348,6 +349,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryBasic</li>
 				<li>Outlander</li>
 				<li>RenegadesLight</li>
 				<li>RenegadesMedium</li>
@@ -495,6 +497,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryBasic</li>
 				<li>OrassanTacticalSuit</li>
 				<li>BrotherhoodUnique</li>
 				<li>BrotherhoodScout</li>
@@ -569,6 +572,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>OrassanTacticalSniper</li>
 				<li>SyndicateMedium</li>
 				<li>OrionScout</li>
@@ -875,6 +879,8 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryAdvanced</li>
+				<li>SpacerMilitary</li>
 				<li>SyndicateUnique</li>
 				<li>OrionUnique</li>
 				<li>OrionScout</li>
@@ -1030,6 +1036,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>SpacerMilitary</li>
 				<li>SyndicateUnique</li>
 				<li>OrionUnique</li>
 				<li>AsariCommando</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Industrial.xml
@@ -401,6 +401,7 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryBasic</li>
 				<li>BrotherhoodLight</li>
 				<li>SectarianLight</li>
 			</tags>
@@ -491,6 +492,7 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>BrotherhoodLight</li>
 				<li>SectarianScout</li>
 			</tags>
@@ -574,6 +576,7 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>SectarianLight</li>
 				<li>OrionLight</li>
 				<li>OrassanTacticalSuit</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Spacer.xml
@@ -68,6 +68,7 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>SpacerMilitary</li>
 				<li>AsariPowerArmor</li>
 				<li>SyndicateMedium</li>
 				<li>OrionMedium</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Industrial.xml
@@ -51,6 +51,7 @@
 			</layers>
 			<tags>
 				<li>Military</li>
+				<li>IndustrialMilitaryBasic</li>
 				<li>BrotherhoodMedium</li>
 				<li>EmpireMedium</li>
 				<li>OrassanTacticalEngineer</li>
@@ -118,6 +119,7 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>BrotherhoodMedium</li>
 				<li>SectarianMedium</li>
 			</tags>
@@ -183,6 +185,8 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryBasic</li>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>SectarianMedium</li>
 				<li>OrassanTacticalSniper</li>
 				<li>OrassanTacticalDemolisher</li>
@@ -322,6 +326,7 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryBasic</li>
 				<li>SectarianMedium</li>
 			</tags>
 			<defaultOutfitTags>
@@ -449,6 +454,7 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>IndustrialBasic</li>
 				<li>CryptosleepSpacer</li>
 				<li>Outlander</li>
 				<li>BanditsLight</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Spacer.xml
@@ -250,6 +250,7 @@
 				<li>Overhead</li>
 			</layers>
 			<tags>
+				<li>SpacerMilitary</li>
 				<li>OrionScout</li>
 				<li>SyndicateScout</li>
 			</tags>
@@ -598,6 +599,9 @@
 			</layers>
 			<tags>
 				<li>Military</li>
+				<li>IndustrialMilitaryBasic</li>
+				<li>IndustrialMilitaryAdvanced</li>
+				<li>SpacerMilitary</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Worker</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Kits.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Kits.xml
@@ -53,6 +53,7 @@
 			<tags>
 				<li>Outlander</li>
 				<li>Military</li>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>OrionLight</li>
 				<li>OrionMedium</li>
 				<li>OrionScout</li>
@@ -221,6 +222,8 @@
 			<tags>
 				<li>Outlander</li>
 				<li>Military</li>
+				<li>IndustrialAdvanced</li>
+				<li>IndustrialMilitaryBasic</li>
 				<li>OrionLight</li>
 				<li>OrionMedium</li>
 				<li>OrionScout</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs.xml
@@ -324,6 +324,7 @@
 			</layers>
 			<tags>
 				<li>Colonist</li>
+				<li>IndustrialBasic</li>
 				<li>Outlander</li>
 				<li>BanditsLight</li>
 				<li>EmpireScout</li>
@@ -485,6 +486,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialBasic</li>
 				<li>Outlander</li>
 				<li>RenegadesLight</li>
 				<li>PredatorsScout</li>
@@ -558,6 +560,8 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryBasic</li>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>Outlander</li>
 				<li>RenegadesMedium</li>
 				<li>PredatorsMedium</li>
@@ -630,6 +634,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialAdvanced</li>
 				<li>Outlander</li>
 				<li>EmpireLight</li>
 				<li>RenegadesLight</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Legs_Hightech.xml
@@ -58,6 +58,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialAdvanced</li>
 				<li>Outlander</li>
 				<li>PredatorsMedium</li>
 				<li>BrotherhoodMedium</li>
@@ -132,6 +133,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>SpacerMilitary</li>
 				<li>SyndicateMedium</li>
 				<li>SyndicateLight</li>
 				<li>OrionScout</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_NightVision.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_NightVision.xml
@@ -44,6 +44,7 @@
 			<tags>
 				<li>IndustrialMilitaryAdvanced</li>
 				<li>UniqueIndustrial</li>
+				<li>NightVisionApparel</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Soldier</li>
@@ -105,6 +106,7 @@
 			<tags>
 				<li>IndustrialMilitaryAdvanced</li>
 				<li>UniqueIndustrial</li>
+				<li>NightVisionApparel</li>
 			</tags>
 			<defaultOutfitTags>
 				<li>Soldier</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Medieval.xml
@@ -343,6 +343,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialBasic</li>
 				<li>Outlander</li>
 				<li>BanditsLight</li>
 				<li>PredatorsLight</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Sheets_Spacer.xml
@@ -58,6 +58,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>BrotherhoodLight</li>
 				<li>BrotherhoodMedium</li>
 				<li>SectarianLight</li>
@@ -332,6 +333,7 @@
 				<li>OnSkin</li>
 			</layers>
 			<tags>
+				<li>IndustrialAdvanced</li>
 				<li>SyndicateMedium</li>
 				<li>SyndicateLight</li>
 				<li>SyndicateMelee</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_SlaveOutfit.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_SlaveOutfit.xml
@@ -493,6 +493,7 @@
 				<li>Worker</li>
 			</defaultOutfitTags>
 			<tags>
+				<li>IndustrialBasic</li>
 				<li>Outlander</li>
 				<li>Slaver</li>
 			</tags>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
@@ -674,6 +674,7 @@
 				<li>Middle</li>
 			</layers>
 			<tags>
+				<li>IndustrialMilitaryBasic</li>
 				<li>Outlander</li>
 				<li>Military</li>
 			</tags>
@@ -749,6 +750,7 @@
 			</layers>
 			<tags>
 				<li>Military</li>
+				<li>IndustrialMilitaryAdvanced</li>
 				<li>BrotherhoodLight</li>
 				<li>BrotherhoodMedium</li>
 				<li>SectarianLight</li>
@@ -846,6 +848,7 @@
 				<li>Middle</li>			
 			</layers>
 			<tags>
+				<li>SpacerMilitary</li>
 				<li>SyndicateMedium</li>
 				<li>SyndicateLight</li>
 				<li>OrionMedium</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Ore.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Ore.xml
@@ -111,6 +111,9 @@
 			<categories>
 				<li>Matty</li>
 			</categories>
+			<statFactors>
+				<Flammability>0.1</Flammability>
+			</statFactors>
 		</stuffProps>
 		<terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
 		<deepCommonality>2.5</deepCommonality>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Blasters.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Blasters.xml
@@ -158,6 +158,7 @@
 		<weaponTags>
 			<li>ADR2</li>
 			<li>AdvancedGun</li>
+			<li>SpacerGun</li>
 			<li>TierTwoHigh</li>
 			<li>Futuristic</li>
 			<li>CE_AI_Rifle</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Chargeblasters.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Chargeblasters.xml
@@ -23,6 +23,7 @@
         <weaponTags>
             <li>ADR2</li>
             <li>AdvancedGun</li>
+			<li>SpacerGun</li>
             <li>TierTwoNormal</li>
             <li>Futuristic</li>
             <li>CE_AI_Rifle</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Lasers.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Lasers.xml
@@ -80,6 +80,7 @@
         <weaponTags>
             <li>ADR1</li>
             <li>AdvancedGun</li>
+			<li>SpacerGun</li>
             <li>TierTwoLow</li>
             <li>Futuristic</li>
             <li>CE_AI_Rifle</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Launchers.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Launchers.xml
@@ -25,6 +25,7 @@
         <weaponTags>
             <li>RKT1</li>
             <li>Glaunchers</li>
+			<li>EmpireGrenadeDestructive</li>
             <li>CE_AI_Rifle</li>
             <li>CE_AI_Launcher</li>
             <li>EliteGun</li>
@@ -172,6 +173,7 @@
             <li>Glaunchers</li>
             <li>CE_AI_Rifle</li>
             <li>CE_AI_Launcher</li>
+			<li>EmpireGrenadeDestructive</li>
         </weaponTags>
         <tradeTags>
             <li>Exotic</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Plasma.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Plasma.xml
@@ -166,6 +166,7 @@
         <weaponTags>
             <li>ADR2</li>
             <li>AdvancedGun</li>
+			<li>SpacerGun</li>
             <li>TierTwoNormal</li>
             <li>Futuristic</li>
             <li>CE_AI_Rifle</li>

--- a/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_Ideology.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_Ideology.xml
@@ -19,7 +19,7 @@
 		<value>
 			<Bulk>6</Bulk>
 			<WornBulk>2.5</WornBulk>
-			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 
@@ -30,7 +30,7 @@
 		<value>
 			<Bulk>5</Bulk>
 			<WornBulk>2</WornBulk>
-			<StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 

--- a/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_IdeologyHeadgear.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_IdeologyHeadgear.xml
@@ -6,7 +6,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Headwrap" or defName="Apparel_Broadwrap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
     </value>
   </Operation>
 
@@ -24,7 +24,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Slicecap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>3</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
     </value>
   </Operation>
 
@@ -34,7 +34,14 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Collar"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationReplace">
+    <xpath>Defs/ThingDef[defName="Apparel_Collar"]/apparel/canBeDesiredForIdeo</xpath>
+    <value>
+		<canBeDesiredForIdeo>true</canBeDesiredForIdeo>
     </value>
   </Operation>
 
@@ -53,7 +60,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Tailcap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
     </value>
   </Operation>
 
@@ -62,7 +69,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Shadecone"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>5</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
     </value>
   </Operation>
 

--- a/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Race_Animal_Dryads.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Race_Animal_Dryads.xml
@@ -30,8 +30,8 @@
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>5</power>
-					<cooldownTime>0.99</cooldownTime>
+					<power>8</power>
+					<cooldownTime>2</cooldownTime>
                     <surpriseAttack>
                         <extraMeleeDamages>
                         <li>
@@ -41,16 +41,16 @@
                         </extraMeleeDamages>
                     </surpriseAttack>                    
 					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.03</armorPenetrationSharp>
+					<armorPenetrationBlunt>1</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.5</armorPenetrationSharp>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right claw</label>
 					<capacities>
 						<li>Scratch</li>
 					</capacities>
-					<power>5</power>
-					<cooldownTime>0.99</cooldownTime>
+					<power>8</power>
+					<cooldownTime>2</cooldownTime>
                     <surpriseAttack>
                         <extraMeleeDamages>
                         <li>
@@ -60,15 +60,15 @@
                         </extraMeleeDamages>
                     </surpriseAttack>                        
 					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>0.288</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.03</armorPenetrationSharp>
+					<armorPenetrationBlunt>1</armorPenetrationBlunt>
+					<armorPenetrationSharp>1.5</armorPenetrationSharp>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>12</power>
-					<cooldownTime>1.77</cooldownTime>
+					<power>9</power>
+					<cooldownTime>2</cooldownTime>
                     <surpriseAttack>
                         <extraMeleeDamages>
                         <li>
@@ -78,19 +78,19 @@
                         </extraMeleeDamages>
                     </surpriseAttack>                        
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
-					<armorPenetrationBlunt>2.880</armorPenetrationBlunt>
-					<armorPenetrationSharp>0.1</armorPenetrationSharp>
+					<armorPenetrationBlunt>1.5</armorPenetrationBlunt>
+					<armorPenetrationSharp>2</armorPenetrationSharp>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
 					<capacities>
 						<li>Blunt</li>
 					</capacities>
-					<power>1</power>
-					<cooldownTime>1.19</cooldownTime>
+					<power>4</power>
+					<cooldownTime>2</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>0.2</armorPenetrationBlunt>
+					<armorPenetrationBlunt>2</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>
@@ -102,8 +102,8 @@
 		<xpath>Defs/ThingDef[defName="Dryad_Clawer"]/statBases/MoveSpeed</xpath>
 		<value>
 			<MoveSpeed>6</MoveSpeed>
-            <ArmorRating_Blunt>0.05</ArmorRating_Blunt>
-			<ArmorRating_Sharp>0.05</ArmorRating_Sharp>
+            <ArmorRating_Blunt>0.5</ArmorRating_Blunt>
+			<ArmorRating_Sharp>0.5</ArmorRating_Sharp>
 			<MeleeDodgeChance>0.25</MeleeDodgeChance>
 			<MeleeCritChance>0.25</MeleeCritChance>
 			<MeleeParryChance>0.09</MeleeParryChance>
@@ -120,8 +120,8 @@
 						<li>Scratch</li>
 						<li>Cut</li>
 					</capacities>
-					<power>20</power>
-					<cooldownTime>1.12</cooldownTime>
+					<power>18</power>
+					<cooldownTime>1.5</cooldownTime>
 					<linkedBodyPartsGroup>FrontLeftPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -131,8 +131,8 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<armorPenetrationSharp>1.2</armorPenetrationSharp>
+					<armorPenetrationBlunt>7</armorPenetrationBlunt>
+					<armorPenetrationSharp>8</armorPenetrationSharp>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>right claw</label>
@@ -140,8 +140,8 @@
 						<li>Scratch</li>
 						<li>Cut</li>
 					</capacities>
-					<power>20</power>
-					<cooldownTime>1.12</cooldownTime>
+					<power>18</power>
+					<cooldownTime>1.5</cooldownTime>
 					<linkedBodyPartsGroup>FrontRightPaw</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -151,15 +151,15 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationBlunt>3.5</armorPenetrationBlunt>
-					<armorPenetrationSharp>1.2</armorPenetrationSharp>
+					<armorPenetrationBlunt>7</armorPenetrationBlunt>
+					<armorPenetrationSharp>8</armorPenetrationSharp>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<capacities>
 						<li>Bite</li>
 					</capacities>
-					<power>28</power>
-					<cooldownTime>1.56</cooldownTime>
+					<power>9</power>
+					<cooldownTime>2</cooldownTime>
 					<linkedBodyPartsGroup>Teeth</linkedBodyPartsGroup>
 					<surpriseAttack>
 						<extraMeleeDamages>
@@ -169,8 +169,8 @@
 							</li>
 						</extraMeleeDamages>
 					</surpriseAttack>
-					<armorPenetrationSharp>2</armorPenetrationSharp>
-					<armorPenetrationBlunt>9.163</armorPenetrationBlunt>
+					<armorPenetrationSharp>9</armorPenetrationSharp>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
 				</li>
 				<li Class="CombatExtended.ToolCE">
 					<label>head</label>
@@ -178,10 +178,10 @@
 						<li>Blunt</li>
 					</capacities>
 					<power>4</power>
-					<cooldownTime>3.2</cooldownTime>
+					<cooldownTime>2</cooldownTime>
 					<linkedBodyPartsGroup>HeadAttackTool</linkedBodyPartsGroup>
 					<chanceFactor>0.2</chanceFactor>
-					<armorPenetrationBlunt>1.225</armorPenetrationBlunt>
+					<armorPenetrationBlunt>8</armorPenetrationBlunt>
 				</li>
 			</tools>
 		</value>

--- a/Mods/Core_SK/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds.xml
+++ b/Mods/Core_SK/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds.xml
@@ -4,14 +4,8 @@
 	<!-- ========== Trader ========== -->
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
-			<li Class="PatchOperationAdd">
-				<xpath>Defs/PawnKindDef[defName="Empire_Common_Lodger"]/apparelTags</xpath>
-				<value>
-					<li>Outlander</li>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Empire_Common_Lodger"]/apparelMoney</xpath>
 				<value>
@@ -28,7 +22,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/PawnKindDef[defName="Empire_Common_Trader"]/weaponTags</xpath>
@@ -52,8 +46,7 @@
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/PawnKindDef[defName="Empire_Common_Trader"]/apparelTags</xpath>
 				<value>
-					<li>UniqueIndustrial</li>
-					<li>Outlander</li>
+					<li>TraderTag</li>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -89,10 +82,28 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationSequence">
+		<success>Normal</success>
+		<operations>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="Empire_Common_Laborer"]/apparelMoney</xpath>
+				<value>
+					<apparelMoney>1250~3000</apparelMoney>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[defName="Empire_Common_Laborer"]/techHediffsMoney</xpath>
+				<value>
+					<techHediffsMoney>1000~2500</techHediffsMoney>
+				</value>
+			</li>
+		</operations>
+	</Operation>
+
 	<!-- ========== Fighters ========== -->
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[@Name="ImperialFighterBase"]/weaponMoney</xpath>
@@ -114,7 +125,6 @@
 					<li>SyndicateLight</li>
 					<li>SyndicateMedium</li>
 					<li>SyndicateScout</li>
-					<li>UniqueIndustrial</li>
 				</value>
 			</li>
 			<li Class="PatchOperationReplace">
@@ -133,7 +143,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[@Name="ImperialTrooperBase"]/combatPower</xpath>
@@ -164,22 +174,24 @@
 					</apparelRequired>
 				</value>
 			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[@Name="ImperialTrooperBase"]/weaponMoney</xpath>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/PawnKindDef[@Name="ImperialTrooperBase"]</xpath>
 				<value>
 					<weaponMoney>2500~3000</weaponMoney>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
-				<xpath>Defs/PawnKindDef[@Name="ImperialTrooperBase"]/apparelTags</xpath>
+				<xpath>Defs/PawnKindDef[@Name="ImperialTrooperBase"]</xpath>
 				<value>
-					<li>SyndicateMedium</li>
-					<li>SyndicateUnique</li>
-					<li>UniqueSpacer</li>
+					<apparelTags>
+						<li>SyndicateMedium</li>
+						<li>SyndicateUnique</li>
+						<li>UniqueSpacer</li>
+					</apparelTags>
 				</value>
 			</li>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[@Name="ImperialTrooperBase"]/techHediffsMoney</xpath>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/PawnKindDef[@Name="ImperialTrooperBase"]</xpath>
 				<value>
 					<techHediffsMoney>12500~15500</techHediffsMoney>
 				</value>
@@ -221,6 +233,37 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Grenadier"]/combatPower</xpath>
+		<value>
+			<combatPower>460</combatPower>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAddModExtension">
+		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Grenadier"]</xpath>
+		<value>
+			<li Class="CombatExtended.LoadoutPropertiesExtension">
+				<primaryMagazineCount>
+					<min>3</min>
+					<max>6</max>
+				</primaryMagazineCount>
+				<sidearms>
+					<li>
+						<generateChance>0.5</generateChance>
+						<sidearmMoney>
+							<min>150</min>
+							<max>350</max>
+						</sidearmMoney>
+						<weaponTags>
+							<li>CE_Sidearm_Melee</li>
+						</weaponTags>
+					</li>
+				</sidearms>
+			</li>
+		</value>
+	</Operation>
+
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Janissary"]/specificApparelRequirements</xpath>
 		<value>
@@ -232,7 +275,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[@Name="JanissaryBase"]/combatPower</xpath>
@@ -293,7 +336,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Champion"]/combatPower</xpath>
@@ -337,7 +380,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[@Name="CataphractBase"]/apparelMoney</xpath>
@@ -355,7 +398,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[defName="Empire_Fighter_Cataphract"]/combatPower</xpath>
@@ -399,7 +442,7 @@
 	</Operation>
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[@Name="StellicGuardBase"]/combatPower</xpath>
@@ -474,14 +517,8 @@
 	<!-- ========== Royalty ========== -->
 
 	<Operation Class="PatchOperationSequence">
-		<success>Always</success>
+		<success>Normal</success>
 		<operations>
-			<li Class="PatchOperationReplace">
-				<xpath>Defs/PawnKindDef[@Name="RoyalBase"]/combatPower</xpath>
-				<value>
-					<combatPower>350</combatPower>
-				</value>
-			</li>
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[@Name="RoyalBase"]/weaponMoney</xpath>
 				<value>

--- a/Mods/Core_SK/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds.xml
+++ b/Mods/Core_SK/Royalty/Patches/PawnKindDefs_Royalty/PawnKinds.xml
@@ -520,6 +520,12 @@
 		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationReplace">
+				<xpath>Defs/PawnKindDef[@Name="RoyalBase"]/combatPower</xpath>
+				<value>
+					<combatPower>350</combatPower>
+				</value>
+			</li>
+			<li Class="PatchOperationReplace">
 				<xpath>Defs/PawnKindDef[@Name="RoyalBase"]/weaponMoney</xpath>
 				<value>
 					<weaponMoney>2700~3500</weaponMoney>


### PR DESCRIPTION
1 added some vanilla apparel and weapon tags to some apparel/weapon to make more compability with royalty and other mods;
2 fixed some non-working royality pawn's patches;
3 fixed dryad CE weird patches;
4 fixed 100% flammability of iron wall;
5 fixed incorrected ideology apparel's armour params.

1 добавлены некоторые ванильные теги для оружия и одежды для лучшей совместимости с Роялти и прочими модами;
2 исправлены неработающие патчи Роялти;
3 исправлены странные патчи СЕ для дриад;
4 исправлена 100% горючесть стен из железа;
5 исправлены завышенные значения брони одежды идеологии (пуленепробиваемая паранджа?).