### PR TITLE
Removed toggleable overlays from default modsconfig

### DIFF
--- a/ModsConfig.xml
+++ b/ModsConfig.xml
@@ -101,7 +101,6 @@
     <li>name.krypt.rimworld.moddiff</li>
     <li>void.charactereditor</li>
     <li>telefonmast.graphicssettings</li>
-    <li>owlchemist.toggleableoverlays</li>
     <li>owlchemist.toggleablereadouts</li>
     <li>owlchemist.scatteredflames</li>
     <li>trinity.runtimegcupdated</li>


### PR DESCRIPTION
Mod by default does unexpected things and many players are confused. Moreover, even after explaining people prefer to turn this off.