### PR TITLE
Some cooking tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_PrepareFishes.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_PrepareFishes.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-  <!--=================== Campfire meal ===============-->
+  <!--===== Campfire meal =====-->
   
   <RecipeDef>
     <defName>GrillFishCampfire</defName>
@@ -11,7 +11,7 @@
     <workSpeedStat>CookSpeed</workSpeedStat>
     <effectWorking>Cook</effectWorking>
     <soundWorking>Recipe_CookMeal</soundWorking>
-    <workAmount>700</workAmount>
+    <workAmount>720</workAmount>
     <ingredients>
       <li>
         <filter>
@@ -23,12 +23,15 @@
       </li>
     </ingredients>
     <products>
-      <MealFine>1</MealFine>
+      <MealFine_Meat>1</MealFine_Meat>
     </products>
     <fixedIngredientFilter>
       <thingDefs>
-        <li>Corpse_ThingDefFishBlueblade</li>
-        <li>Corpse_ThingDefFishSeasnake</li>
+        <li>Corpse_ThingDefFishSduiggles</li>
+		<li>Corpse_ThingDefFishSeasnake</li>
+		<li>Corpse_ThingDefFishMashgon</li>
+		<li>Corpse_ThingDefFishBlueblade</li>
+        <li>Corpse_ThingDefFishTailteeth</li>
       </thingDefs>
       <specialFiltersToDisallow>
         <li>AllowRotten</li>
@@ -52,7 +55,8 @@
     <workSpeedStat>CookSpeed</workSpeedStat>
     <effectWorking>Cook</effectWorking>
     <soundWorking>Recipe_CookMeal</soundWorking>
-    <workAmount>1600</workAmount>
+    <workAmount>1800</workAmount>
+	<allowMixingIngredients>true</allowMixingIngredients>
     <ingredients>
       <li>
         <filter>
@@ -64,12 +68,15 @@
       </li>
     </ingredients>
     <products>
-      <MealFine>4</MealFine>
+      <MealFine_Meat>4</MealFine_Meat>
     </products>
     <fixedIngredientFilter>
       <thingDefs>
-        <li>Corpse_ThingDefFishBlueblade</li>
-        <li>Corpse_ThingDefFishSeasnake</li>
+        <li>Corpse_ThingDefFishSduiggles</li>
+		<li>Corpse_ThingDefFishSeasnake</li>
+		<li>Corpse_ThingDefFishMashgon</li>
+		<li>Corpse_ThingDefFishBlueblade</li>
+        <li>Corpse_ThingDefFishTailteeth</li>
       </thingDefs>
       <specialFiltersToDisallow>
         <li>AllowRotten</li>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
@@ -553,18 +553,30 @@
 	</RecipeDef>
 	
 
-	<RecipeDef>
-		<defName>CookMealFine</defName>
-		<label>cook fine meal</label>
-		<description>Cooks a somewhat complex meal from a combination of raw meat and raw plant ingredients. Produces 2.</description>
-		<jobString>Cooking fine meal.</jobString>
+	<RecipeDef Name="CookMealFineBase" Abstract="True">
 		<workSpeedStat>CookSpeed</workSpeedStat>
 		<effectWorking>Cook</effectWorking>
+		<workSkill>Cooking</workSkill>
 		<workAmount>800</workAmount>
 		<soundWorking>Recipe_CookMeal</soundWorking>
 		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
 		<allowMixingIngredients>true</allowMixingIngredients>
 		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
+		<skillRequirements>
+		  <Cooking>6</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>FueledStove</li>
+			<li>ElectricStove</li>
+		</recipeUsers>
+		<researchPrerequisite>Food_B4</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealFineBase">
+		<defName>CookMealFine</defName>
+		<label>cook fine meal</label>
+		<description>Cooks a somewhat complex meal from a combination of raw meat and raw plant ingredients. Produces 2.</description>
+		<jobString>Cooking fine meal.</jobString>
 		<ingredients>
 			<li>
 				<filter>
@@ -636,29 +648,103 @@
 				<li>EggsFertilized</li>
 			</disallowedCategories>
 		</defaultIngredientFilter>
-		<skillRequirements>
-			<Cooking>4</Cooking>
-		</skillRequirements>
-		<workSkill>Cooking</workSkill>
-		<recipeUsers>
-			<li>FueledStove</li>
-			<li>ElectricStove</li>
-		</recipeUsers>
-		<researchPrerequisite>Food_B4</researchPrerequisite>
 	</RecipeDef>
