### PR TITLE
Pull Request, sledgehammer is now a tool

### DIFF
--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Items/Items_Tools.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Items/Items_Tools.xml
@@ -248,5 +248,41 @@
 			</li>
 		</operations>
 	</Operation>
+	<!-- MeleeWeapon_Sledgehammer-->
+	<Operation Class="PatchOperationSequence">
+		<success>Always</success>
+		<operations>
+		    
+
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]</xpath>
+				<value>
+				  <thingClass>SurvivalToolsLite.SurvivalTool</thingClass>
+				</value>
+			</li>
+			<li Class="PatchOperationAdd">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]/statBases</xpath>
+				<value>
+				  <ToolEffectivenessFactor>1</ToolEffectivenessFactor>
+				</value>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]/equippedStatOffsets</xpath>
+			</li>
+			<li Class="PatchOperationAddModExtension">
+				<xpath>Defs/ThingDef[defName="MeleeWeapon_Sledgehammer"]</xpath>
+				<value>
+					<li Class="SurvivalToolsLite.SurvivalToolProperties">
+						<baseWorkStatFactors>
+							<ConstructionSpeed>1.2</ConstructionSpeed>
+						</baseWorkStatFactors>
+						<defaultSurvivalToolAssignmentTags>
+							<li>Constructor</li>	
+						</defaultSurvivalToolAssignmentTags>
+					</li>
+				</value>
+			</li> 
+		</operations>
+	</Operation>
 
 </Patch>


### PR DESCRIPTION
Added Patch operation to sledgehammer that makes it a tool for constuction works with Survival toold hardcore mode allowing pawns to build. + removes notification that pawn needs a constuction tool if pawn has a sledgehammer.

Changed Construction speed multiplayer to 1.2 so it is like wrench but Monkeywrench is also a Smithing tool.