### PR TITLE
QoL changes for Neural Supercharger

### DIFF
--- a/Mods/Core_SK/Ideology/Patches/ThingDefs_Buildings/Buildings_Ideo.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingDefs_Buildings/Buildings_Ideo.xml
@@ -107,13 +107,31 @@
 					<stuffCategories>
 						<li>RuggedMetallic</li>
 					</stuffCategories>
-					<costStuffCount>50</costStuffCount>
+					<costStuffCount>150</costStuffCount>
 					<costList>
-						<ComponentIndustrial>4</ComponentIndustrial>
-						<ElectronicComponents>2</ElectronicComponents>
+						<ComponentIndustrial>8</ComponentIndustrial>
+						<Mechanism>5</Mechanism>
+						<ElectronicComponents>10</ElectronicComponents>
+						<Electronics>5</Electronics>
+						<Plastic>20</Plastic>
 					</costList>
 				</value>
 			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="NeuralSupercharger"]/comps/li[@Class="CompProperties_NeuralSupercharger"]/ticksToRecharge</xpath>
+				<value>
+					<ticksToRecharge>10000</ticksToRecharge>
+				</value>
+			</li>
+			
+			<li Class="PatchOperationReplace">
+				<xpath>Defs/ThingDef[defName="NeuralSupercharger"]/comps/li[@Class="CompProperties_Power"]/basePowerConsumption</xpath>
+				<value>
+					<basePowerConsumption>1500</basePowerConsumption>
+				</value>
+			</li>
+			
 			<!-- Christmas tree patches -->
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingDef[defName="ChristmasTree"]/costList</xpath>


### PR DESCRIPTION
Increased power draw (400W -> 1500W) and build cost of Neural Supercharger in favour of reduced cooldown (24h -> 4h) so Transhumanist colonies don't need to build one for each colonist which takes a lot of space.