### PR TITLE
Un-hide biocoded filter for smelting weapons

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Extracts.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Extracts.xml
@@ -73,8 +73,6 @@
 			<li>AllowSmeltable</li>
 			<li>AllowNonBurnableWeapons</li>
 			<li>AllowBurnableWeapons</li>
-			<li>AllowBiocodedWeapons</li>
-			<li>AllowNonBiocodedWeapons</li>
 		</forceHiddenSpecialFilters>
 	</RecipeDef>
 	<RecipeDef>


### PR DESCRIPTION
Removes the biocoded weapon filters from the list of hidden filters so that the player can set smelting bills to target biocoded weapons specifically.