-	
-	<RecipeDef>
+
+	<RecipeDef ParentName="CookMealFineBase">
+		<defName>CookMealFine_Veg</defName>
+		<label>cook vegetarian fine meal</label>
+		<description>Cook a somewhat complex meal from plant ingredients. Produces 2.</description>
+		<jobString>Cooking vegetarian fine meal.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>BasicPlantFoodRaw</li>
+						<li>FruitFoodRaw</li>
+						<li>ExtraPlantFoodRaw</li>
+					</categories>
+					<thingDefs>
+						<li>RawGiantLeaf</li>
+					</thingDefs>
+				</filter>
+				<count>1.5</count>
+			</li>
+		</ingredients>
+		<products>
+			<MealFine_Veg>2</MealFine_Veg>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawGiantLeaf</li>
+			</thingDefs>
+			<categories>
+				<li>BasicPlantFoodRaw</li>
+				<li>FruitFoodRaw</li>
+				<li>ExtraPlantFoodRaw</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealFineBase">
+		<defName>CookMealFine_Meat</defName>
+		<label>cook carnivore fine meal</label>
+		<description>Cook a somewhat complex meal from meat ingredients. Produces 2.</description>
+		<jobString>Cooking carnivore fine meal.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>MeatRaw</li>
+					</categories>
+				</filter>
+				<count>1.5</count>
+			</li>
+		</ingredients>
+		<products>
+			<MealFine_Meat>2</MealFine_Meat>
+		</products>
+		<fixedIngredientFilter>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+		</defaultIngredientFilter>
+	</RecipeDef>
+
+	<RecipeDef Name="CookMealFineBulkBase" Abstract="True">
+		<workSpeedStat>CookSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<workSkill>Cooking</workSkill>
+		<workAmount>2400</workAmount>
+		<soundWorking>Recipe_CookMeal</soundWorking>
+		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
+		<skillRequirements>
+		  <Cooking>7</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealFineBulkBase">
 		<defName>CookMealFine_Bulk</defName>
 		<label>cook fine meals (x4)</label>
 		<description>Cooks a somewhat complex meal from a combination of raw meat and raw plant ingredients. Produces 8.</description>
 		<jobString>Cooking fine meals.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<workAmount>2400</workAmount>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -727,29 +813,104 @@
 				<li>EggsFertilized</li>
 			</disallowedCategories>
 		</defaultIngredientFilter>
-		<skillRequirements>
-			<Cooking>4</Cooking>
-		</skillRequirements>
-		<workSkill>Cooking</workSkill>
-		<recipeUsers>
-			<li>ElectricStove_Pro</li>
-		</recipeUsers>
-		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealFineBulkBase">
+		<defName>CookMealFineBulk_Veg</defName>
+		<label>cook vegetarian fine meal (x4)</label>
+		<description>Cook somewhat complex meals from plant ingredients. Some of the ingredients are wasted in order to create a good eating experience. Producing varied flavors with plants alone introduces extra inefficiencies. Produces 8.</description>
+		<jobString>Cooking vegetarian fine meal.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>BasicPlantFoodRaw</li>
+						<li>FruitFoodRaw</li>
+						<li>ExtraPlantFoodRaw</li>
+					</categories>
+					<thingDefs>
+						<li>RawGiantLeaf</li>
+					</thingDefs>
+				</filter>
+				<count>6</count>
+			</li>
+		</ingredients>
+		<products>
+			<MealFine_Veg>8</MealFine_Veg>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawGiantLeaf</li>
+			</thingDefs>
+			<categories>
+				<li>BasicPlantFoodRaw</li>
+				<li>FruitFoodRaw</li>
+				<li>ExtraPlantFoodRaw</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealFineBulkBase">
+		<defName>CookMealFineBulk_Meat</defName>
+		<label>cook carnivore fine meal (x4)</label>
+		<description>Cook somewhat complex meals from meat ingredients. Some of the ingredients are wasted in order to create a good eating experience. Producing varied flavors with meat alone introduces extra inefficiencies. Produces 8.</description>
+		<jobString>Cooking carnivore fine meal.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>MeatRaw</li>
+					</categories>
+				</filter>
+				<count>6</count>
+			</li>
+		</ingredients>
+		<products>
+			<MealFine_Meat>8</MealFine_Meat>
+		</products>
+		<fixedIngredientFilter>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+		</defaultIngredientFilter>
 	</RecipeDef>
 
 
-	<RecipeDef>
+	<RecipeDef Name="CookMealLavishBase" Abstract="True">
+		<workSpeedStat>CookSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<workSkill>Cooking</workSkill>
+		<workAmount>900</workAmount>
+		<soundWorking>Recipe_CookMeal</soundWorking>
+		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
+		<skillRequirements>
+		  <Cooking>9</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove</li>
+		</recipeUsers>
+		<researchPrerequisite>Food_C1</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealLavishBase">
 		<defName>CookMealLavish</defName>
 		<label>cook lavish meal</label>
 		<description>Cooks a very complex meal from a combination of raw meat and raw plant ingredients. Produces 2.</description>
 		<jobString>Cooking lavish meal.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<workAmount>900</workAmount>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -820,30 +981,104 @@
 				<li>EggsFertilized</li>
 			</disallowedCategories>
 		</defaultIngredientFilter>
