### PR TITLE
Some quest's rewards tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/30x64mmFuelCell.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/30x64mmFuelCell.xml
@@ -50,6 +50,9 @@
 		</statBases>
 		<ammoClass>IncendiaryFuel</ammoClass>
 		<generateAllowChance>0.2</generateAllowChance>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoHC</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="30x64mmFuelBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/6x24mmCharged.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/6x24mmCharged.xml
@@ -48,6 +48,9 @@
 			<MarketValue>5.7</MarketValue>
 		</statBases>
 		<ammoClass>Charged</ammoClass>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoAC</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="6x24mmChargedBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/BlasterBolt.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/BlasterBolt.xml
@@ -41,6 +41,9 @@
 		<tradeability>Sellable</tradeability>
 		<destroyOnDrop>False</destroyOnDrop>
 		<ammoClass>ChargedAP</ammoClass>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoAC</li>
+		</thingSetMakerTags>
 		<comps>
 			<li Class="CompProperties_Explosive">
 				<explosiveRadius>0.7</explosiveRadius>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/Laserbeam.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/Laserbeam.xml
@@ -63,6 +63,9 @@
 			<Bulk>0.02</Bulk>
 		</statBases>
 		<ammoClass>LaserST</ammoClass>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoAC</li>
+		</thingSetMakerTags>
 	</ThingDef>  
 
 	<!-- ================== Projectiles ================== -->

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/PlasmaBolt.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/PlasmaBolt.xml
@@ -49,6 +49,9 @@
 		<tradeability>Sellable</tradeability>
 		<destroyOnDrop>False</destroyOnDrop>
 		<ammoClass>Charged</ammoClass>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoAC</li>
+		</thingSetMakerTags>
 		<comps>
 			<li Class="CompProperties_Explosive">
 				<explosiveRadius>0.65</explosiveRadius>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Grenade/40x46mmGrenade.xml
@@ -50,6 +50,9 @@
 		</statBases>
 		<ammoClass>GrenadeHE</ammoClass>
 		<detonateProjectile>Bullet_40x46mmGrenade_HE</detonateProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoHC</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="40x46mmGrenadeBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -50,6 +50,9 @@
 		</statBases>
 		<ammoClass>FullMetalJacket</ammoClass>
 		<cookOffProjectile>Bullet_145x114mm_FMJ</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoHC</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo145x114mmBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/50BMG.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/HighCaliber/50BMG.xml
@@ -66,6 +66,9 @@
 		<ammoClass>Sabot</ammoClass>
 		<generateAllowChance>0.125</generateAllowChance>
 		<cookOffProjectile>Bullet_50BMG_Sabot</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoHC</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="Ammo50BMGBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Pistols/9x19mmPara.xml
@@ -64,6 +64,9 @@
 		<ammoClass>ArmorPiercing</ammoClass>
 		<generateAllowChance>0.4</generateAllowChance>
 		<cookOffProjectile>Bullet_9x19mmPara_AP</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoSC</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="9x19mmParaBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/556x45mmNATO.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/556x45mmNATO.xml
@@ -64,6 +64,9 @@
 		<ammoClass>ArmorPiercing</ammoClass>
 		<generateAllowChance>0.35</generateAllowChance>
 		<cookOffProjectile>Bullet_556x45mmNATO_AP</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoSC</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="556x45mmNATOBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x51mmNATO.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Rifle/762x51mmNATO.xml
@@ -64,6 +64,9 @@
 		<ammoClass>ArmorPiercing</ammoClass>
 		<generateAllowChance>0.3</generateAllowChance>
 		<cookOffProjectile>Bullet_762x51mmNATO_AP</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoSC</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="762x51mmNATOBase">

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Shotgun/12Gauge.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Shotgun/12Gauge.xml
@@ -94,6 +94,9 @@
 		</statBases>
 		<ammoClass>Slug</ammoClass>
 		<cookOffProjectile>Bullet_12Gauge_Slug</cookOffProjectile>
+		<thingSetMakerTags>
+			<li>HSKCombatSuppliesAmmoSC</li>
+		</thingSetMakerTags>
 	</ThingDef>
 
 	<ThingDef Class="CombatExtended.AmmoDef" ParentName="12GaugeBase">

