### PR TITLE
Some bow, arrow, bolts, poison tweaks and fixes

### DIFF
--- a/Mods/CombatExtended/Defs/HediffDefs/Hediffs_CE.xml
+++ b/Mods/CombatExtended/Defs/HediffDefs/Hediffs_CE.xml
@@ -541,7 +541,7 @@
     <labelNoun>a venomous arrow wound</labelNoun>
     <comps>
       <li Class="CombatExtended.HediffCompProperties_Venom">
-        <VenomPerSeverity>0.0000080</VenomPerSeverity>
+        <VenomPerSeverity>0.0000060</VenomPerSeverity>
         <MinTicks>10000</MinTicks>
         <MaxTicks>17500</MaxTicks>
       </li>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrows.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrows.xml
@@ -101,7 +101,7 @@
 		<defName>Ammo_Arrow_Explosive</defName>
 		<label>arrow (explosive)</label>
 		<graphicData>
-			<texPath>Things/Ammo/Neolithic/Arrow/Plasteel</texPath>
+			<texPath>Things/Ammo/Neolithic/Arrow/Flame</texPath>
 			<graphicClass>Graphic_StackCount</graphicClass>
 		</graphicData>
 		<statBases>
@@ -139,6 +139,10 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
 		<defName>Projectile_Arrow_Stone</defName>
 		<label>arrow (stone)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Stone</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>10</damageAmountBase>
 			<!-- <armorPenetrationBase>0.24</armorPenetrationBase> -->
@@ -152,6 +156,10 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
 		<defName>Projectile_Arrow_Steel</defName>
 		<label>arrow (metallic)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Steel</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>14</damageAmountBase>
 			<!-- <armorPenetrationBase>0.3</armorPenetrationBase> -->
@@ -165,9 +173,13 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
 		<defName>Projectile_Arrow_Poison</defName>
 		<label>arrow (poison)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Venom</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>ArrowVenom</damageDef>
-			<damageAmountBase>1</damageAmountBase>
+			<damageAmountBase>3</damageAmountBase>
 			<!-- <armorPenetrationBase>0.25</armorPenetrationBase> -->
 			<armorPenetrationSharp>2.5</armorPenetrationSharp>
 			<armorPenetrationBlunt>3.84</armorPenetrationBlunt>
@@ -176,7 +188,7 @@
 			<secondaryDamage>
 				<li>
 					<def>ArrowHighVelocity</def>
-					<amount>5</amount>
+					<amount>3</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -185,6 +197,10 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseArrowProjectile">
 		<defName>Projectile_Arrow_Explosive</defName>
 		<label>arrow (explosive)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>12</damageAmountBase>
 			<!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
@@ -215,6 +231,10 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
 		<defName>Projectile_StreamlinedArrow_Stone</defName>
 		<label>streamlined arrow (stone)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Stone</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>11</damageAmountBase>
 			<armorPenetrationSharp>2.7</armorPenetrationSharp>
@@ -227,6 +247,10 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
 		<defName>Projectile_StreamlinedArrow_Steel</defName>
 		<label>streamlined arrow (metallic)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Steel</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>15</damageAmountBase>
 			<armorPenetrationSharp>3.5</armorPenetrationSharp>
@@ -239,9 +263,13 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
 		<defName>Projectile_StreamlinedArrow_Poison</defName>
 		<label>streamlined arrow (poison)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Venom</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>ArrowVenom</damageDef>
-			<damageAmountBase>2</damageAmountBase>
+			<damageAmountBase>3</damageAmountBase>
 			<armorPenetrationSharp>2.8</armorPenetrationSharp>
 			<armorPenetrationBlunt>4</armorPenetrationBlunt>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>
@@ -249,7 +277,7 @@
 			<secondaryDamage>
 				<li>
 					<def>ArrowHighVelocity</def>
-					<amount>6</amount>
+					<amount>4</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -258,6 +286,10 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseStreamlinedArrowProjectile">
 		<defName>Projectile_StreamlinedArrow_Explosive</defName>
 		<label>streamlined arrow (explosive)</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>13</damageAmountBase>
 			<armorPenetrationSharp>2.2</armorPenetrationSharp>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
@@ -114,6 +114,11 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBoltProjectile">
 		<defName>Projectile_MetallicBolt</defName>
 		<label>metallic bolt</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Steel</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>0.67</drawSize>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>18</damageAmountBase>
 			<!-- <armorPenetrationBase>0.37</armorPenetrationBase> -->			
@@ -127,9 +132,14 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBoltProjectile">
 		<defName>Projectile_PoisonBolt</defName>
 		<label>poison bolt</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Venom</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>0.67</drawSize>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>ArrowVenom</damageDef>
-			<damageAmountBase>1</damageAmountBase>
+			<damageAmountBase>3</damageAmountBase>
 			<!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
 			<armorPenetrationBlunt>5.8</armorPenetrationBlunt>
 			<armorPenetrationSharp>3.1</armorPenetrationSharp>
@@ -138,7 +148,7 @@
 			<secondaryDamage>
 				<li>
 					<def>ArrowHighVelocity</def>
