### PR TITLE
Fixed non-hostile relation of Bloodmoon brotherhood and Orion Corporaion factions

### DIFF
--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Brotherhood.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Brotherhood.xml
@@ -16,6 +16,7 @@
 		<autoFlee>true</autoFlee>
 		<earliestRaidDays>145</earliestRaidDays>	
 		<mustStartOneEnemy>true</mustStartOneEnemy>
+		<naturalEnemy>true</naturalEnemy>
 		<techLevel>Spacer</techLevel>
 		<factionIconPath>World/WorldObjects/Expanding/Brotherhood</factionIconPath>
 		<factionNameMaker>NamerFactionPirate</factionNameMaker>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Orion.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Orion.xml
@@ -17,6 +17,7 @@
 		<leaderTitle>Commander</leaderTitle>
 		<earliestRaidDays>260</earliestRaidDays>
 		<mustStartOneEnemy>true</mustStartOneEnemy>
+		<naturalEnemy>true</naturalEnemy>
 		<geneticVariance>0.8</geneticVariance>		
 		<factionIconPath>World/WorldObjects/Expanding/Orion</factionIconPath>		
 		<factionNameMaker>NamerFactionPirate</factionNameMaker>


### PR DESCRIPTION
mustStartOneEnemy don't work on 1.3 ver.
naturalColonyGoodwill was removed on 1.3 ver.
Added new 1.3 ver. naturalEnemy property