### PR TITLE
Food update

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_PrepareFishes.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_PrepareFishes.xml
@@ -23,7 +23,7 @@
       </li>
     </ingredients>
     <products>
-      <MealFine_Meat>1</MealFine_Meat>
+      <MealFine>1</MealFine>
     </products>
     <fixedIngredientFilter>
       <thingDefs>
@@ -68,7 +68,7 @@
       </li>
     </ingredients>
     <products>
-      <MealFine_Meat>4</MealFine_Meat>
+      <MealFine>4</MealFine>
     </products>
     <fixedIngredientFilter>
       <thingDefs>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals.xml
@@ -18,6 +18,7 @@
 				<filter>
 					<categories>
 						<li>BasicPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
 					</categories>
 				</filter>
 				<count>0.45</count>
@@ -29,11 +30,13 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>BasicPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<categories>
 				<li>BasicPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 		</defaultIngredientFilter>
 		<skillRequirements>
@@ -67,6 +70,7 @@
 				<filter>
 					<categories>
 						<li>BasicPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
 					</categories>
 				</filter>
 				<count>2.25</count>
@@ -78,11 +82,13 @@
 		<fixedIngredientFilter>
 			<categories>
 				<li>BasicPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<categories>
 				<li>BasicPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 		</defaultIngredientFilter>
 		<skillRequirements>
@@ -92,119 +98,6 @@
 		<recipeUsers>
 			<li>ElectricStove_Pro</li>
 		</recipeUsers>
-		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
-	</RecipeDef>
-
-
-	<RecipeDef>
-		<defName>MakeFriedMushrooms</defName>
-		<label>cook fried cave mushrooms</label>
-		<description>Prepares fried cave mushrooms. Produces 1.</description>
-		<jobString>Preparing fried cave mushrooms.</jobString>
-		<workAmount>600</workAmount>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>RawShimmershroom</li>
-						<li>RawGlowbulb</li>
-					</thingDefs>
-				</filter>
-				<count>0.5</count>
-			</li>
-		</ingredients>
-		<products>
-			<FriedMushrooms>1</FriedMushrooms>
-		</products>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-			</thingDefs>
-			<specialFiltersToDisallow>
-				<li>AllowPlantFood</li>
-			</specialFiltersToDisallow>
-		</fixedIngredientFilter>
-		<defaultIngredientFilter>
-			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-			</thingDefs>
-			<disallowedCategories>
-				<li>EggsFertilized</li>
-			</disallowedCategories>
-		</defaultIngredientFilter>
-		<skillRequirements>
-			<Cooking>2</Cooking>
-		</skillRequirements>
-		<workSkill>Cooking</workSkill>
-		<recipeUsers>
-			<li>Campfire</li>
-			<li>TableGrill</li>
-			<li>FueledStove</li>
-			<li>ElectricStove</li>
-		</recipeUsers>
-		<researchPrerequisite>Food_00</researchPrerequisite>
-	</RecipeDef>
-
-
-	<RecipeDef>
-		<defName>MakeFriedMushroomsBulk</defName>
-		<label>cook fried cave mushrooms (x4)</label>
-		<description>Prepares fried cave mushrooms. Produces 4. Much of the ingredients are wasted in order to create the best eating experience.</description>
-		<jobString>Preparing fried cave mushrooms.</jobString>
-		<workAmount>1600</workAmount>
-		<workSpeedStat>CookSpeed</workSpeedStat>
-		<effectWorking>Cook</effectWorking>
-		<soundWorking>Recipe_CookMeal</soundWorking>
-		<requiredGiverWorkType>Cooking</requiredGiverWorkType>
-		<allowMixingIngredients>true</allowMixingIngredients>
-		<ingredientValueGetterClass>IngredientValueGetter_Nutrition</ingredientValueGetterClass>
-		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>RawShimmershroom</li>
-						<li>RawGlowbulb</li>
-					</thingDefs>
-				</filter>
-				<count>2.5</count>
-			</li>
-		</ingredients>
-		<products>
-			<FriedMushrooms>4</FriedMushrooms>
-		</products>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-			</thingDefs>
-			<specialFiltersToDisallow>
-				<li>AllowPlantFood</li>
-			</specialFiltersToDisallow>
-		</fixedIngredientFilter>
-		<defaultIngredientFilter>
-			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-			</thingDefs>
-			<disallowedCategories>
-				<li>EggsFertilized</li>
-			</disallowedCategories>
-		</defaultIngredientFilter>
-		<skillRequirements>
-			<Cooking>3</Cooking>
-		</skillRequirements>
-		<recipeUsers>
-			<li>ElectricStove_Pro</li>
-		</recipeUsers>
-		<workSkill>Cooking</workSkill>
 		<researchPrerequisite>PackagedSurvivalMeal</researchPrerequisite>
 	</RecipeDef>
 
@@ -250,7 +143,7 @@
 			</disallowedCategories>
 		</defaultIngredientFilter>
 		<skillRequirements>
