### PR TITLE
Tea update

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Drinks.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Meals/Recipes_Meals_Drinks.xml
@@ -166,7 +166,9 @@
 		<workAmount>1200</workAmount>
 		<allowMixingIngredients>true</allowMixingIngredients>
 		<recipeUsers>
-			<li>TableCoffee</li>
+			<li>Campfire</li>
+			<li>FueledStove</li>
+			<li>ElectricStove</li>
 		</recipeUsers>
 		<ingredients>
 			<li>
@@ -200,6 +202,53 @@
 		</skillRequirements>
 		<workSkill>Cooking</workSkill>
 		<researchPrerequisite>Food_00</researchPrerequisite>
+	</RecipeDef>
+
+	<RecipeDef>
+		<defName>BrewTeaBulk</defName>
+		<label>brew bulk cups of tea</label>
+		<description>Prepare tea leaves and brew them into cups of tea. Produces 12.</description>
+		<jobString>Brewing cups of tea.</jobString>
+		<workSpeedStat>DrugCookingSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<soundWorking>Recipe_Brewing</soundWorking>
+		<workAmount>2400</workAmount>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<recipeUsers>
+			<li>TableCoffee</li>
+		</recipeUsers>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>RawTea</li>
+					</thingDefs>
+				</filter>
+				<count>60</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Sugar</li>
+					</thingDefs>
+				</filter>
+				<count>12</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>RawTea</li>
+				<li>Sugar</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<Cuptea>12</Cuptea>
+		</products>
+		<skillRequirements>
+			<Cooking>8</Cooking>
+		</skillRequirements>
+		<workSkill>Cooking</workSkill>
+		<researchPrerequisite>Food_C3</researchPrerequisite>
 	</RecipeDef>
 
 
@@ -340,7 +389,9 @@
 		<recipeMaker>
 			<researchPrerequisite>Food_00</researchPrerequisite>
 			<recipeUsers>
-				<li>TableCoffee</li>
+				<li>Campfire</li>
+				<li>FueledStove</li>
+				<li>ElectricStove</li>
 			</recipeUsers>
 			<workSpeedStat>DrugCookingSpeed</workSpeedStat>
 			<workSkill>Cooking</workSkill>
@@ -363,5 +414,43 @@
 			</li>
 		</comps>
 	</ThingDef>
+
+	<RecipeDef>
+		<defName>BrewPsychiteTeaBulk</defName>
+		<label>brew bulk cups of psychite tea</label>
+		<description>Prepare psychite tea leaves and brew them into cups of psychite tea. Produces 12.</description>
+		<jobString>Brewing cups of psychite tea.</jobString>
+		<workSpeedStat>DrugCookingSpeed</workSpeedStat>
+		<effectWorking>Cook</effectWorking>
+		<soundWorking>Recipe_Brewing</soundWorking>
+		<workAmount>2400</workAmount>
+		<allowMixingIngredients>true</allowMixingIngredients>
+		<recipeUsers>
+			<li>TableCoffee</li>
+		</recipeUsers>
+		<ingredients>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>PsychoidLeaves</li>
+					</thingDefs>
+				</filter>
+				<count>48</count>
+			</li>
+		</ingredients>
+		<fixedIngredientFilter>
+			<thingDefs>
+				<li>PsychoidLeaves</li>
+			</thingDefs>
+		</fixedIngredientFilter>
+		<products>
+			<PsychiteTea>12</PsychiteTea>
+		</products>
+		<skillRequirements>
+			<Cooking>8</Cooking>
+		</skillRequirements>
+		<workSkill>Cooking</workSkill>
+		<researchPrerequisite>Food_C3</researchPrerequisite>
+	</RecipeDef>
 
 </Defs>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RecipeDef/Recipes_Meals.xml
@@ -220,6 +220,14 @@
 	<BrewTea.description>Заварить чай.</BrewTea.description>
 	<BrewTea.jobstring>Заваривает чай.</BrewTea.jobstring>
 
+	<BrewTeaBulk.label>Заварить чай (x4)</BrewTeaBulk.label>
+	<BrewTeaBulk.description>Заварить чай.</BrewTeaBulk.description>
+	<BrewTeaBulk.jobstring>Заваривает чай.</BrewTeaBulk.jobstring>
+
+	<BrewPsychiteTeaBulk.label>Заварить психиновый чай (x12)</BrewPsychiteTeaBulk.label>
+	<BrewPsychiteTeaBulk.description>Заварить психиновый чай.</BrewPsychiteTeaBulk.description>
+	<BrewPsychiteTeaBulk.jobstring>Заваривает психиновый чай.</BrewPsychiteTeaBulk.jobstring>
+
 	<BrewCoffee.label>Сварить кофе</BrewCoffee.label>
 	<BrewCoffee.description>Поселенец сварит чашку кофе.</BrewCoffee.description>
 	<BrewCoffee.jobString>Варит кофе.</BrewCoffee.jobString>


### PR DESCRIPTION
1 added simple tea's and psychite tea's recipes to campfire and stoves (cuz its available with almost first neolothic researches). Removed ones from coffee machine;
2 added bulk version tea's and psychite tea's recipes to coffee machine.

1 добавлены простые рецепты чая и психинового чая костру и плитам (т.к. по исследованиям они открываются чуть не в самом начале неолита), но удалены у кофе машины;
2 добавлены оптовые версии рецептов чая и психинового чая для кофе машины.