-		<skillRequirements>
-			<Cooking>8</Cooking>
-		</skillRequirements>
-		<workSkill>Cooking</workSkill>
-		<recipeUsers>
-			<li>ElectricStove</li>
-		</recipeUsers>
-		<researchPrerequisite>Food_C1</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealLavishBase">
+		<defName>CookMealLavish_Veg</defName>
+		<label>cook vegetarian lavish meal</label>
+		<description>Cook a very complex meal from plant ingredients. Much of the ingredients are wasted in order to create the best eating experience. Producing varied flavors with plants alone introduces extra inefficiencies. Produces 2.</description>
+		<jobString>Cooking vegetarian lavish meal.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>BasicPlantFoodRaw</li>
+						<li>FruitFoodRaw</li>
+						<li>ExtraPlantFoodRaw</li>
+					</categories>
+					<thingDefs>
+						<li>RawGiantLeaf</li>
+					</thingDefs>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<products>
+			<MealLavish_Veg>2</MealLavish_Veg>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawGiantLeaf</li>
+			</thingDefs>
+			<categories>
+				<li>BasicPlantFoodRaw</li>
+				<li>FruitFoodRaw</li>
+				<li>ExtraPlantFoodRaw</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealLavishBase">
+		<defName>CookMealLavish_Meat</defName>
+		<label>cook carnivore lavish meal</label>
+		<description>Cook a very complex meal from meat ingredients. Much of the ingredients are wasted in order to create the best eating experience. Producing varied flavors with meat alone introduces extra inefficiencies. Produces 2.</description>
+		<jobString>Cooking carnivore lavish meal.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>MeatRaw</li>
+					</categories>
+				</filter>
+				<count>5</count>
+			</li>
+		</ingredients>
+		<products>
+			<MealLavish_Meat>2</MealLavish_Meat>
+		</products>
+		<fixedIngredientFilter>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+		</defaultIngredientFilter>
 	</RecipeDef>
 
 
+	<RecipeDef Name="CookMealLavishBulkBase" Abstract="True">
+		<workSpeedStat>CookSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<workSkill>Cooking</workSkill>
+		<workAmount>2700</workAmount>
+		<soundWorking>Recipe_CookMeal</soundWorking>
+		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
+		<skillRequirements>
+		  <Cooking>11</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
 
-	<RecipeDef>
+	<RecipeDef ParentName="CookMealLavishBulkBase">
 		<defName>CookMealLavish_Bulk</defName>
 		<label>cook lavish meals (x4)</label>
 		<description>Cooks a very complex meal from a combination of raw meat and raw plant ingredients. Produces 8.</description>
 		<jobString>Cooking lavish meals.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<workAmount>2700</workAmount>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -914,14 +1149,78 @@
 				<li>EggsFertilized</li>
 			</disallowedCategories>
 		</defaultIngredientFilter>
-		<skillRequirements>
-			<Cooking>10</Cooking>
-		</skillRequirements>
-		<workSkill>Cooking</workSkill>
-		<recipeUsers>
-			<li>ElectricStove_Pro</li>
-		</recipeUsers>
-		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealLavishBulkBase">
+		<defName>CookMealLavishBulk_Veg</defName>
+		<label>cook vegetarian lavish meal (x4)</label>
+		<description>Cook very complex meals from plant ingredients. Much of the ingredients are wasted in order to create the best eating experience. Producing varied flavors with plants alone introduces extra inefficiencies. Produces 8.</description>
+		<jobString>Cooking vegetarian lavish meals.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>BasicPlantFoodRaw</li>
+						<li>FruitFoodRaw</li>
+						<li>ExtraPlantFoodRaw</li>
+					</categories>
+					<thingDefs>
+						<li>RawGiantLeaf</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>
+		</ingredients>
+		<products>
+			<MealLavish_Veg>8</MealLavish_Veg>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawGiantLeaf</li>
+			</thingDefs>
+			<categories>
+				<li>BasicPlantFoodRaw</li>
+				<li>FruitFoodRaw</li>
+				<li>ExtraPlantFoodRaw</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealLavishBulkBase">
+		<defName>CookMealLavishBulk_Meat</defName>
+		<label>cook carnivore lavish meal (x4)</label>
+		<description>Cook very complex meals from meat ingredients. Much of the ingredients are wasted in order to create the best eating experience. Producing varied flavors with meat alone introduces extra inefficiencies. Produces 8.</description>
+		<jobString>Cooking carnivore lavish meals.</jobString>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>MeatRaw</li>
+					</categories>
+				</filter>
+				<count>20</count>
+			</li>
+		</ingredients>
+		<products>
+			<MealLavish_Meat>8</MealLavish_Meat>
+		</products>
+		<fixedIngredientFilter>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+		</defaultIngredientFilter>
 	</RecipeDef>
 
 	<!--<RecipeDef>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Special.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Special.xml
@@ -1,18 +1,23 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 
-	<RecipeDef>
+	<RecipeDef Name="CookMealSpecialBase_SK" Abstract="True">
+		<workSpeedStat>CookSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<workAmount>700</workAmount>
+		<workSkill>Cooking</workSkill>
+		<soundWorking>Recipe_CookMeal</soundWorking>
+		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>CookMeatSoup</defName>
 		<label>cook meat soup</label>
 		<description>Prepares a meat soup from raw meat and a few raw plants. Produces 3.</description>
 		<jobString>Cooking meat soup.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<workAmount>700</workAmount>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
 		<soundWorking>Chemlab_Medicine_Drink</soundWorking>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -65,30 +70,86 @@
 		<skillRequirements>
 			<Cooking>4</Cooking>
 		</skillRequirements>
-		<workSkill>Cooking</workSkill>
 		<recipeUsers>
 			<li>FueledStove</li>
 			<li>ElectricStove</li>
