### PR TITLE
New category for fungi

### DIFF
--- a/Mods/Core_SK/Defs/ThingCategoryDefs/ThingCategories_SK.xml
+++ b/Mods/Core_SK/Defs/ThingCategoryDefs/ThingCategories_SK.xml
@@ -76,7 +76,6 @@
 		<label>Preserves</label>
 		<parent>Foods</parent>
 		<resourceReadoutRoot>true</resourceReadoutRoot>
-		<iconPath>UI/Icons/ThingCategories/Preserves</iconPath>
 	</ThingCategoryDef>
 	<ThingCategoryDef>
 		<defName>Alcohol</defName>
@@ -154,6 +153,13 @@
 	<ThingCategoryDef>
 		<defName>FruitFoodRaw</defName>
 		<label>Fruits</label>
+		<parent>PlantFoodRaw</parent>
+		<resourceReadoutRoot>true</resourceReadoutRoot>
+		<iconPath>UI/Icons/ThingCategories/FruitFoodRaw</iconPath>
+	</ThingCategoryDef>
+	<ThingCategoryDef>
+		<defName>FungusPlantRaw</defName>
+		<label>Fungi</label>
 		<parent>PlantFoodRaw</parent>
 		<resourceReadoutRoot>true</resourceReadoutRoot>
 		<iconPath>UI/Icons/ThingCategories/FruitFoodRaw</iconPath>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_CookingSupplies.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_CookingSupplies.xml
@@ -68,6 +68,7 @@
 		<statBases>
 			<MarketValue>2.0</MarketValue>
 		</statBases>   
+		<stackLimit>150</stackLimit>
 		<tickerType>Rare</tickerType>   
 		<thingCategories>
 			<li>CookingSupplies</li>
@@ -258,38 +259,6 @@
 			</li>
 		</comps>
 		<stackLimit>100</stackLimit>
-	</ThingDef>
-
-	<ThingDef ParentName="SK_PlantFoodRawBase">
-		<defName>RawFungus</defName>
-		<label>raw fungus</label>
-		<description>Raw fungus.</description>
-		<soundInteract>Grain_Drop</soundInteract>
-		<soundDrop>Grain_Drop</soundDrop>
-		<graphicData>
-			<texPath>Things/Item/Resource/PlantFoodRaw/RawFungus</texPath>
-		</graphicData>
-		<thingCategories>
-			<li>BasicPlantFoodRaw</li>
-		</thingCategories>
-		<statBases>
-			<MarketValue>1.1</MarketValue>
-			<Nutrition>0.05</Nutrition>
-		</statBases>
-		<tickerType>Rare</tickerType>   
-		<ingestible>
-			<foodType>Fungus</foodType>
-		</ingestible>
-		<ingredient>
-			<mergeCompatibilityTags>
-				<li MayRequire="Ludeon.RimWorld.Ideology">Fungus</li>
-			</mergeCompatibilityTags>
-		</ingredient>
-		<comps>
-			<li Class="CompProperties_Rottable">
-				<daysToRotStart>40</daysToRotStart>
-			</li>
-		</comps>
 	</ThingDef>
 
 </Defs>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Fungi.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Fungi.xml
@@ -12,16 +12,18 @@
 			<Mass>0.04</Mass>
 			<Bulk>0.05</Bulk>
 			<Nutrition>0.05</Nutrition>
+			<FoodPoisonChanceFixedHuman>0.02</FoodPoisonChanceFixedHuman>
 		</statBases>
 		<tickerType>Rare</tickerType>
 		<socialPropernessMatters>true</socialPropernessMatters>
 		<ingestible>
 			<preferability>RawBad</preferability>
+			<tasteThought>AteRawFood</tasteThought>
 			<ingestEffect>EatVegetarian</ingestEffect>
 			<ingestSound>RawVegetable_Eat</ingestSound>
 		</ingestible>
 		<thingCategories>
-			<li>PlantFoodRaw</li>
+			<li>FungusPlantRaw</li>
 		</thingCategories>
 	</ThingDef>
 
@@ -42,7 +44,7 @@
 			<foodType>Fungus</foodType>
 			<joy>0.08</joy>
 			<joyKind>Gluttonous</joyKind>
-			<specialThoughtDirect>AteRawShimmershroom</specialThoughtDirect>
+			<tasteThought>AteRawShimmershroom</tasteThought>
 			<specialThoughtAsIngredient>AteRawShimmershroom</specialThoughtAsIngredient>
 		</ingestible>
 		<ingredient>
@@ -70,7 +72,6 @@
 		</statBases>
 		<ingestible>
 			<foodType>Fungus</foodType>
-			<specialThoughtDirect>AteRawFood</specialThoughtDirect>
 		</ingestible>
 		<ingredient>
 			<mergeCompatibilityTags>
@@ -115,21 +116,16 @@
 		</comps>
 	</ThingDef>
 
-	<ThingDef ParentName="SK_PlantFoodRawBase">
-		<defName>RawGiantLeaf</defName>
-		<label>giant leaf</label>
-		<description>Raw giant leaf. Not really appetizing raw, it is better prepared as a soup.</description>
+	<ThingDef ParentName="MushroomBase">
+		<defName>RawFungus</defName>
+		<label>raw fungus</label>
+		<description>Raw fungus.</description>
 		<graphicData>
