### PR TITLE
Added vanilla weapon tags to some HSK weapon (for more compatibility with some mods and DLCs)

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Carabines.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Carabines.xml
@@ -199,6 +199,7 @@
         </statBases>
         <weaponTags>
             <li>RF3</li>
+			<li>IndustrialGunAdvanced</li>
             <li>TierTwoRifle</li>
             <li>TierOneRifle</li>
             <li>CE_AI_Rifle</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
@@ -283,7 +283,7 @@
         <weaponTags>
             <li>MG3</li>
             <li>AdvancedGun</li>
-            <li>TierTwoAdvanced</li>
+			<li>GunHeavy</li>
             <li>TierTwoAdvanced</li>
 			<li>CE_AI_Suppressive</li>
             <li>Microgun</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Rifles.xml
@@ -22,6 +22,7 @@
         <weaponTags>
             <li>RF4</li>
             <li>AdvancedGun</li>
+			<li>IndustrialGunAdvanced</li>
             <li>TierTwoRifle</li>
             <li>CE_AI_Rifle</li>
 			<li>AssaultRifle</li>
@@ -83,6 +84,7 @@
         <weaponTags>
             <li>RF4</li>
             <li>AdvancedGun</li>
+			<li>IndustrialGunAdvanced</li>
             <li>TierTwoRifle</li>
             <li>CE_AI_Rifle</li>
         </weaponTags>
@@ -266,6 +268,7 @@
         <weaponTags>
             <li>RF4</li>
             <li>AdvancedGun</li>
+			<li>IndustrialGunAdvanced</li>
             <li>TierTwoRifle</li>
             <li>CE_AI_Rifle</li>
         </weaponTags>
@@ -326,6 +329,7 @@
         <weaponTags>
             <li>RF4</li>
             <li>AdvancedGun</li>
+			<li>IndustrialGunAdvanced</li>
             <li>TierThreeRifle</li>
             <li>CE_AI_Rifle</li>
         </weaponTags>
@@ -389,6 +393,7 @@
         <weaponTags>
             <li>RF4</li>
             <li>AdvancedGun</li>
+			<li>IndustrialGunAdvanced</li>
             <li>TierThreeRifle</li>
             <li>CE_AI_Rifle</li>
         </weaponTags>
@@ -449,6 +454,7 @@
         <weaponTags>
             <li>RF4</li>
             <li>AdvancedGun</li>
+			<li>IndustrialGunAdvanced</li>
             <li>TierThreeRifle</li>
             <li>CE_AI_Rifle</li>
         </weaponTags>
@@ -510,6 +516,7 @@
         <weaponTags>
             <li>RF4</li>
             <li>AdvancedGun</li>
+			<li>IndustrialGunAdvanced</li>
             <li>TierThreeRifle</li>
             <li>CE_AI_Rifle</li>
         </weaponTags>


### PR DESCRIPTION
Добавлены ванильные оружейные теги для некоторого ХСК вооружения (для большей совместимости с некоторыми модами и DLC).