### PR TITLE
Updated old loadAfter list

### DIFF
--- a/Mods/CombatExtended/About/About.xml
+++ b/Mods/CombatExtended/About/About.xml
@@ -32,7 +32,7 @@ Extiende la mecánica de combate para hacerlos más profundos y más tácticos
 		<li>Flyfire2002.FieldMedic</li>
 		<li>hobtook.mortaraccuracy</li>
 		<li>XeoNovaDan.ProperShotguns</li>
-		<li>swedishmask.ProperShotgunsPatch</li>		
+		<li>swedishmask.ProperShotgunsPatch</li>
 	</incompatibleWith>
 	<loadAfter>
 		<li>brrainz.harmony</li>
@@ -41,18 +41,7 @@ Extiende la mecánica de combate para hacerlos más profundos y más tácticos
 		<li>Ludeon.RimWorld.Ideology</li>
 		<li>UnlimitedHugs.HugsLib</li>
 		<li>skyarkhangel.RimThemesLite</li>
-		<li>TheInfinityIQ.Halo.UNSC</li>
-		<li>TheKingInYellow.Lope</li>
-		<li>RunneLatki.RabbieRaceMod</li>
-		<li>HC.GiantRace</li>
-		<li>neronix17.fr.compilation</li>
-		<li>VanillaExpanded.VWEFT</li>
-		<li>oskarpotocki.vfe.mechanoid</li>
-		<li>sarg.alphaanimals</li>
-		<li>oskarpotocki.vanillafactionsexpanded.medievalmodule</li>
-		<li>vanillaexpanded.vwe</li>
-		<li>HLX.RimworldUNSCArmoury</li>
-		<li>Argon.VMEuP</li>
-		<li>VanillaExpanded.VWEG</li>
+		<li>oskarpotocki.vanillafactionsexpanded.core</li>
+		<li>jecrell.jecstools</li>
 	</loadAfter>
 </ModMetaData>


### PR DESCRIPTION
This is for better compatibility with new patches for HSK. The old list is now pointless because all patches were deleted from CE.