### PR TITLE
Some tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -116,7 +116,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>30</amount>
+					<amount>27</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -132,7 +132,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>16</amount>
+					<amount>19</amount>
 				</li>
 			</secondaryDamage>
 			<ai_IsIncendiary>true</ai_IsIncendiary>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/20x120mm.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/20x120mm.xml
@@ -101,8 +101,8 @@
 		<label>20x102mm bullet (FMJ)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>55</damageAmountBase>
-			<armorPenetrationSharp>24</armorPenetrationSharp>
-			<armorPenetrationBlunt>869.04</armorPenetrationBlunt>
+			<armorPenetrationSharp>27</armorPenetrationSharp>
+			<armorPenetrationBlunt>869</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -110,13 +110,13 @@
 		<defName>Bullet_20x102mm_HE</defName>
 		<label>20x102mm bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>46</damageAmountBase>
-			<armorPenetrationSharp>24</armorPenetrationSharp>
-			<armorPenetrationBlunt>869.04</armorPenetrationBlunt>
+			<damageAmountBase>45</damageAmountBase>
+			<armorPenetrationSharp>27</armorPenetrationSharp>
+			<armorPenetrationBlunt>869</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>39</amount>
+					<amount>34</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -126,13 +126,13 @@
 		<defName>Bullet_20x102mm_Incendiary</defName>
 		<label>20x102mm bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>45</damageAmountBase>
-			<armorPenetrationSharp>40</armorPenetrationSharp>
-			<armorPenetrationBlunt>869.04</armorPenetrationBlunt>
+			<damageAmountBase>46</damageAmountBase>
+			<armorPenetrationSharp>45</armorPenetrationSharp>
+			<armorPenetrationBlunt>869</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>16</amount>
+					<amount>22</amount>
 				</li>
 			</secondaryDamage>
 			<ai_IsIncendiary>true</ai_IsIncendiary>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/20x120mm.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/20x120mm.xml
@@ -127,7 +127,7 @@
 		<label>20x102mm bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>46</damageAmountBase>
-			<armorPenetrationSharp>45</armorPenetrationSharp>
+			<armorPenetrationSharp>40</armorPenetrationSharp>
 			<armorPenetrationBlunt>869</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/30x173mm.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/30x173mm.xml
@@ -111,7 +111,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>65</damageAmountBase>
 			<armorPenetrationSharp>32</armorPenetrationSharp>
-			<armorPenetrationBlunt>1669.04</armorPenetrationBlunt>
+			<armorPenetrationBlunt>1669</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -120,12 +120,12 @@
 		<label>30x173mm bullet (HE)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>54</damageAmountBase>
-			<armorPenetrationSharp>34</armorPenetrationSharp>
-			<armorPenetrationBlunt>1669.04</armorPenetrationBlunt>
+			<armorPenetrationSharp>32</armorPenetrationSharp>
+			<armorPenetrationBlunt>1669</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>48</amount>
+					<amount>42</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -135,13 +135,13 @@
 		<defName>Bullet_30x173mm_Incendiary</defName>
 		<label>30x173mm bullet (AP-I)</label>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>54</damageAmountBase>
-			<armorPenetrationSharp>36</armorPenetrationSharp>
-			<armorPenetrationBlunt>1669.04</armorPenetrationBlunt>
+			<damageAmountBase>55</damageAmountBase>
+			<armorPenetrationSharp>48</armorPenetrationSharp>
+			<armorPenetrationBlunt>1669</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>29</amount>
+					<amount>25</amount>
 				</li>
 			</secondaryDamage>
 			<ai_IsIncendiary>true</ai_IsIncendiary>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/50BMG.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/50BMG.xml
@@ -118,7 +118,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>34</damageAmountBase>
 			<armorPenetrationSharp>18</armorPenetrationSharp>
-			<armorPenetrationBlunt>334.380</armorPenetrationBlunt>
+			<armorPenetrationBlunt>334</armorPenetrationBlunt>
 		</projectile>
 	</ThingDef>
 
@@ -128,7 +128,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>30</damageAmountBase>
 			<armorPenetrationSharp>32</armorPenetrationSharp>
-			<armorPenetrationBlunt>341.780</armorPenetrationBlunt>
+			<armorPenetrationBlunt>377</armorPenetrationBlunt>
 			<speed>200</speed>
 		</projectile>
 	</ThingDef>
@@ -139,11 +139,11 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>28</damageAmountBase>
 			<armorPenetrationSharp>18</armorPenetrationSharp>
-			<armorPenetrationBlunt>334.380</armorPenetrationBlunt>
+			<armorPenetrationBlunt>334</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>24</amount>
+					<amount>22</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -155,7 +155,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>28</damageAmountBase>
 			<armorPenetrationSharp>28</armorPenetrationSharp>
-			<armorPenetrationBlunt>314.7</armorPenetrationBlunt>
+			<armorPenetrationBlunt>334</armorPenetrationBlunt>
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrows.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrows.xml
@@ -209,7 +209,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>15</amount>
+					<amount>14</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -297,7 +297,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>15</amount>
+					<amount>14</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
@@ -170,7 +170,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>15</amount>
+					<amount>14</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Vests.xml
@@ -650,7 +650,7 @@
 			<ArmorRating_Heat>0</ArmorRating_Heat>
 		</statBases>
 		<equippedStatOffsets>
-			<CarryBulk>25</CarryBulk>
+			<CarryBulk>18</CarryBulk>
 			<MoveSpeed>-0.18</MoveSpeed>
 			<WorkSpeedGlobal>-0.13</WorkSpeedGlobal>
 			<MentalBreakThreshold>-0.03</MentalBreakThreshold>