-			<li>ElectricStove_Pro</li>
 		</recipeUsers>
 		<researchPrerequisite>Food_B4</researchPrerequisite>
 	</RecipeDef>
-	
 
-<!--         Grilled Meals       -->
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
+		<defName>CookMeatSoupBulk</defName>
+		<label>cook meat soup (x4)</label>
+		<description>Prepares a meat soup from raw meat and a few raw plants. Produces 12.</description>
+		<jobString>Cooking meat soup.</jobString>
+		<workAmount>2460</workAmount>
+		<soundWorking>Chemlab_Medicine_Drink</soundWorking>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>MeatRaw</li>
+					</categories>
+				</filter>
+				<count>2.6</count>
+			</li>
+			<li>
+				<filter>
+					<categories>
+						<li>BasicPlantFoodRaw</li>
+					</categories>
+					<thingDefs>
+						<li>RawGiantLeaf</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<products>
+			<MeatSoup>12</MeatSoup>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawGiantLeaf</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+				<li>BasicPlantFoodRaw</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>RawGiantLeaf</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+				<li>BasicPlantFoodRaw</li>
+			</categories>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+		</defaultIngredientFilter>
+		<skillRequirements>
+			<Cooking>6</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
 
-	<RecipeDef>
+
+	<!--     Grilled Meals     -->
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>MakeCheeseGrilled</defName>
 		<label>Grill cheese sandwich</label>
 		<description>Grills a sandwich from bread and cheese. Produces 2.</description>
 		<jobString>Grilling cheese sandwich.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<workAmount>700</workAmount>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -132,24 +193,67 @@
 			<li>TableGrill</li>
 			<li>FueledStove</li>
 			<li>ElectricStove</li>
-			<li>ElectricStove_Pro</li>
 		</recipeUsers>
-		<workSkill>Cooking</workSkill>
 		<researchPrerequisite>Food_B3</researchPrerequisite>
 	</RecipeDef>
-	
-	<RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
+		<defName>MakeCheeseGrilledBulk</defName>
+		<label>Grill cheese sandwich (x4)</label>
+		<description>Grills a sandwich from bread and cheese. Produces 8.</description>
+		<jobString>Grilling cheese sandwich.</jobString>
+		<workAmount>2460</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Cheese</li>
+						<li>AgedCheese</li>
+					</thingDefs>
+				</filter>
+				<count>0.8</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>bread</li>
+					</thingDefs>
+				</filter>
+				<count>0.4</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Cheese</li>
+				<li>AgedCheese</li>
+				<li>bread</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>Cheese</li>
+				<li>AgedCheese</li>
+				<li>bread</li>
+			</thingDefs>
+		</defaultIngredientFilter>
+		<products>
+			<GrilledCheese>8</GrilledCheese>
+		</products>
+		<skillRequirements>
+			<Cooking>7</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>MakePotatoesCheese</defName>
 		<label>Grill potatoes with cheese</label>
 		<description>Grills potatoes with some cheese on top. Produces 3.</description>
 		<jobString>Grilling potatoes with cheese.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
 		<workAmount>450</workAmount>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -193,28 +297,70 @@
 			<li>TableGrill</li>
 			<li>FueledStove</li>
 			<li>ElectricStove</li>
-			<li>ElectricStove_Pro</li>
 		</recipeUsers>
-		<workSkill>Cooking</workSkill>
 		<researchPrerequisite>Food_B3</researchPrerequisite>
 	</RecipeDef>
-	
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
+		<defName>MakePotatoesCheeseBulk</defName>
+		<label>Grill potatoes with cheese (x4)</label>
+		<description>Grills potatoes with some cheese on top. Produces 12.</description>
+		<jobString>Grilling potatoes with cheese.</jobString>
+		<workAmount>1600</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Cheese</li>
+						<li>AgedCheese</li>
+					</thingDefs>
+				</filter>
+				<count>1.6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawPotatoes</li>
+					</thingDefs>
+				</filter>
+				<count>1.6</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Cheese</li>
+				<li>AgedCheese</li>
+				<li>RawPotatoes</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>Cheese</li>
+				<li>AgedCheese</li>
+				<li>RawPotatoes</li>
+			</thingDefs>
+		</defaultIngredientFilter>
+		<products>
+			<PotatoesCheese>12</PotatoesCheese>
+		</products>
+		<skillRequirements>
+			<Cooking>4</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
 
 	
-<!--         Fine Meals          -->
-	
-	<RecipeDef>
+	<!--     Fine Meals     -->
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>CookHeartyStew</defName>
 		<label>cook hearty stew</label>
 		<description>Prepares a hearty stew from raw meat, potatoes and carrots. Produces 2.</description>
 		<jobString>Cooking hearty stew.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<workAmount>700</workAmount>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
 		<soundWorking>Chemlab_Medicine_Drink</soundWorking>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -272,26 +418,87 @@
 		<skillRequirements>
 			<Cooking>8</Cooking>
 		</skillRequirements>
-		<workSkill>Cooking</workSkill>
 		<recipeUsers>
 			<li>ElectricStove</li>