-			<Cooking>2</Cooking>
+			<Cooking>0</Cooking>
 		</skillRequirements>
 		<workSkill>Cooking</workSkill>
 		<recipeUsers>
@@ -304,7 +197,7 @@
 			</disallowedCategories>
 		</defaultIngredientFilter>
 		<skillRequirements>
-			<Cooking>2</Cooking>
+			<Cooking>0</Cooking>
 		</skillRequirements>
 		<recipeUsers>
 			<li>ElectricStove_Pro</li>
@@ -333,9 +226,6 @@
 						<li>FruitFoodRaw</li>
 						<li>ExtraPlantFoodRaw</li>
 					</categories>
-					<thingDefs>
-						<li>RawGiantLeaf</li>
-					</thingDefs>
 				</filter>
 				<count>0.45</count>
 			</li>
@@ -348,9 +238,6 @@
 				<li>FruitFoodRaw</li>
 				<li>ExtraPlantFoodRaw</li>
 			</categories>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<specialFiltersToDisallow>
 				<li>AllowPlantFood</li>
 			</specialFiltersToDisallow>
@@ -359,15 +246,12 @@
 			<categories>
 				<li>FruitFoodRaw</li>
 			</categories>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<disallowedCategories>
 				<li>EggsFertilized</li>
 			</disallowedCategories>
 		</defaultIngredientFilter>
 		<skillRequirements>
-			<Cooking>2</Cooking>
+			<Cooking>0</Cooking>
 		</skillRequirements>
 		<workSkill>Cooking</workSkill>
 		<recipeUsers>
@@ -398,9 +282,6 @@
 						<li>FruitFoodRaw</li>
 						<li>ExtraPlantFoodRaw</li>
 					</categories>
-					<thingDefs>
-						<li>RawGiantLeaf</li>
-					</thingDefs>
 				</filter>
 				<count>2.25</count>
 			</li>
@@ -413,9 +294,6 @@
 				<li>FruitFoodRaw</li>
 				<li>ExtraPlantFoodRaw</li>
 			</categories>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<specialFiltersToDisallow>
 				<li>AllowPlantFood</li>
 			</specialFiltersToDisallow>
@@ -425,15 +303,12 @@
 				<li>FruitFoodRaw</li>
 				<li>ExtraPlantFoodRaw</li>
 			</categories>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<disallowedCategories>
 				<li>EggsFertilized</li>
 			</disallowedCategories>
 		</defaultIngredientFilter>
 		<skillRequirements>
-			<Cooking>3</Cooking>
+			<Cooking>0</Cooking>
 		</skillRequirements>
 		<workSkill>Cooking</workSkill>
 		<recipeUsers>
@@ -580,10 +455,6 @@
 		<ingredients>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>RawShimmershroom</li>
-						<li>RawGlowbulb</li>
-					</thingDefs>
 					<categories>
 						<li>MeatRaw</li>
 						<li>EggsUnfertilized</li>
@@ -598,10 +469,8 @@
 						<li>BasicPlantFoodRaw</li>
 						<li>FruitFoodRaw</li>
 						<li>ExtraPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
 					</categories>
-					<thingDefs>
-						<li>RawGiantLeaf</li>
-					</thingDefs>
 				</filter>
 				<count>0.45</count>
 			</li>
@@ -610,11 +479,6 @@
 			<MealFine>2</MealFine>
 		</products>
 		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
 				<li>EggsUnfertilized</li>
@@ -622,23 +486,20 @@
 				<li>BasicPlantFoodRaw</li>
 				<li>FruitFoodRaw</li>
 				<li>ExtraPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<specialFiltersToDisallow>
 				<li>AllowPlantFood</li>
 			</specialFiltersToDisallow>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
-			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
 				<li>EggsUnfertilized</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>FruitFoodRaw</li>
 				<li>ExtraPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<disallowedThingDefs>
 				<li>Meat_Megaspider</li>
@@ -647,78 +508,6 @@
 			<disallowedCategories>
 				<li>EggsFertilized</li>
 			</disallowedCategories>
