### PR TITLE
Heavy Missile System Fix

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Launchers.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Launchers.xml
@@ -160,7 +160,7 @@
 
 	<!-- ================ Heavy missile system ============== -->
 
-	<ThingDef ParentName="BaseArtilleryGun">
+	<ThingDef ParentName="BaseGun_Turret">
 		<defName>Gun_RL</defName>
 		<label>Heavy Missile System</label>
 		<description>A mounted heavy missile system on a turret. Uses six rockets.</description>


### PR DESCRIPTION
Changed Heavy Missile System ParentName from "BaseArtilleryGun" to "BaseGun_Turret", should fix the weird trajectory issue(no change for accuracy)

Guess not many people use them