-			<li>ElectricStove_Pro</li>
 		</recipeUsers>
 		<researchPrerequisite>Food_C1</researchPrerequisite>
 	</RecipeDef>
-	
-	<RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
+		<defName>CookHeartyStewBulk</defName>
+		<label>cook hearty stew (x4)</label>
+		<description>Prepares a hearty stew from raw meat, potatoes and carrots. Produces 8.</description>
+		<jobString>Cooking hearty stew.</jobString>
+		<workAmount>2460</workAmount>
+		<soundWorking>Chemlab_Medicine_Drink</soundWorking>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>MeatRaw</li>
+					</categories>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawPotatoes</li>
+					</thingDefs>
+				</filter>
+				<count>1.6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawCarrots</li>
+					</thingDefs>
+				</filter>
+				<count>1.2</count>
+			</li>
+		</ingredients>
+		<products>
+			<HeartyStew>8</HeartyStew>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawPotatoes</li>
+				<li>RawCarrots</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>RawPotatoes</li>
+				<li>RawCarrots</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+		</defaultIngredientFilter>
+		<skillRequirements>
+			<Cooking>10</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>MakeMakiRolls</defName>
 		<label>make maki rolls</label>
 		<description>Make maki rolls from rice, algae and fish meat. Produces 2.</description>
 		<jobString>Cooking maki rolls.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<workAmount>700</workAmount>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -348,26 +555,85 @@
 		<skillRequirements>
 			<Cooking>9</Cooking>
 		</skillRequirements>
-		<workSkill>Cooking</workSkill>
 		<recipeUsers>
 			<li>ElectricStove</li>
-			<li>ElectricStove_Pro</li>
 		</recipeUsers>
 		<researchPrerequisite>Food_C2</researchPrerequisite>
 	</RecipeDef>
-	
-	<RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
+		<defName>MakeMakiRollsBulk</defName>
+		<label>make maki rolls (x4)</label>
+		<description>Make maki rolls from rice, algae and fish meat. Produces 8.</description>
+		<jobString>Cooking maki rolls.</jobString>
+		<workAmount>2460</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Meat_ThingDefFishSduiggles</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawAlgae</li>
+					</thingDefs>
+				</filter>
+				<count>0.8</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawRice</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+		</ingredients>
+		<products>
+			<MakiRolls>8</MakiRolls>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Meat_ThingDefFishSduiggles</li>
+				<li>RawAlgae</li>
+				<li>RawRice</li>
+			</thingDefs>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>Meat_ThingDefFishSduiggles</li>
+				<li>RawAlgae</li>
+				<li>RawRice</li>
+			</thingDefs>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+			<disallowedCategories>
+				<li>EggsFertilized</li>
+			</disallowedCategories>
+		</defaultIngredientFilter>
+		<skillRequirements>
+			<Cooking>11</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>MakeKebab</defName>
 		<label>make kebab</label>
 		<description>Make kebab from vegetables, mushrooms and meat. Produces 2.</description>
 		<jobString>Cooking kebab.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<workAmount>700</workAmount>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -434,26 +700,95 @@
 		<skillRequirements>
 			<Cooking>8</Cooking>
 		</skillRequirements>
-		<workSkill>Cooking</workSkill>
 		<recipeUsers>
 			<li>ElectricStove</li>
-			<li>ElectricStove_Pro</li>
 		</recipeUsers>
 		<researchPrerequisite>Food_C1</researchPrerequisite>
 	</RecipeDef>
-	
-	<RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
+		<defName>MakeKebabBulk</defName>
+		<label>make kebab (x4)</label>
+		<description>Make kebab from vegetables, mushrooms and meat. Produces 8.</description>
+		<jobString>Cooking kebab.</jobString>
+		<workAmount>2460</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>MeatRaw</li>
+					</categories>
+				</filter>
+				<count>2.8</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawTomatoes</li>
+					</thingDefs>
+				</filter>
+				<count>1.2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawShimmershroom</li>
+						<li>RawGlowbulb</li>
+						<li>Rawmushroom</li>
+					</thingDefs>
+				</filter>
+				<count>1.2</count>
+			</li>
+		</ingredients>
+		<products>
+			<Kebab>8</Kebab>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawShimmershroom</li>
+				<li>RawGlowbulb</li>
+				<li>Rawmushroom</li>
+				<li>RawTomatoes</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>RawShimmershroom</li>
+				<li>RawGlowbulb</li>
+				<li>Rawmushroom</li>
+				<li>RawTomatoes</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+			<disallowedCategories>
+				<li>EggsFertilized</li>
+			</disallowedCategories>
+		</defaultIngredientFilter>
+		<skillRequirements>
+			<Cooking>10</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>MakeMushroomMadness</defName>
 		<label>make mushroom madness</label>
 		<description>Make a mysterious dish from different mushrooms. Produces 2.</description>
 		<jobString>Cooking mushroom madness.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<workAmount>700</workAmount>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -510,26 +845,86 @@
 		<skillRequirements>
 			<Cooking>7</Cooking>
 		</skillRequirements>
-		<workSkill>Cooking</workSkill>
 		<recipeUsers>
 			<li>ElectricStove</li>
-			<li>ElectricStove_Pro</li>
 		</recipeUsers>
 		<researchPrerequisite>Food_C2</researchPrerequisite>
 	</RecipeDef>
 