-		</defaultIngredientFilter>
-	</RecipeDef>
-
-	<RecipeDef ParentName="CookMealFineBase">
-		<defName>CookMealFine_Veg</defName>
-		<label>cook vegetarian fine meal</label>
-		<description>Cook a somewhat complex meal from plant ingredients. Produces 2.</description>
-		<jobString>Cooking vegetarian fine meal.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<categories>
-						<li>BasicPlantFoodRaw</li>
-						<li>FruitFoodRaw</li>
-						<li>ExtraPlantFoodRaw</li>
-					</categories>
-					<thingDefs>
-						<li>RawGiantLeaf</li>
-					</thingDefs>
-				</filter>
-				<count>1.5</count>
-			</li>
-		</ingredients>
-		<products>
-			<MealFine_Veg>2</MealFine_Veg>
-		</products>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
-			<categories>
-				<li>BasicPlantFoodRaw</li>
-				<li>FruitFoodRaw</li>
-				<li>ExtraPlantFoodRaw</li>
-			</categories>
-			<specialFiltersToDisallow>
-				<li>AllowPlantFood</li>
-			</specialFiltersToDisallow>
-		</fixedIngredientFilter>
-	</RecipeDef>
-
-	<RecipeDef ParentName="CookMealFineBase">
-		<defName>CookMealFine_Meat</defName>
-		<label>cook carnivore fine meal</label>
-		<description>Cook a somewhat complex meal from meat ingredients. Produces 2.</description>
-		<jobString>Cooking carnivore fine meal.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<categories>
-						<li>MeatRaw</li>
-					</categories>
-				</filter>
-				<count>1.5</count>
-			</li>
-		</ingredients>
-		<products>
-			<MealFine_Meat>2</MealFine_Meat>
-		</products>
-		<fixedIngredientFilter>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-		</fixedIngredientFilter>
-		<defaultIngredientFilter>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-			<disallowedThingDefs>
-				<li>Meat_Megaspider</li>
-				<li>Meat_Human</li>
-			</disallowedThingDefs>
 		</defaultIngredientFilter>
 	</RecipeDef>
 
@@ -748,10 +537,6 @@
 		<ingredients>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>RawShimmershroom</li>
-						<li>RawGlowbulb</li>
-					</thingDefs>
 					<categories>
 						<li>MeatRaw</li>
 						<li>EggsUnfertilized</li>
@@ -766,6 +551,7 @@
 						<li>BasicPlantFoodRaw</li>
 						<li>FruitFoodRaw</li>
 						<li>ExtraPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
 					</categories>
 				</filter>
 				<count>2.25</count>
@@ -775,11 +561,6 @@
 			<MealFine>8</MealFine>
 		</products>
 		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
 				<li>EggsUnfertilized</li>
@@ -787,23 +568,20 @@
 				<li>BasicPlantFoodRaw</li>
 				<li>FruitFoodRaw</li>
 				<li>ExtraPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<specialFiltersToDisallow>
 				<li>AllowPlantFood</li>
 			</specialFiltersToDisallow>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
-			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
 				<li>EggsUnfertilized</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>FruitFoodRaw</li>
 				<li>ExtraPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<disallowedThingDefs>
 				<li>Meat_Megaspider</li>
@@ -812,78 +590,6 @@
 			<disallowedCategories>
 				<li>EggsFertilized</li>
 			</disallowedCategories>
-		</defaultIngredientFilter>
-	</RecipeDef>
-
-	<RecipeDef ParentName="CookMealFineBulkBase">
-		<defName>CookMealFineBulk_Veg</defName>
-		<label>cook vegetarian fine meal (x4)</label>
-		<description>Cook somewhat complex meals from plant ingredients. Some of the ingredients are wasted in order to create a good eating experience. Producing varied flavors with plants alone introduces extra inefficiencies. Produces 8. Much of the ingredients are wasted in order to create the best eating experience.</description>
-		<jobString>Cooking vegetarian fine meal.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<categories>
-						<li>BasicPlantFoodRaw</li>
-						<li>FruitFoodRaw</li>
-						<li>ExtraPlantFoodRaw</li>
-					</categories>
-					<thingDefs>
-						<li>RawGiantLeaf</li>
-					</thingDefs>
-				</filter>
-				<count>7.5</count>
-			</li>
-		</ingredients>
-		<products>
-			<MealFine_Veg>8</MealFine_Veg>
-		</products>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
-			<categories>
-				<li>BasicPlantFoodRaw</li>
-				<li>FruitFoodRaw</li>
-				<li>ExtraPlantFoodRaw</li>
-			</categories>
-			<specialFiltersToDisallow>
-				<li>AllowPlantFood</li>
-			</specialFiltersToDisallow>
-		</fixedIngredientFilter>
-	</RecipeDef>
-
-	<RecipeDef ParentName="CookMealFineBulkBase">
-		<defName>CookMealFineBulk_Meat</defName>
-		<label>cook carnivore fine meal (x4)</label>
-		<description>Cook somewhat complex meals from meat ingredients. Some of the ingredients are wasted in order to create a good eating experience. Producing varied flavors with meat alone introduces extra inefficiencies. Produces 8. Much of the ingredients are wasted in order to create the best eating experience.</description>
-		<jobString>Cooking carnivore fine meal.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<categories>
-						<li>MeatRaw</li>
-					</categories>
-				</filter>
-				<count>7.5</count>
-			</li>
-		</ingredients>
-		<products>
-			<MealFine_Meat>8</MealFine_Meat>
-		</products>
-		<fixedIngredientFilter>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-		</fixedIngredientFilter>
-		<defaultIngredientFilter>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-			<disallowedThingDefs>
-				<li>Meat_Megaspider</li>
-				<li>Meat_Human</li>
-			</disallowedThingDefs>
 		</defaultIngredientFilter>
 	</RecipeDef>
 