--- a/Mods/Core_SK/Patches/ThingSetMakerDefs/ThingSetMakers_RewardPatches.xml
+++ b/Mods/Core_SK/Patches/ThingSetMakerDefs/ThingSetMakers_RewardPatches.xml
@@ -33,14 +33,14 @@
 			<li Class="PatchOperationReplace">
 				<xpath>Defs/ThingSetMakerDef[defName = "Reward_ItemsStandard"]/root/options/li[1]/thingSetMaker/options/li[8]/weight</xpath>
 				<value>
-					<weight>8</weight>
+					<weight>5</weight>
 				</value>
 			</li>
 			<li Class="PatchOperationAdd">
 				<xpath>Defs/ThingSetMakerDef[defName = "Reward_ItemsStandard"]/root/options/li[1]/thingSetMaker/options</xpath>
 				<value>
 					<li>
-						<weight>0.5</weight>
+						<weight>0.75</weight>
 						<thingSetMaker Class="ThingSetMaker_RandomOption">
 							<options>
 							  <!-- Some simple and usefull sets. -->
@@ -53,6 +53,20 @@
 										<thingSetMakerTagsToAllow>
 											<li>HSKCombatSuppliesTierOne</li>
 											<li>HSKhumanitarianSuppliesTierOne</li>
+										</thingSetMakerTagsToAllow>
+									</filter>
+									<minSingleItemMarketValuePct>0.01</minSingleItemMarketValuePct>
+								  </fixedParams>
+								</thingSetMaker>
+							  </li>
+							  <li>
+								<weight>1.25</weight>
+								<thingSetMaker Class="ThingSetMaker_MarketValue">
+								  <fixedParams>
+									<allowNonStackableDuplicates>False</allowNonStackableDuplicates>
+									<filter>
+										<thingSetMakerTagsToAllow>
+											<li>HSKCombatSuppliesAmmoSC</li>
 										</thingSetMakerTagsToAllow>
 									</filter>
 									<minSingleItemMarketValuePct>0.01</minSingleItemMarketValuePct>
@@ -75,6 +89,20 @@
 								</thingSetMaker>
 							  </li>
 							  <li>
+								<weight>0.75</weight>
+								<thingSetMaker Class="ThingSetMaker_MarketValue">
+								  <fixedParams>
+									<allowNonStackableDuplicates>False</allowNonStackableDuplicates>
+									<filter>
+										<thingSetMakerTagsToAllow>
+											<li>HSKCombatSuppliesAmmoHC</li>
+										</thingSetMakerTagsToAllow>
+									</filter>
+									<minSingleItemMarketValuePct>0.01</minSingleItemMarketValuePct>
+								  </fixedParams>
+								</thingSetMaker>
+							  </li>
+							  <li>
 								<weight>0.5</weight>
 								<thingSetMaker Class="ThingSetMaker_MarketValue">
 								  <fixedParams>
@@ -90,7 +118,21 @@
 								</thingSetMaker>
 							  </li>
 							  <li>
-								<weight>0.25</weight>
+								<weight>0.425</weight>
+								<thingSetMaker Class="ThingSetMaker_MarketValue">
+								  <fixedParams>
+									<allowNonStackableDuplicates>False</allowNonStackableDuplicates>
+									<filter>
+										<thingSetMakerTagsToAllow>
+											<li>HSKCombatSuppliesAmmoAC</li>
+										</thingSetMakerTagsToAllow>
+									</filter>
+									<minSingleItemMarketValuePct>0.01</minSingleItemMarketValuePct>
+								  </fixedParams>
+								</thingSetMaker>
+							  </li>
+							  <li>
+								<weight>0.375</weight>
 								<thingSetMaker Class="ThingSetMaker_MarketValue">
 								  <fixedParams>
 									<allowNonStackableDuplicates>False</allowNonStackableDuplicates>


### PR DESCRIPTION
1 slightly reduced Royalty apparel items spawn chance as quest reward;
2 slightly increased non-Royalty item spawn chance as quest reward;
3 added new quest rewards sub-blocks with ammo to diversify types of entire ammo block rewards.

1 немного уменьшена вероятность выпадения Royalty предметов одежды в качестве награды за квесты;
2 немного увеличена вероятность выпадения прочих предметов в качестве награды за квесты (кроме Royalty);
3 добавлены новые подблоки наград с боеприпасами для увеличения разнообразия выдаваемых во всем блоке боеприпасов.