### PR TITLE
Disable Cleaning Area mod by default

### DIFF
--- a/ModsConfig.xml
+++ b/ModsConfig.xml
@@ -63,7 +63,6 @@
     <li>weilbyte.snapout</li>
     <li>notfood.seedsplease</li>
     <li>fluffy.areaunlocker</li>
-    <li>hatti.cleaningarea</li>
     <li>chippedchap.blueprinttotalstooltip</li>
     <li>jkluch.haultostack</li>
     <li>mehni.pickupandhaul</li>


### PR DESCRIPTION
Mod has been quite unstable and bugs unpredictably. Removal should be considered too (it works for *some* people so I'll leave it up to Sky).