@@ -929,6 +635,7 @@
 				<filter>
 					<categories>
 						<li>BasicPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
 					</categories>
 				</filter>
 				<count>0.4</count>
@@ -953,6 +660,7 @@
 				<li>BasicPlantFoodRaw</li>
 				<li>EggsUnfertilized</li>
 				<li>EggsFertilized</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<thingDefs>
 				<li>Meat_Muffalo</li>
@@ -967,6 +675,7 @@
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>AnimalProductRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<thingDefs>
 				<li>Meat_Muffalo</li>
@@ -980,78 +689,6 @@
 			<disallowedCategories>
 				<li>EggsFertilized</li>
 			</disallowedCategories>
-		</defaultIngredientFilter>
-	</RecipeDef>
-
-	<RecipeDef ParentName="CookMealLavishBase">
-		<defName>CookMealLavish_Veg</defName>
-		<label>cook vegetarian lavish meal</label>
-		<description>Cook a very complex meal from plant ingredients. Much of the ingredients are wasted in order to create the best eating experience. Producing varied flavors with plants alone introduces extra inefficiencies. Produces 2.</description>
-		<jobString>Cooking vegetarian lavish meal.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<categories>
-						<li>BasicPlantFoodRaw</li>
-						<li>FruitFoodRaw</li>
-						<li>ExtraPlantFoodRaw</li>
-					</categories>
-					<thingDefs>
-						<li>RawGiantLeaf</li>
-					</thingDefs>
-				</filter>
-				<count>5</count>
-			</li>
-		</ingredients>
-		<products>
-			<MealLavish_Veg>2</MealLavish_Veg>
-		</products>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
-			<categories>
-				<li>BasicPlantFoodRaw</li>
-				<li>FruitFoodRaw</li>
-				<li>ExtraPlantFoodRaw</li>
-			</categories>
-			<specialFiltersToDisallow>
-				<li>AllowPlantFood</li>
-			</specialFiltersToDisallow>
-		</fixedIngredientFilter>
-	</RecipeDef>
-
-	<RecipeDef ParentName="CookMealLavishBase">
-		<defName>CookMealLavish_Meat</defName>
-		<label>cook carnivore lavish meal</label>
-		<description>Cook a very complex meal from meat ingredients. Much of the ingredients are wasted in order to create the best eating experience. Producing varied flavors with meat alone introduces extra inefficiencies. Produces 2.</description>
-		<jobString>Cooking carnivore lavish meal.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<categories>
-						<li>MeatRaw</li>
-					</categories>
-				</filter>
-				<count>5</count>
-			</li>
-		</ingredients>
-		<products>
-			<MealLavish_Meat>2</MealLavish_Meat>
-		</products>
-		<fixedIngredientFilter>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-		</fixedIngredientFilter>
-		<defaultIngredientFilter>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-			<disallowedThingDefs>
-				<li>Meat_Megaspider</li>
-				<li>Meat_Human</li>
-			</disallowedThingDefs>
 		</defaultIngredientFilter>
 	</RecipeDef>
 
@@ -1097,6 +734,7 @@
 				<filter>
 					<categories>
 						<li>BasicPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
 					</categories>
 				</filter>
 				<count>2</count>
@@ -1121,6 +759,7 @@
 				<li>BasicPlantFoodRaw</li>
 				<li>EggsUnfertilized</li>
 				<li>EggsFertilized</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<thingDefs>
 				<li>Meat_Muffalo</li>
@@ -1135,6 +774,7 @@
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>AnimalProductRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<thingDefs>
 				<li>Meat_Muffalo</li>
@@ -1151,77 +791,6 @@
 		</defaultIngredientFilter>
 	</RecipeDef>
 