-			<texPath>Things/Item/Resource/PlantFoodRaw/RawGiantLeaf</texPath>
-			<graphicClass>Graphic_Single</graphicClass>
+			<texPath>Things/Item/Resource/PlantFoodRaw/RawFungus</texPath>
 		</graphicData>
 		<statBases>
-			<MarketValue>2.0</MarketValue>
-			<Nutrition>0.05</Nutrition>
+			<MarketValue>1.1</MarketValue>
 		</statBases>
-		<thingCategories>
-			<li>BasicPlantFoodRaw</li>
-		</thingCategories>
 		<ingestible>
 			<foodType>Fungus</foodType>
 		</ingestible>
@@ -140,7 +136,36 @@
 		</ingredient>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>25</daysToRotStart>
+				<daysToRotStart>12</daysToRotStart>
+				<rotDestroys>true</rotDestroys>
+			</li>
+		</comps>
+	</ThingDef>
+
+
+	<ThingDef ParentName="MushroomBase">
+		<defName>Rawmushroom</defName>
+		<label>Raw Champignon</label>
+		<description>Raw Champignon are small white or brown edible caps of the Champignon Mushroom. The caps are round in appearance. Unsavory when eaten raw, as the texture is similar to raw meat.</description>
+		<graphicData>
+			<texPath>Things/Veg/mushroom</texPath>
+		</graphicData>
+		<statBases>
+			<MarketValue>5</MarketValue>
+			<Nutrition>0.09</Nutrition>
+		</statBases>
+		<ingestible>
+			<foodType>Fungus</foodType>
+		</ingestible>
+		<ingredient>
+			<mergeCompatibilityTags>
+				<li MayRequire="Ludeon.RimWorld.Ideology">Fungus</li>
+			</mergeCompatibilityTags>
+		</ingredient>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>14</daysToRotStart>
+				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>
 	</ThingDef>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Vegetables.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops_Vegetables.xml
@@ -106,19 +106,18 @@
 		</comps>
 	</ThingDef> 
 
-
 	<ThingDef ParentName="SK_PlantFoodRawBase">
-		<defName>Rawmushroom</defName>
-		<label>Raw Champignon</label>
-		<description>Raw Champignon are small white or brown edible caps of the Champignon Mushroom. The caps are round in appearance. Unsavory when eaten raw, as the texture is similar to raw meat.</description>
+		<defName>RawGiantLeaf</defName>
+		<label>giant leaf</label>
+		<description>Raw giant leaf. Not really appetizing raw, it is better prepared as a soup.</description>
 		<graphicData>
-			<texPath>Things/Veg/mushroom</texPath>
+			<texPath>Things/Item/Resource/PlantFoodRaw/RawGiantLeaf</texPath>
+			<graphicClass>Graphic_Single</graphicClass>
 		</graphicData>
 		<statBases>
-			<MarketValue>5</MarketValue>
-			<Nutrition>0.09</Nutrition>
+			<MarketValue>2.0</MarketValue>
+			<Nutrition>0.05</Nutrition>
 		</statBases>
-		<tickerType>Rare</tickerType>   
 		<thingCategories>
 			<li>BasicPlantFoodRaw</li>
 		</thingCategories>
@@ -127,12 +126,10 @@
 		</ingestible>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>14</daysToRotStart>
-				<rotDestroys>true</rotDestroys>
+				<daysToRotStart>25</daysToRotStart>
 			</li>
 		</comps>
 	</ThingDef>
-
 
 	<ThingDef ParentName="SK_PlantFoodRawBase">
 		<defName>RawAlgae</defName>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ThingCategoryDef/Categories_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ThingCategoryDef/Categories_SK.xml
@@ -54,10 +54,11 @@
 	<Animalfood.label>Еда для зверей</Animalfood.label>
 	<BasicPlantFoodRaw.label>Обычная</BasicPlantFoodRaw.label>
 	<ExtraPlantFoodRaw.label>Вкусная</ExtraPlantFoodRaw.label>
-	<LuxuryStuffs.label>Отдельные</LuxuryStuffs.label>
+	<LuxuryStuffs.label>Особая</LuxuryStuffs.label>
 	<Hydrocarbons.label>Углеводороды</Hydrocarbons.label>
 	<Chemical.label>Химия</Chemical.label>
 	<FruitFoodRaw.label>Фрукты</FruitFoodRaw.label>
+	<FungusPlantRaw.label>Грибы</FungusPlantRaw.label>
 	<SweetMeals.label>Сладости</SweetMeals.label>
 	<Preserves.label>Консервы</Preserves.label>
 	<CookingSupplies.label>Кулинарные ингредиенты</CookingSupplies.label>


### PR DESCRIPTION
- All fungi related edibles are now in "Fungi" category
- Champignon are now recognized by ideology as fungi
- Giant leaves are no longe considered fungi
-------

- Все съедобные грибы теперь в категории "грибы"
- Шампиньоны теперь корректно распознаются идеалогией
- Гигантские листья теперь не считаются грибами