### PR TITLE
Изменен рецепт настенного факела

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Accessories.xml
@@ -1018,7 +1018,7 @@
 		<stuffCategories>
 			<li>Kindlingstuff</li>
 		</stuffCategories>
-		<costStuffCount>40</costStuffCount>
+		<costStuffCount>10</costStuffCount>
 		<surfaceType>Item</surfaceType>
 		<placeWorkers>
 			<li>PlaceWorker_Heater</li>


### PR DESCRIPTION
Изменил количество дров для постройки (было 40).
На обычный факел тратится всего 10, а тут в 4 раза больше.
Возможно конечно что всё ради баланса :) Если так, извиняюсь что отнял время.