-	<RecipeDef ParentName="CookMealLavishBulkBase">
-		<defName>CookMealLavishBulk_Veg</defName>
-		<label>cook vegetarian lavish meal (x4)</label>
-		<description>Cook very complex meals from plant ingredients. Much of the ingredients are wasted in order to create the best eating experience. Producing varied flavors with plants alone introduces extra inefficiencies. Produces 8. Much of the ingredients are wasted in order to create the best eating experience.</description>
-		<jobString>Cooking vegetarian lavish meals.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<categories>
-						<li>BasicPlantFoodRaw</li>
-						<li>FruitFoodRaw</li>
-						<li>ExtraPlantFoodRaw</li>
-					</categories>
-					<thingDefs>
-						<li>RawGiantLeaf</li>
-					</thingDefs>
-				</filter>
-				<count>25</count>
-			</li>
-		</ingredients>
-		<products>
-			<MealLavish_Veg>8</MealLavish_Veg>
-		</products>
-		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
-			<categories>
-				<li>BasicPlantFoodRaw</li>
-				<li>FruitFoodRaw</li>
-				<li>ExtraPlantFoodRaw</li>
-			</categories>
-			<specialFiltersToDisallow>
-				<li>AllowPlantFood</li>
-			</specialFiltersToDisallow>
-		</fixedIngredientFilter>
-	</RecipeDef>
-
-	<RecipeDef ParentName="CookMealLavishBulkBase">
-		<defName>CookMealLavishBulk_Meat</defName>
-		<label>cook carnivore lavish meal (x4)</label>
-		<description>Cook very complex meals from meat ingredients. Much of the ingredients are wasted in order to create the best eating experience. Producing varied flavors with meat alone introduces extra inefficiencies. Produces 8. Much of the ingredients are wasted in order to create the best eating experience.</description>
-		<jobString>Cooking carnivore lavish meals.</jobString>
-		<ingredients>
-			<li>
-				<filter>
-					<categories>
-						<li>MeatRaw</li>
-					</categories>
-				</filter>
-				<count>25</count>
-			</li>
-		</ingredients>
-		<products>
-			<MealLavish_Meat>8</MealLavish_Meat>
-		</products>
-		<fixedIngredientFilter>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-		</fixedIngredientFilter>
-		<defaultIngredientFilter>
-			<categories>
-				<li>MeatRaw</li>
-			</categories>
-			<disallowedThingDefs>
-				<li>Meat_Megaspider</li>
-				<li>Meat_Human</li>
-			</disallowedThingDefs>
-		</defaultIngredientFilter>
-	</RecipeDef>
 
 	<!--<RecipeDef>
 		<defName>CookMealLuxury</defName>
@@ -1461,6 +1030,7 @@
 				<filter>
 					<categories>
 						<li>BasicPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
 					</categories>
 				</filter>
 				<count>1.6</count>
@@ -1474,6 +1044,7 @@
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>AnimalProductRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<thingDefs>
 				<li>Meat_Muffalo</li>
@@ -1487,6 +1058,7 @@
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>AnimalProductRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<thingDefs>
 				<li>Meat_Muffalo</li>
@@ -1545,6 +1117,7 @@
 				<filter>
 					<categories>
 						<li>BasicPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
 					</categories>
 				</filter>
 				<count>8</count>
@@ -1558,6 +1131,7 @@
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>AnimalProductRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<thingDefs>
 				<li>Meat_Muffalo</li>
@@ -1571,6 +1145,7 @@
 				<li>ExtraPlantFoodRaw</li>
 				<li>BasicPlantFoodRaw</li>
 				<li>AnimalProductRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<thingDefs>
 				<li>Meat_Muffalo</li>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Bakery.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Bakery.xml
@@ -50,11 +50,9 @@
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>RawShimmershroom</li>
-						<li>RawGlowbulb</li>
-						<li>Rawmushroom</li>
-					</thingDefs>
+					<categories>
+						<li>FungusPlantRaw</li>
+					</categories>
 				</filter>
 				<count>0.4</count>
 			</li>
@@ -65,12 +63,12 @@
 				<li>Cheese</li>
 				<li>AgedCheese</li>
 				<li>RawTomatoes</li>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>Rawmushroom</li>
 				<li>Meat_Muffalo</li>
 				<li>MetalCannedMeat_prime</li>
 			</thingDefs>
+			<categories>
+				<li>FungusPlantRaw</li>
+			</categories>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<thingDefs>
@@ -78,12 +76,12 @@
 				<li>Cheese</li>
 				<li>AgedCheese</li>
 				<li>RawTomatoes</li>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>Rawmushroom</li>
 				<li>Meat_Muffalo</li>
 				<li>MetalCannedMeat_prime</li>
 			</thingDefs>
+			<categories>
+				<li>FungusPlantRaw</li>
+			</categories>
 		</defaultIngredientFilter>
 		<products>
 			<Pizza>3</Pizza>

--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Special.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Special.xml
@@ -31,10 +31,9 @@
 				<filter>
 					<categories>
 						<li>BasicPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
+						<li>ExtraPlantFoodRaw</li>
 					</categories>
-					<thingDefs>
-						<li>RawGiantLeaf</li>
-					</thingDefs>
 				</filter>
 				<count>0.5</count>
 			</li>
@@ -43,24 +42,22 @@
 			<MeatSoup>3</MeatSoup>
 		</products>
 		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
 				<li>BasicPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
+				<li>ExtraPlantFoodRaw</li>
 			</categories>
 			<specialFiltersToDisallow>
 				<li>AllowPlantFood</li>
 			</specialFiltersToDisallow>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
 				<li>BasicPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
+				<li>ExtraPlantFoodRaw</li>
 			</categories>
 			<disallowedThingDefs>
 				<li>Meat_Megaspider</li>
@@ -97,10 +94,9 @@
 				<filter>
 					<categories>
 						<li>BasicPlantFoodRaw</li>
+						<li>FungusPlantRaw</li>
+						<li>ExtraPlantFoodRaw</li>
 					</categories>
-					<thingDefs>
-						<li>RawGiantLeaf</li>
-					</thingDefs>
 				</filter>
 				<count>2.5</count>
 			</li>
