### PR TITLE
Removed some duplicate damage's multipliers and some tweaks and fixes

### DIFF
--- a/Mods/CombatExtended/Defs/DamageDefs/Damages_LocalInjury.xml
+++ b/Mods/CombatExtended/Defs/DamageDefs/Damages_LocalInjury.xml
@@ -60,7 +60,7 @@
     <workerClass>DamageWorker_Flame</workerClass>
     <!-- <buildingDamageFactor>3</buildingDamageFactor> -->
     <plantDamageFactor>3</plantDamageFactor>
-	<buildingDamageFactorImpassable>4</buildingDamageFactorImpassable>
+	<buildingDamageFactorImpassable>3</buildingDamageFactorImpassable>
     <buildingDamageFactorPassable>3</buildingDamageFactorPassable>
   </DamageDef>
 

--- a/Mods/Core_SK/Defs/DamageDefs/Damages_LocalInjury_SK.xml
+++ b/Mods/Core_SK/Defs/DamageDefs/Damages_LocalInjury_SK.xml
@@ -37,6 +37,7 @@
 		<defaultArmorPenetration>0</defaultArmorPenetration>
 		<canUseDeflectMetalEffect>false</canUseDeflectMetalEffect>
 		<buildingDamageFactor>3</buildingDamageFactor>
+		<plantDamageFactor>5</plantDamageFactor>
 		<explosionHeatEnergyPerCell>3</explosionHeatEnergyPerCell>
 		<explosionCellFleck>BlastPlasma</explosionCellFleck>
 		<soundExplosion>Explosion_PlasmaEXP</soundExplosion>
@@ -89,6 +90,7 @@
 		<armorCategory>Heat</armorCategory>
 		<canUseDeflectMetalEffect>false</canUseDeflectMetalEffect>
 		<harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
+		<plantDamageFactor>3.5</plantDamageFactor>
 		<explosionCellFleck>SmokeRed</explosionCellFleck>
 		<overkillPctToDestroyPart>0~0.7</overkillPctToDestroyPart>
 		<isRanged>true</isRanged>
@@ -194,6 +196,8 @@
 		<impactSoundType>Slice</impactSoundType>
 		<armorCategory>Sharp</armorCategory>
 		<overkillPctToDestroyPart>0~0.7</overkillPctToDestroyPart>
+		<buildingDamageFactor>0.1</buildingDamageFactor>
+		<plantDamageFactor>0.1</plantDamageFactor>
 		<isRanged>true</isRanged>
 		<makesAnimalsFlee>true</makesAnimalsFlee>
 	</DamageDef>
@@ -208,6 +212,8 @@
 		<impactSoundType>Bullet</impactSoundType>
 		<armorCategory>Sharp</armorCategory>
 		<overkillPctToDestroyPart>0~0.7</overkillPctToDestroyPart>
+		<buildingDamageFactor>0.05</buildingDamageFactor>
+		<plantDamageFactor>0.5</plantDamageFactor>
 		<isRanged>true</isRanged>
 		<makesAnimalsFlee>true</makesAnimalsFlee>
 		<additionalHediffs>
@@ -232,6 +238,8 @@
 		<impactSoundType>Slice</impactSoundType>
 		<armorCategory>Sharp</armorCategory>
 		<overkillPctToDestroyPart>0~0.1</overkillPctToDestroyPart>
+		<buildingDamageFactor>0.55</buildingDamageFactor>
+		<plantDamageFactor>0.55</plantDamageFactor>
 		<applyAdditionalHediffsIfHuntingForFood>false</applyAdditionalHediffsIfHuntingForFood>
 	</DamageDef>
 	<SK.Events.DamageDef_Disease ParentName="DiseaseBite">
@@ -271,6 +279,8 @@
 		<defaultDamage>10</defaultDamage>
 		<defaultArmorPenetration>0</defaultArmorPenetration>
 		<explosionHeatEnergyPerCell>15</explosionHeatEnergyPerCell>
+		<buildingDamageFactor>0.7</buildingDamageFactor>
+		<plantDamageFactor>0.7</plantDamageFactor>
 		<explosionCellFleck>BlastFlame</explosionCellFleck>
 		<explosionColorCenter>(0.6, 0.9, 0.6)</explosionColorCenter>
 		<explosionColorEdge>(0.3, 0.65, 0.3)</explosionColorEdge>