-					<amount>10</amount>
+					<amount>8</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -147,6 +157,11 @@
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="BaseBoltProjectile">
 		<defName>Projectile_ExplosiveBolt</defName>
 		<label>explosive bolt</label>
+		<graphicData>
+			<texPath>Things/Projectile/Arrows/Arrow_Flame</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
+			<drawSize>0.67</drawSize>
+		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>15</damageAmountBase>
 			<!-- <armorPenetrationBase>0.35</armorPenetrationBase> -->

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Darts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Darts.xml
@@ -65,7 +65,7 @@
 		<defName>PoisonDart</defName>
 		<label>Poison Dart</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>1</damageAmountBase>
+			<damageAmountBase>3</damageAmountBase>
 			<!-- <armorPenetrationBase>0.15</armorPenetrationBase> -->
 			<armorPenetrationBlunt>1</armorPenetrationBlunt>
 			<armorPenetrationSharp>1.9</armorPenetrationSharp>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
@@ -124,8 +124,8 @@
 			<SightsEfficiency>0.85</SightsEfficiency>
 			<ShotSpread>1</ShotSpread>
 			<SwayFactor>2</SwayFactor>
-			<Bulk>3.00</Bulk>
-			<Mass>2.00</Mass>
+			<Bulk>3.0</Bulk>
+			<Mass>1.8</Mass>
 			<RangedWeapon_Cooldown>1.15</RangedWeapon_Cooldown>
 		</statBases>
 		<tradeability>Sellable</tradeability>
@@ -310,7 +310,7 @@
 			<ShotSpread>1</ShotSpread>
 			<SwayFactor>2</SwayFactor>
 			<Bulk>5.00</Bulk>
-			<Mass>2.00</Mass>
+			<Mass>3.00</Mass>
 			<RangedWeapon_Cooldown>1.25</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>
@@ -351,7 +351,7 @@
 	<ThingDef ParentName="RangedWeaponMedievalBase">
 		<defName>Norbal_Scorpion</defName>
 		<label>Scorpion Crossbow</label>
-		<description>Fearsome crossbow. Deadly but slow.</description>
+		<description>Fearsome norbal crossbow. Deadly but slow.</description>
 		<graphicData>
 			<texPath>Things/Weapons/Norbal/NorbalCrossBow</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
@@ -374,7 +374,7 @@
 			<RangedWeapon_Cooldown>1.3</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>
-			<li>MedievalRanged</li>
+			<li>NorbalRanged</li>
 			<li>NorbalHeroRanged</li>
 			<li>CE_Bow</li>
 		</weaponTags>
@@ -502,7 +502,6 @@
 		</statBases>
 		<weaponTags>
 			<li>MedievalRanged</li>
-			<li>NorbalRanged</li>
 			<li>CE_Bow</li>
 		</weaponTags>
 		<weaponClasses>
@@ -555,10 +554,10 @@
 		<statBases>
 			<WorkToMake>7000</WorkToMake>
 			<SightsEfficiency>1.0</SightsEfficiency>
-			<ShotSpread>2.1</ShotSpread>
+			<ShotSpread>2</ShotSpread>
 			<SwayFactor>1</SwayFactor>
-			<Bulk>4.50</Bulk>
-			<Mass>1.30</Mass>
+			<Bulk>4.5</Bulk>
+			<Mass>2.0</Mass>
 			<RangedWeapon_Cooldown>1.10</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>
@@ -614,14 +613,13 @@
 		<statBases>
 			<WorkToMake>7500</WorkToMake>
 			<SightsEfficiency>1.1</SightsEfficiency>
-			<ShotSpread>2.25</ShotSpread>
-			<SwayFactor>1.3</SwayFactor>
-			<Bulk>4.50</Bulk>
-			<Mass>1.30</Mass>
+			<ShotSpread>2.15</ShotSpread>
+			<SwayFactor>1.15</SwayFactor>
+			<Bulk>5.50</Bulk>
+			<Mass>3.25</Mass>
 			<RangedWeapon_Cooldown>0.85</RangedWeapon_Cooldown>
 		</statBases>
 		<weaponTags>
-			<li>MedievalRanged</li>
 			<li>NorbalRanged</li>
 			<li>CE_Bow</li>
 		</weaponTags>


### PR DESCRIPTION
1 decreased poison buildup speed from projectiles by ~25%;
2 increased darts, posion arrows and posion bolts posion dmg from 1 to 3 but decreased physical damage by 2 (posion arrows and bolts only);
3 added new CE textures to arrow's and bolt's projectiles to all arrows and bolts types;
4 some bows and crossbows param and tags light tweaks and fixes.

1 уменьшена скорость накопления яда от снарядов на ~25%;
2 ядовитый урон дротиков, ядовитых стрел и ядовитых болтов увеличен c 1 до 3, но уменьшен физический урон на 2 ед. (только у ядовитых стрел и болтов);
3 добавлены новые текстуры для стрел и болтов из СЕ для каждого типа стрел и болтов;
4 некоторые небольшие правки параметров и тегов луков и арбалетов.