@@ -109,24 +105,22 @@
 			<MeatSoup>12</MeatSoup>
 		</products>
 		<fixedIngredientFilter>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
 				<li>BasicPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
+				<li>ExtraPlantFoodRaw</li>
 			</categories>
 			<specialFiltersToDisallow>
 				<li>AllowPlantFood</li>
 			</specialFiltersToDisallow>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
-			<thingDefs>
-				<li>RawGiantLeaf</li>
-			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
 				<li>BasicPlantFoodRaw</li>
+				<li>FungusPlantRaw</li>
+				<li>ExtraPlantFoodRaw</li>
 			</categories>
 			<disallowedThingDefs>
 				<li>Meat_Megaspider</li>
@@ -653,11 +647,9 @@
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>RawShimmershroom</li>
-						<li>RawGlowbulb</li>
-						<li>Rawmushroom</li>
-					</thingDefs>
+					<categories>
+						<li>FungusPlantRaw</li>
+					</categories>
 				</filter>
 				<count>0.3</count>
 			</li>
@@ -667,13 +659,11 @@
 		</products>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>Rawmushroom</li>
 				<li>RawTomatoes</li>
 			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<specialFiltersToDisallow>
 				<li>AllowPlantFood</li>
@@ -681,13 +671,11 @@
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>Rawmushroom</li>
 				<li>RawTomatoes</li>
 			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<disallowedThingDefs>
 				<li>Meat_Megaspider</li>
@@ -731,11 +719,9 @@
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>RawShimmershroom</li>
-						<li>RawGlowbulb</li>
-						<li>Rawmushroom</li>
-					</thingDefs>
+					<categories>
+						<li>FungusPlantRaw</li>
+					</categories>
 				</filter>
 				<count>1.5</count>
 			</li>
@@ -745,13 +731,11 @@
 		</products>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>Rawmushroom</li>
 				<li>RawTomatoes</li>
 			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<specialFiltersToDisallow>
 				<li>AllowPlantFood</li>
@@ -759,13 +743,11 @@
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>Rawmushroom</li>
 				<li>RawTomatoes</li>
 			</thingDefs>
 			<categories>
 				<li>MeatRaw</li>
+				<li>FungusPlantRaw</li>
 			</categories>
 			<disallowedThingDefs>
 				<li>Meat_Megaspider</li>
@@ -1282,11 +1264,9 @@
 			</li>
 			<li>
 				<filter>
-					<thingDefs>
-						<li>RawShimmershroom</li>
-						<li>RawGlowbulb</li>
-						<li>Rawmushroom</li>
-					</thingDefs>
+					<categories>
+						<li>FungusPlantRaw</li>
+					</categories>
 				</filter>
 				<count>0.4</count>
 			</li>
@@ -1312,26 +1292,26 @@
 		</products>
 		<fixedIngredientFilter>
 			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>Rawmushroom</li>
 				<li>Tofu</li>
 				<li>Rawonion</li>
 				<li>RawAlgae</li>
 			</thingDefs>
+			<categories>
+				<li>FungusPlantRaw</li>
+			</categories>
 			<specialFiltersToDisallow>
 				<li>AllowPlantFood</li>
 			</specialFiltersToDisallow>
 		</fixedIngredientFilter>
 		<defaultIngredientFilter>
 			<thingDefs>
-				<li>RawShimmershroom</li>
-				<li>RawGlowbulb</li>
-				<li>Rawmushroom</li>
 				<li>Tofu</li>
 				<li>Rawonion</li>
 				<li>RawAlgae</li>
 			</thingDefs>
+			<categories>
+				<li>FungusPlantRaw</li>
+			</categories>
 			<disallowedThingDefs>
 				<li>Meat_Megaspider</li>
 				<li>Meat_Human</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals.xml
@@ -143,7 +143,7 @@
 	<ThingDef Name="SK_MealFineBase" ParentName="SK_MealBaseIngredientless" Abstract="True">
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>28</MarketValue>
+			<MarketValue>20</MarketValue>
 			<WorkToMake>450</WorkToMake>
 			<Bulk>1.30</Bulk>
 			<Mass>1.00</Mass>
@@ -173,36 +173,6 @@
 		</graphicData>
 		<comps>
 			<li Class="CompProperties_Ingredients"/>
-		</comps>
-	</ThingDef>
-
-	<ThingDef ParentName="SK_MealFineBase">
-		<defName>MealFine_Veg</defName>
-		<label>vegetarian fine meal</label>
-		<description>A complex dish assembled with care from vegetarian ingredients.</description>
-		<graphicData>
-			<texPath>Things/Item/Meal/FineVeg</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<comps>
-			<li Class="CompProperties_Ingredients">
-				<noIngredientsFoodKind>NonMeat</noIngredientsFoodKind>
-			</li>
-		</comps>
-	</ThingDef>
-
-	<ThingDef ParentName="SK_MealFineBase">
-		<defName>MealFine_Meat</defName>
-		<label>carnivore fine meal</label>
-		<description>A complex dish assembled with care from meat ingredients.</description>
-		<graphicData>
-			<texPath>Things/Item/Meal/FineMeat</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<comps>
-			<li Class="CompProperties_Ingredients">
-				<noIngredientsFoodKind>Meat</noIngredientsFoodKind>
-			</li>
 		</comps>
 	</ThingDef>
 