@@ -298,6 +308,8 @@
 		<harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
 		<armorCategory>Sharp</armorCategory>
 		<canUseDeflectMetalEffect>false</canUseDeflectMetalEffect>
+		<buildingDamageFactor>0.3</buildingDamageFactor>
+		<plantDamageFactor>0.6</plantDamageFactor>
 		<additionalHediffs>
 			<li>
 				<hediff>Acid_Poison</hediff>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Insectoids.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Insectoids.xml
@@ -15,6 +15,7 @@
 		<autoFlee>false</autoFlee>
 		<canSiege>false</canSiege>
 		<canUseAvoidGrid>false</canUseAvoidGrid>
+		<earliestRaidDays>15</earliestRaidDays>
 		<techLevel>Animal</techLevel>
 		<permanentEnemy>true</permanentEnemy>
 		<attackersDownPercentageRangeForAutoFlee>1</attackersDownPercentageRangeForAutoFlee>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Kingdom.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Kingdom.xml
@@ -16,7 +16,7 @@
 		<canStageAttacks>true</canStageAttacks>
 		<autoFlee>true</autoFlee>
 		<leaderTitle>king</leaderTitle>
-		<earliestRaidDays>20</earliestRaidDays>
+		<earliestRaidDays>30</earliestRaidDays>
 		<geneticVariance>0.2</geneticVariance>	
 		<leaderForceGenerateNewPawn>true</leaderForceGenerateNewPawn>
 		<factionIconPath>World/WorldObjects/Expanding/Kingdom</factionIconPath>	

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Norbal.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Norbal.xml
@@ -16,6 +16,7 @@
 		<canSiege>true</canSiege>
 		<autoFlee>true</autoFlee>
 		<mustStartOneEnemy>true</mustStartOneEnemy>
+		<earliestRaidDays>15</earliestRaidDays>
 		<factionIconPath>World/WorldObjects/Expanding/Norbals</factionIconPath>
 		<factionNameMaker>NamerFactionNorbal</factionNameMaker>
 		<settlementNameMaker>NamerFactionBaseNorbal</settlementNameMaker>

--- a/Mods/Core_SK/Defs/Storyteller/Incidents_Map_Threats.xml
+++ b/Mods/Core_SK/Defs/Storyteller/Incidents_Map_Threats.xml
@@ -79,7 +79,7 @@
 			<li>Map_PlayerHome</li>
 		</targetTags>
 		<workerClass>SK.Events.IncidentWorker_ManhunterPack</workerClass>
-		<baseChance>0.75</baseChance>
+		<baseChance>0</baseChance>
 		<minRefireDays>8</minRefireDays>
 		<category>ThreatBig</category>
 		<pointsScaleable>true</pointsScaleable>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings.xml
@@ -16,52 +16,20 @@
 		</statBases>
 		<damageMultipliers>
 			<li>
-				<damageDef>Bomb</damageDef>
-				<multiplier>1.0</multiplier>
-			</li>
-			<li>
-				<damageDef>Thermobaric</damageDef>
-				<multiplier>1.2</multiplier>
-			</li>
-			<li>
 				<damageDef>Bullet</damageDef>
 				<multiplier>0.5</multiplier>
-			</li>
-			<li>
-				<damageDef>Dart</damageDef>
-				<multiplier>0.1</multiplier>
 			</li>
 			<li>
 				<damageDef>Arrow</damageDef>
 				<multiplier>0.2</multiplier>
 			</li>
 			<li>
-				<damageDef>Poison</damageDef>
-				<multiplier>0.05</multiplier>
-			</li>
-			<li>
-				<damageDef>Acid</damageDef>
-				<multiplier>0.7</multiplier>
-			</li>
-			<li>
-				<damageDef>AcidPoison</damageDef>
-				<multiplier>0.3</multiplier>
-			</li>	
-			<li>
 				<damageDef>Beanbag</damageDef>
 				<multiplier>0.1</multiplier>
 			</li>
 			<li>
