### PR TITLE
Spacer guns recipe moved

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Futuristic_Charged.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs_Weapons/Recipes_Weapons_Futuristic_Charged.xml
@@ -67,7 +67,6 @@
 			</categories>
 		</fixedIngredientFilter>
 		<recipeUsers>
-			<li>AdvToolBench</li>
 			<li>MechWeaponCraftingWorkTable</li>
 		</recipeUsers>
 		<researchPrerequisite>Charge_weapons_D</researchPrerequisite>
@@ -147,7 +146,6 @@
 			</categories>
 		</fixedIngredientFilter>
 		<recipeUsers>
-			<li>AdvToolBench</li>
 			<li>MechWeaponCraftingWorkTable</li>
 		</recipeUsers>
 		<researchPrerequisite>Charge_weapons_E</researchPrerequisite>


### PR DESCRIPTION
Removed R3 Menstruum and R6 Splitter recipes from electric assembling bench, now only craftable on futuristic weapon bench