@@ -241,34 +211,6 @@
 		</graphicData>
 		<comps>
 			<li Class="CompProperties_Ingredients" />
-		</comps>
-	</ThingDef>
-
-	<ThingDef ParentName="SK_MealLavishBase">
-		<defName>MealLavish_Veg</defName>
-		<label>vegetarian lavish meal</label>
-		<graphicData>
-			<texPath>Things/Item/Meal/LavishVeg</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<comps>
-			<li Class="CompProperties_Ingredients">
-				<noIngredientsFoodKind>NonMeat</noIngredientsFoodKind>
-			</li>
-		</comps>
-	</ThingDef>
-
-	<ThingDef ParentName="SK_MealLavishBase">
-		<defName>MealLavish_Meat</defName>
-		<label>carnivore lavish meal</label>
-		<graphicData>
-			<texPath>Things/Item/Meal/LavishMeat</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<comps>
-			<li Class="CompProperties_Ingredients">
-				<noIngredientsFoodKind>Meat</noIngredientsFoodKind>
-			</li>
 		</comps>
 	</ThingDef>
 
@@ -312,7 +254,7 @@
 		</graphicData>
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>20</MarketValue>
+			<MarketValue>12</MarketValue>
 			<WorkToMake>300</WorkToMake>
 			<Bulk>1.50</Bulk>
 			<Mass>1.20</Mass>
@@ -345,7 +287,7 @@
 			<WorkToMake>200</WorkToMake>
 			<Bulk>1.5</Bulk>
 			<Mass>1.2</Mass>
-			<Nutrition>0.68</Nutrition>
+			<Nutrition>0.7</Nutrition>
 		</statBases>
 		<stackLimit>10</stackLimit>
 		<ingestible>
@@ -384,37 +326,6 @@
 		<ingestible>
 			<preferability>MealSimple</preferability>
 			<ingestEffect>EatMeat</ingestEffect>
-			<ingestSound>Meal_Eat</ingestSound>
-		</ingestible>
-		<comps>
-			<li Class="CompProperties_Rottable">
-				<daysToRotStart>4</daysToRotStart>
-				<rotDestroys>true</rotDestroys>
-			</li>
-		</comps>
-	</ThingDef>
-
-	<ThingDef ParentName="SK_MealBase">
-		<defName>FriedMushrooms</defName>
-		<label>fried cave mushrooms</label>
-		<description>Fried cave mushrooms. Rich with proteins and are able to replace meat in some recipes.</description>
-		<graphicData>
-			<texPath>Things/Item/Meal/SaladSimple</texPath>
-			<graphicClass>Graphic_StackCount</graphicClass>
-		</graphicData>
-		<statBases>
-			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>40</MarketValue>
-			<WorkToMake>500</WorkToMake>
-			<Bulk>1.5</Bulk>
-			<Mass>1.2</Mass>
-			<Nutrition>0.7</Nutrition>				
-		</statBases>
-		<stackLimit>10</stackLimit>
-		<ingestible>
-			<foodType>Meal, Processed</foodType>
-			<preferability>MealSimple</preferability>
-			<ingestEffect>EatVegetarian</ingestEffect>
 			<ingestSound>Meal_Eat</ingestSound>
 		</ingestible>
 		<comps>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Canned.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Canned.xml
@@ -76,7 +76,7 @@
 			<li>BasicPlantFoodRaw</li>
 		</thingCategories>
 		<statBases>
-			<MarketValue>13</MarketValue>
+			<MarketValue>9</MarketValue>
 			<Nutrition>0.15</Nutrition>
 		</statBases>
 		<ingestible>
@@ -239,7 +239,7 @@
 		</thingCategories>
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>14</MarketValue>
+			<MarketValue>6</MarketValue>
 			<Bulk>0.25</Bulk>
 			<Mass>0.12</Mass>
 			<WorkToMake>1500</WorkToMake>
@@ -273,7 +273,7 @@
 		</thingCategories>
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>8</MarketValue>
+			<MarketValue>3</MarketValue>
 			<WorkToMake>300</WorkToMake>
 			<Bulk>0.1</Bulk>
 			<Mass>0.04</Mass>
@@ -305,7 +305,7 @@
     </graphicData>
 	 <socialPropernessMatters>true</socialPropernessMatters>
 		<statBases>
-			<MarketValue>3.1</MarketValue>
+			<MarketValue>3.5</MarketValue>
 			<WorkToMake>600</WorkToMake>
 			<Mass>0.03</Mass>
 			<Bulk>0.06</Bulk>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Drinks.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Drinks.xml