@@ -725,7 +725,7 @@
 			<ArmorRating_Heat>0</ArmorRating_Heat>
 		</statBases>
 		<equippedStatOffsets>
-			<CarryBulk>28</CarryBulk>
+			<CarryBulk>17</CarryBulk>
 			<MoveSpeed>-0.25</MoveSpeed>
 			<WorkSpeedGlobal>-0.15</WorkSpeedGlobal>
 			<MentalBreakThreshold>-0.03</MentalBreakThreshold>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Heavy.xml
@@ -297,15 +297,15 @@
         <statBases>
             <MarketValue>3100</MarketValue>
             <SightsEfficiency>1</SightsEfficiency>
-            <ShotSpread>0.1</ShotSpread>
-            <SwayFactor>1.6</SwayFactor>
+            <ShotSpread>0.11</ShotSpread>
+            <SwayFactor>1.5</SwayFactor>
             <RangedWeapon_Cooldown>1.2</RangedWeapon_Cooldown>
             <Bulk>21</Bulk>
             <Mass>22</Mass>
         </statBases>
         <verbs>
             <li Class="CombatExtended.VerbPropertiesCE">
-                <recoilAmount>1.7</recoilAmount>
+                <recoilAmount>1.6</recoilAmount>
                 <verbClass>CombatExtended.Verb_ShootCE</verbClass>
                 <hasStandardCommand>true</hasStandardCommand>
                 <defaultProjectile>Bullet_556x45mmNATO_FMJ</defaultProjectile>

--- a/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_Ideology.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_Ideology.xml
@@ -7,7 +7,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_BodyStrap"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
-			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>1.35</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 
@@ -19,7 +19,7 @@
 		<value>
 			<Bulk>6</Bulk>
 			<WornBulk>2.5</WornBulk>
-			<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>1.2</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 
@@ -30,7 +30,7 @@
 		<value>
 			<Bulk>5</Bulk>
 			<WornBulk>2</WornBulk>
-			<StuffEffectMultiplierArmor>2.5</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>1.25</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 
@@ -39,7 +39,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Apparel_Blindfold"]/statBases/StuffEffectMultiplierArmor</xpath>
 		<value>
-			<StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+			<StuffEffectMultiplierArmor>1.15</StuffEffectMultiplierArmor>
 		</value>
 	</Operation>
 

--- a/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_IdeologyHeadgear.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_IdeologyHeadgear.xml
@@ -6,7 +6,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Headwrap" or defName="Apparel_Broadwrap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>1.2</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -15,7 +15,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_VisageMask"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-      <StuffEffectMultiplierArmor>1.5</StuffEffectMultiplierArmor>
+      <StuffEffectMultiplierArmor>1.35</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -24,7 +24,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Slicecap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>1.2</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -34,7 +34,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Collar"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -51,7 +51,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_AuthorityCap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>		  
+		  <StuffEffectMultiplierArmor>1.15</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -60,7 +60,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Tailcap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>1.15</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -69,7 +69,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Shadecone"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>	  
+		  <StuffEffectMultiplierArmor>1.3</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -78,7 +78,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Flophat"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>2</StuffEffectMultiplierArmor>
+		  <StuffEffectMultiplierArmor>1.25</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 

--- a/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
+++ b/Mods/RatkinRaceHSK/Defs/FactionDefs/Factions_Misc.xml
@@ -239,7 +239,7 @@
 
 	<FactionDef ParentName="RatkinFactionBase">
 		<defName>Rakinia</defName>
-		<label>ratkin kingdom</label>
+		<label>ratkin war kingdom</label>
 		<description>Ratkin War Kingdom. It is a invasive xenophobic species that lives visible to human beings and want to kill them all.</description>
 		<colorSpectrum>
 			<li>(0.80, 0.40, 0.15)</li>
@@ -250,6 +250,10 @@
 		<requiredMemes>
 			<li MayRequire="Ludeon.RimWorld.Ideology">Supremacist</li>
 		</requiredMemes>
+		<disallowedPrecepts>
+			<li MayRequire="Ludeon.RimWorld.Ideology">ApparelDesired_Strong_Subordinate</li>
+			<li MayRequire="Ludeon.RimWorld.Ideology">ApparelDesired_Soft_Subordinate</li>
+		</disallowedPrecepts>
 		<maxConfigurableAtWorldCreation>9999</maxConfigurableAtWorldCreation>
 		<configurationListOrderPriority>58</configurationListOrderPriority>
 	</FactionDef>


### PR DESCRIPTION
1 slightly reduced armor rating of some Ideology apparels (very high value);
2 slightly reduced carry bulk bonus of tactical vestplate and flak vest (very high value (like a backpacks and tac vest));
3 slightly reduced XM214 Microgun accuracy of first shot, but slightly increased full burst accuracy;
4 slightly reduced secondary bomb damage from all high caliber ammo and arrows/bolts (~7-15%);
5 corrected all high caliber ammo armor penetration (like 30 mm AP-I have less armor penetration than 20 mm one) and flame secondary damage params (all ammo had same flame damage).

1 немного уменьшена броня некоторой одежды Идеологии (были завышенные значения);
2 немного уменьшен переносимый объем у бронежилета и тактического бронежилета (были очень высокие значения (как у рюкзака или разгрузки));
3 немного уменьшена точность первого выстрела у XM214 Микроган, но увеличена точность полной очереди;
4 немного уменьшен урон от вторичного взрыва всех крупнокалиберных боеприпасов и стрел/болтов (~7-15%);
5 у всех крупнокалиберных боеприпасов скорректированы параметры бронепробития (например, 30 мм AP-I имел меньшее бронепробитие, чем аналогичный 20 мм) и вторичный урон от ожога (урон был одинаковый у всех крупнокалиберных боеприпасов).