-	<RecipeDef>
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
+		<defName>MakeMushroomMadnessBulk</defName>
+		<label>make mushroom madness (x4)</label>
+		<description>Make a mysterious dish from different mushrooms. Produces 8.</description>
+		<jobString>Cooking mushroom madness.</jobString>
+		<workAmount>2460</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawShimmershroom</li>
+					</thingDefs>
+				</filter>
+				<count>1.6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawGlowbulb</li>
+					</thingDefs>
+				</filter>
+				<count>1.6</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Rawmushroom</li>
+					</thingDefs>
+				</filter>
+				<count>1.6</count>
+			</li>
+		</ingredients>
+		<products>
+			<MushroomMadness>8</MushroomMadness>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawShimmershroom</li>
+				<li>RawGlowbulb</li>
+				<li>Rawmushroom</li>
+			</thingDefs>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>RawShimmershroom</li>
+				<li>RawGlowbulb</li>
+				<li>Rawmushroom</li>
+			</thingDefs>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+			<disallowedCategories>
+				<li>EggsFertilized</li>
+			</disallowedCategories>
+		</defaultIngredientFilter>
+		<skillRequirements>
+			<Cooking>9</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>MakeCoconutCurry</defName>
 		<label>cook coconut curry</label>
 		<description>Prepares an exotic dish from meat, rice and coconut milk. Produces 2.</description>
 		<jobString>Cooking coconut curry.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<workAmount>700</workAmount>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
 		<soundWorking>Chemlab_Medicine_Drink</soundWorking>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -587,26 +982,88 @@
 		<skillRequirements>
 			<Cooking>9</Cooking>
 		</skillRequirements>
-		<workSkill>Cooking</workSkill>
 		<recipeUsers>
 			<li>ElectricStove</li>
-			<li>ElectricStove_Pro</li>
 		</recipeUsers>
 		<researchPrerequisite>Food_C2</researchPrerequisite>
 	</RecipeDef>
 
-	<RecipeDef>
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
+		<defName>MakeCoconutCurryBulk</defName>
+		<label>cook coconut curry (x4)</label>
+		<description>Prepares an exotic dish from meat, rice and coconut milk. Produces 8.</description>
+		<jobString>Cooking coconut curry.</jobString>
+		<soundWorking>Chemlab_Medicine_Drink</soundWorking>
+		<workAmount>2460</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>MeatRaw</li>
+					</categories>
+				</filter>
+				<count>1.2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>coconutmilk</li>
+					</thingDefs>
+				</filter>
+				<count>2</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawRice</li>
+					</thingDefs>
+				</filter>
+				<count>1.6</count>
+			</li>
+		</ingredients>
+		<products>
+			<CoconutCurry>8</CoconutCurry>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawRice</li>
+				<li>coconutmilk</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>RawRice</li>
+				<li>coconutmilk</li>
+			</thingDefs>
+			<categories>
+				<li>MeatRaw</li>
+			</categories>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+		</defaultIngredientFilter>
+		<skillRequirements>
+			<Cooking>11</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>MakePelmeni</defName>
 		<label>make pelmeni</label>
 		<description>Make pelmeni from flour and prime meat. Produces 2.</description>
 		<jobString>Cooking pelmeni.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
 		<workAmount>800</workAmount>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -656,30 +1113,82 @@
 		<skillRequirements>
 			<Cooking>8</Cooking>
 		</skillRequirements>
-		<workSkill>Cooking</workSkill>
 		<recipeUsers>
 			<li>ElectricStove</li>
-			<li>ElectricStove_Pro</li>
 		</recipeUsers>
 		<researchPrerequisite>Food_C1</researchPrerequisite>
 	</RecipeDef>
 
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
+		<defName>MakePelmeniBulk</defName>
+		<label>make pelmeni (x4)</label>
+		<description>Make pelmeni from flour and prime meat. Produces 8.</description>
+		<jobString>Cooking pelmeni.</jobString>
+		<workAmount>2800</workAmount>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Meat_Muffalo</li>
+						<li>MetalCannedMeat_prime</li>
+					</thingDefs>
+				</filter>
+				<count>2.8</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Flour</li>
+					</thingDefs>
+				</filter>
+				<count>0.2</count>
+			</li>
+		</ingredients>
+		<products>
+			<Pelmeni>8</Pelmeni>
+		</products>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>Meat_Muffalo</li>
+				<li>MetalCannedMeat_prime</li>
+				<li>Flour</li>
+			</thingDefs>
+			<specialFiltersToDisallow>
+				<li>AllowPlantFood</li>
+			</specialFiltersToDisallow>
+		</fixedIngredientFilter>
+		<defaultIngredientFilter>
+			<thingDefs>
+				<li>Meat_Muffalo</li>
+				<li>MetalCannedMeat_prime</li>
+				<li>Flour</li>
+			</thingDefs>
+			<disallowedThingDefs>
+				<li>Meat_Megaspider</li>
+				<li>Meat_Human</li>
+			</disallowedThingDefs>
+			<disallowedCategories>
+				<li>EggsFertilized</li>
+			</disallowedCategories>
+		</defaultIngredientFilter>
+		<skillRequirements>
+			<Cooking>10</Cooking>
+		</skillRequirements>
+		<recipeUsers>
+			<li>ElectricStove_Pro</li>
+		</recipeUsers>
+		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
+	</RecipeDef>
 
