### PR TITLE
Update Minerals mod patch to include terraforming patch

### DIFF
--- a/Mods/Minerals/Patches/01_HardcoreSK/HardcoreSK.xml
+++ b/Mods/Minerals/Patches/01_HardcoreSK/HardcoreSK.xml
@@ -127,6 +127,39 @@
       <name>ClayBrick</name>
     </match>
   </Operation>
+  
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Core SK</li>
+    </mods>
+    <match Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Stone-Topsoil"]/modExtensions/li[@Class="FertileFields.Terrain"]/above</xpath>
+      <value>
+		<li>ZF_BasaltBase_Smooth</li>
+		<li>ZF_ClaystoneBase_Smooth</li>
+		<li>ZF_MudstoneBase_Smooth</li>
+      </value>
+    </match>
+  </Operation>
 
-
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Core SK</li>
+    </mods>
+    <match Class="PatchOperationAdd">
+      <xpath>Defs/ThingDef[defName="Stone-RockyDirt"]/modExtensions/li[@Class="FertileFields.Terrain"]/above</xpath>
+      <value>
+		<li>ZF_BasaltBase_Smooth</li>
+		<li>ZF_BasaltBase_Rough</li>
+		<li>ZF_BasaltBase_RoughHewn</li>
+		<li>ZF_ClaystoneBase_Smooth</li>
+		<li>ZF_ClaystoneBase_Rough</li>
+		<li>ZF_ClaystoneBase_RoughHewn</li>
+		<li>ZF_MudstoneBase_Smooth</li>
+		<li>ZF_MudstoneBase_Rough</li>
+		<li>ZF_MudstoneBase_RoughHewn</li>
+      </value>
+    </match>
+  </Operation>
+ 
 </Patch>


### PR DESCRIPTION
Patch 'Stone-Rocky dirt' and 'Stone-Topsoil' terraforming buildings so that they work on the Basalt, Claystone, and Mudstone terrains added in Minerals mod. Thanks to Spaniard for helping me out with getting the xpath working.