-				<damageDef>LaserBurn</damageDef>
-				<multiplier>1.0</multiplier>
-			</li>
-			<li>
 				<damageDef>Optic</damageDef>
 				<multiplier>0.7</multiplier>
-			</li>
-			<li>
-				<damageDef>Plasma</damageDef>
-				<multiplier>1.1</multiplier>
 			</li>
 			<li>
 				<damageDef>Microwave</damageDef>
@@ -78,18 +46,6 @@
 			<li>
 				<damageDef>Bite</damageDef>
 				<multiplier>0.55</multiplier>
-			</li>
-			<li>
-				<damageDef>PlagueBite</damageDef>
-				<multiplier>0.55</multiplier>
-			</li>
-			<li>
-				<damageDef>MalariaBite</damageDef>
-				<multiplier>0.55</multiplier>
-			</li>
-			<li>
-				<damageDef>Electrical</damageDef>
-				<multiplier>1.0</multiplier>
 			</li>
 			<li>
 				<damageDef>KineticPulse</damageDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Hive.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Hive.xml
@@ -88,6 +88,10 @@
 				<damageDef>Bullet</damageDef>
 				<multiplier>4</multiplier>
 			</li>
+			<li>
+				<damageDef>Arrow</damageDef>
+				<multiplier>4</multiplier>
+			</li>
 		</damageMultipliers>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Base.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Base.xml
@@ -36,14 +36,6 @@
 		</thingCategories>
 		<damageMultipliers>
 			<li>
-				<damageDef>Bomb</damageDef>
-				<multiplier>4.2</multiplier>
-			</li>
-			<li>
-				<damageDef>Thermobaric</damageDef>
-				<multiplier>7.5</multiplier>
-			</li>
-			<li>
 				<damageDef>Bullet</damageDef>
 				<multiplier>0.5</multiplier>
 			</li>
@@ -56,16 +48,8 @@
 				<multiplier>0.1</multiplier>
 			</li>
 			<li>
-				<damageDef>LaserBurn</damageDef>
-				<multiplier>3.5</multiplier>
-			</li>
-			<li>
 				<damageDef>Optic</damageDef>
 				<multiplier>4.0</multiplier>
-			</li>
-			<li>
-				<damageDef>Plasma</damageDef>
-				<multiplier>5.0</multiplier>
 			</li>
 			<li>
 				<damageDef>Microwave</damageDef>

--- a/Mods/Core_SK/Patches/DamageDef_Patch.xml
+++ b/Mods/Core_SK/Patches/DamageDef_Patch.xml
@@ -4,7 +4,7 @@
     <Operation Class="PatchOperationReplace">
         <xpath>Defs/DamageDef[defName="Bomb"]/buildingDamageFactorImpassable</xpath>
         <value>
-            <buildingDamageFactorImpassable>3</buildingDamageFactorImpassable>
+            <buildingDamageFactorImpassable>2</buildingDamageFactorImpassable>
         </value>
     </Operation>
 


### PR DESCRIPTION
1 removed some duplicate damage's multipliers for plants and buildings. Some of them moved to damage defs;
2 corrected building damage factor of impassable buildings to 1.2 HSK values;
3 added missed hive's arrows damage multiplier (like bullets one);
4 disable duplicate manhunter pack event;
5 increased earliest raid days of kingdom faction (20->30 days), norbal faction (0->15 days) (to prevent early siege raids spam) and insectoids (0->15 days) (cuz arriving only one antises).

1 удалены некоторые дублирующие множители урона по растениям и постройкам. Некоторые из них перемещены в настройки урона для их корректного отображения в игре;
2 скорректированы некоторые значения множителей урона (частично откатил до значений из 1.2, т.к. в ваниле 1.3 появились подмножители, которые не учитывались ранее во время балансировки тех же гранат);
3 добавлен пропущенный множитель урона от стрел для ульев (как у пуль);
4 выключен дубликат события прихода агрессивных животных;
5 увеличена задержка прихода рейдов фракции королевства (с 20 до 30 дней), фракции норбалов (с 0 до 15 дней) (чтобы предотвратить спам ранних осад этих фракций) и инсектоидов (с 0 до 15 дней) (т.к. в 99% случаев приходит один антис).