-<!--         Lavish Meals              -->
-	
-	
-	<RecipeDef>
+
+	<!--     Lavish Meals     -->
+
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>MakeBurgerCheese</defName>
 		<label>cook cheese burger</label>
 		<description>Cooks a burger made from bread, meat and cheese. Delicious! Produces 2.</description>
 		<jobString>Cooking cheese burger.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
 		<workAmount>900</workAmount>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -752,22 +1261,16 @@
 		<recipeUsers>
 			<li>ElectricStove_Pro</li>
 		</recipeUsers>
-		<workSkill>Cooking</workSkill>
 		<researchPrerequisite>Food_C6</researchPrerequisite>
 	</RecipeDef>
 	
-	<RecipeDef>
+	<RecipeDef ParentName="CookMealSpecialBase_SK">
 		<defName>MakeMisoSoup</defName>
 		<label>cook miso soup</label>
 		<description>Prepares a luxury miso soup from tofu, algae, mushrooms and onion. Produces 2.</description>
 		<jobString>Cooking coconut curry.</jobString>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
 		<workAmount>900</workAmount>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
 		<soundWorking>Chemlab_Medicine_Drink</soundWorking>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
 		<ingredients>
 			<li>
 				<filter>
@@ -837,7 +1340,6 @@
 		<skillRequirements>
 			<Cooking>14</Cooking>
 		</skillRequirements>
-		<workSkill>Cooking</workSkill>
 		<recipeUsers>
 			<li>ElectricStove_Pro</li>
 		</recipeUsers>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
@@ -8,9 +8,17 @@
 	<MakePelmeni.description>Приготовить пельмени. Производит 2.</MakePelmeni.description>
 	<MakePelmeni.jobString>Готовит пельмени</MakePelmeni.jobString>
 
+	<MakePelmeniBulk.label>Приготовить пельмени (x4)</MakePelmeniBulk.label>
+	<MakePelmeniBulk.description>Приготовить пельмени. Производит 8.</MakePelmeniBulk.description>
+	<MakePelmeniBulk.jobString>Готовит пельмени</MakePelmeniBulk.jobString>
+
 	<MakePotatoesCheese.label>Приготовить картофель с сыром</MakePotatoesCheese.label>
 	<MakePotatoesCheese.description>Пожарить картофель с сыром. Производит 3.</MakePotatoesCheese.description>
 	<MakePotatoesCheese.jobString>Готовит картофель с сыром</MakePotatoesCheese.jobString>
+
+	<MakePotatoesCheeseBulk.label>Приготовить картофель с сыром (x4)</MakePotatoesCheeseBulk.label>
+	<MakePotatoesCheeseBulk.description>Пожарить картофель с сыром. Производит 12.</MakePotatoesCheeseBulk.description>
+	<MakePotatoesCheeseBulk.jobString>Готовит картофель с сыром</MakePotatoesCheeseBulk.jobString>
 
 	<MakeMisoSoup.label>Приготовить мисо суп</MakeMisoSoup.label>
 	<MakeMisoSoup.description>Приготовить мисо суп из тофу, водорослей, грибов и лука.</MakeMisoSoup.description>
@@ -20,25 +28,49 @@
 	<MakeCoconutCurry.description>Приготовить кокосовое карри из мяса, риса и кокосового молока.</MakeCoconutCurry.description>
 	<MakeCoconutCurry.jobString>Готовит кокосовое карри</MakeCoconutCurry.jobString>
 
+	<MakeCoconutCurryBulk.label>Приготовить кокосовое карри (x4)</MakeCoconutCurryBulk.label>
+	<MakeCoconutCurryBulk.description>Приготовить кокосовое карри из мяса, риса и кокосового молока.</MakeCoconutCurryBulk.description>
+	<MakeCoconutCurryBulk.jobString>Готовит кокосовое карри</MakeCoconutCurryBulk.jobString>
+
 	<MakeMushroomMadness.label>Приготовить грибное безумие</MakeMushroomMadness.label>
 	<MakeMushroomMadness.description>Приготовить грибное безумие из различных грибов.</MakeMushroomMadness.description>
 	<MakeMushroomMadness.jobString>Готовит грибное безумие</MakeMushroomMadness.jobString>
+
+	<MakeMushroomMadnessBulk.label>Приготовить грибное безумие (x4)</MakeMushroomMadnessBulk.label>
+	<MakeMushroomMadnessBulk.description>Приготовить грибное безумие из различных грибов.</MakeMushroomMadnessBulk.description>
+	<MakeMushroomMadnessBulk.jobString>Готовит грибное безумие</MakeMushroomMadnessBulk.jobString>
 
 	<MakeKebab.label>Приготовить кебаб</MakeKebab.label>
 	<MakeKebab.description>Приготовить кебаб из мяса, овощей и грибов.</MakeKebab.description>
 	<MakeKebab.jobString>Готовит кебаб</MakeKebab.jobString>
 