@@ -11,11 +11,11 @@
 		</graphicData>
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>25</MarketValue>
+			<MarketValue>10</MarketValue>
 			<WorkToMake>750</WorkToMake>
 			<Bulk>1.0</Bulk>
 			<Mass>0.7</Mass>	
-			<Nutrition>0.4</Nutrition>		 
+			<Nutrition>0.2</Nutrition>		 
 		</statBases>
 		<comps>
 			<li Class="CompProperties_Rottable">
@@ -49,7 +49,7 @@
 		</graphicData>
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>12</MarketValue>
+			<MarketValue>10</MarketValue>
 			<WorkToMake>450</WorkToMake>
 			<Nutrition>0.08</Nutrition>
 		</statBases>
@@ -174,8 +174,8 @@
 		<socialPropernessMatters>true</socialPropernessMatters>
 		<stackLimit>10</stackLimit>
 		<statBases>
-			<MarketValue>12</MarketValue>
-			<Nutrition>0.35</Nutrition>
+			<MarketValue>9</MarketValue>
+			<Nutrition>0.15</Nutrition>
 		</statBases>
 		<thingCategories>
 			<li>Energetics</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Drinks.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_ Drinks.xml
@@ -80,7 +80,7 @@
 				</li>
 				<li Class="IngestionOutcomeDoer_OffsetNeed">
 					<need>Rest</need>
-					<offset>0.5</offset>
+					<offset>0.05</offset>
 					<toleranceChemical>Caffeine</toleranceChemical>
 				</li>
 				<li Class="IngestionOutcomeDoer_GiveHediff">

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_CookingSupplies.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_CookingSupplies.xml
@@ -10,7 +10,7 @@
 		</graphicData>
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>20</MarketValue>
+			<MarketValue>14</MarketValue>
 			<Bulk>1.0</Bulk>
 			<Mass>0.7</Mass>
 			<Nutrition>0.1</Nutrition>
@@ -83,7 +83,7 @@
 		</graphicData>
 		<statBases>
 			<DeteriorationRate>10</DeteriorationRate>
-			<MarketValue>25</MarketValue>
+			<MarketValue>14</MarketValue>
 			<WorkToMake>450</WorkToMake>
 			<Mass>0.03</Mass>
 			<Bulk>0.02</Bulk>

--- a/Mods/Core_SK/Patches/MealsRemover.xml
+++ b/Mods/Core_SK/Patches/MealsRemover.xml
@@ -1,0 +1,45 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+	<!-- Remove redundant Ideology meals from the game -->
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/RecipeDef[defName="CookMealFine_Veg" or
+							  defName="CookMealLavish_Veg" or
+							  defName="CookMealFine_Meat" or
+							  defName="CookMealLavish_Meat" or
+							  defName="CookMealFineBulk_Veg" or
+							  defName="CookMealLavishBulk_Veg" or
+							  defName="CookMealFineBulk_Meat" or
+							  defName="CookMealLavishBulk_Meat"]</xpath>
+	</Operation>	
+	
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="MealFine_Veg" or
+							 defName="MealLavish_Veg" or
+							 defName="MealFine_Meat" or
+							 defName="MealLavish_Meat"]</xpath>
+	</Operation>
+	
+	
+	<!-- Also remove recipes from table recipes -->
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/ThingDef[defName="ElectricStove" or defName="FueledStove"]/recipes/li[text()="CookMealFineBulk_Veg" or 
+																						  text()="CookMealLavishBulk_Veg" or 
+																						  text()="CookMealFineBulk_Meat" or
+																						  text()="CookMealLavishBulk_Meat" or
+																						  text()="CookMealFine_Veg" or
+																						  text()="CookMealLavish_Veg" or
+																						  text()="CookMealFine_Meat" or
+																						  text()="CookMealLavish_Meat"]</xpath>
+	</Operation>
+	
+	
+	<!-- And from biosculpter too -->
+	<Operation Class="PatchOperationFindMod">
+		<mods>
+			<li>Ideology</li>
+		</mods>
+		<match Class="PatchOperationRemove"> 
+			<xpath>Defs/ThingDef[defName="BiosculpterPod"]/building/defaultStorageSettings/filter/disallowedThingDefs/li[text()="MealLavish_Veg" or text()="MealLavish_Meat"]</xpath>
+		</match>
+	</Operation>
+</Patch>


### PR DESCRIPTION
- Removed separate vanilla meat/veg meals as similar system already exists in HSK
- Lowered cost of some foods to make them a bit easier to but from traders
- Integrated recent fungi category into existing recipes
- small tea fix 50%->5% rest need reduction
-------

- Убрал ванильные веганские/мясные блюда т.к. дублируют функционал ХСК (+ идиотские рецепты)
- Снизил стоимость большинства еды чтобы её было проще покупать у торговцев
- Внедрил недавно добавленную категорию "грибы" в существующие рецепты
- Небольшой фикс чая 50%->5% снижения усталости