+	<MakeKebabBulk.label>Приготовить кебаб (x4)</MakeKebabBulk.label>
+	<MakeKebabBulk.description>Приготовить кебаб из мяса, овощей и грибов.</MakeKebabBulk.description>
+	<MakeKebabBulk.jobString>Готовит кебаб</MakeKebabBulk.jobString>
+
 	<MakeMakiRolls.label>Приготовить маки роллы</MakeMakiRolls.label>
 	<MakeMakiRolls.description>Приготовить маки роллы из риса, водорослей и рыбы.</MakeMakiRolls.description>
 	<MakeMakiRolls.jobString>Готовит маки роллы</MakeMakiRolls.jobString>
+
+	<MakeMakiRollsBulk.label>Приготовить маки роллы (x4)</MakeMakiRollsBulk.label>
+	<MakeMakiRollsBulk.description>Приготовить маки роллы из риса, водорослей и рыбы.</MakeMakiRollsBulk.description>
+	<MakeMakiRollsBulk.jobString>Готовит маки роллы</MakeMakiRollsBulk.jobString>
 
 	<CookHeartyStew.label>Приготовить домашнее рагу</CookHeartyStew.label>
 	<CookHeartyStew.description>Приготовить домашнее рагу из сырого мяса, картофеля и моркови.</CookHeartyStew.description>
 	<CookHeartyStew.jobString>Готовит домашнее рагу</CookHeartyStew.jobString>
 
+	<CookHeartyStewBulk.label>Приготовить домашнее рагу (x4)</CookHeartyStewBulk.label>
+	<CookHeartyStewBulk.description>Приготовить домашнее рагу из сырого мяса, картофеля и моркови.</CookHeartyStewBulk.description>
+	<CookHeartyStewBulk.jobString>Готовит домашнее рагу</CookHeartyStewBulk.jobString>
+
 	<CookMeatSoup.label>Приготовить мясной суп</CookMeatSoup.label>
 	<CookMeatSoup.description>Приготовить мясной суп из сырого мяса и растительных ингредиентов.</CookMeatSoup.description>
 	<CookMeatSoup.jobString>Готовит мясной суп</CookMeatSoup.jobString>
+
+	<CookMeatSoupBulk.label>Приготовить мясной суп (x4)</CookMeatSoupBulk.label>
+	<CookMeatSoupBulk.description>Приготовить мясной суп из сырого мяса и растительных ингредиентов.</CookMeatSoupBulk.description>
+	<CookMeatSoupBulk.jobString>Готовит мясной суп</CookMeatSoupBulk.jobString>
 
 	<CookMealSalad.label>Приготовить простой салат</CookMealSalad.label>
 	<CookMealSalad.description>Приготовить простой салат.</CookMealSalad.description>
@@ -131,6 +163,10 @@
 	<MakeCheeseGrilled.label>Приготовить бутерброд с сыром</MakeCheeseGrilled.label>
 	<MakeCheeseGrilled.description>Приготовить два ломтика хлеба с плавленым сыром.</MakeCheeseGrilled.description>
 	<MakeCheeseGrilled.jobString>Готовит бутерброд с сыром</MakeCheeseGrilled.jobString>
+
+	<MakeCheeseGrilledBulk.label>Приготовить бутерброд с сыром (x4)</MakeCheeseGrilledBulk.label>
+	<MakeCheeseGrilledBulk.description>Приготовить восемь ломтиков хлеба с плавленым сыром.</MakeCheeseGrilledBulk.description>
+	<MakeCheeseGrilledBulk.jobString>Готовит бутерброды с сыром</MakeCheeseGrilledBulk.jobString>
 
 	<MakePizza.label>Приготовить пиццу</MakePizza.label>
 	<MakePizza.description>Приготовить пиццу.</MakePizza.description>


### PR DESCRIPTION
1 added missed carnivore and vegetarian meal recipes;
2 added bulk (x4) recipes for pelmeni, potatoes with cheese, coconut curry, mushroom madness, kebab, maki rolls, hearty stew, meat soup and grill cheese sandwich to professional cook stove;
3 replace fine meal to carnivore fine meal in grill fish recipes;
4 added all fish types to grill fish recipes (notes: some fishes gives more benefit if you use its in grill fish recipe immediately instead of butchering and cook carnivore fine meal afterwards);
5 fixed grill fish x4 (bulk) recipe inability using various fish corpses at once.

1 добавлены пропущенные рецепты мясных и вегетарианских блюд;
2 добавлены x4 рецепты для пельменей, картофеля с сыром, кокосового карри, грибного безумия, кебаба, маки роллов, домашнего рагу, мясного супа и бутерброда с сыром. Доступны на столе шеф-повара;
3 в рецепты жарки рыбы вкусное блюдо заменено на мясное вкусное блюдо;
4 в рецепты жарки рыбы добавлена возможность использовать любую рыбу, а не только морского змея и голубого клинка (заметка: некоторую рыбу выгоднее сразу зажарить, нежели разделывать её и впоследствии готовить из её мяса вкусное мясное блюдо);
5 исправлен баг х4 рецепта жарки рыбы, из-за которого было невозможно жарить разные типы рыбы одновременно (только один тип).