### PR TITLE
Update plasma ammo explosive dmg type from flame to plasma

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/PlasmaBolt.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/PlasmaBolt.xml
@@ -55,7 +55,7 @@
 		<comps>
 			<li Class="CompProperties_Explosive">
 				<explosiveRadius>0.65</explosiveRadius>
-				<explosiveDamageType>Flame</explosiveDamageType>
+				<explosiveDamageType>PlasmaFlame</explosiveDamageType>
 				<explosiveExpandPerStackcount>0.01</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.333</startWickHitPointsPercent>
 				<wickTicks>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/PlasmaPelletBolt.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Advanced/PlasmaPelletBolt.xml
@@ -45,7 +45,7 @@
 		<comps>
 			<li Class="CompProperties_Explosive">
 				<explosiveRadius>0.65</explosiveRadius>
-				<explosiveDamageType>Flame</explosiveDamageType>
+				<explosiveDamageType>PlasmaFlame</explosiveDamageType>
 				<explosiveExpandPerStackcount>0.01</explosiveExpandPerStackcount>
 				<startWickHitPointsPercent>0.333</startWickHitPointsPercent>
 				<wickTicks>

--- a/Mods/Core_SK/Defs/DamageDefs/Damages_LocalInjury_SK.xml
+++ b/Mods/Core_SK/Defs/DamageDefs/Damages_LocalInjury_SK.xml
@@ -33,7 +33,7 @@
 		<harmAllLayersUntilOutside>true</harmAllLayersUntilOutside>
 		<impactSoundType>Blunt</impactSoundType>
 		<armorCategory>Heat</armorCategory>
-		<defaultDamage>3</defaultDamage>
+		<defaultDamage>10</defaultDamage>
 		<defaultArmorPenetration>0</defaultArmorPenetration>
 		<canUseDeflectMetalEffect>false</canUseDeflectMetalEffect>
 		<buildingDamageFactor>3</buildingDamageFactor>


### PR DESCRIPTION
Updated the damage type plasma ammo when detonating (from simple flame to plasma dmg type with plasma visual and sound effects). Also increased the base plasma damage from 3 to 10 (like flame damage. Default damage is only used when detonating plasma ammo)

Обновлен тип урона при детонации плазменных боеприпасов (был обычный огненный, теперь плазменный с соответствующими визуальными и звуковыми эффектами). Также увеличен базовый урон плазмы с 3 до 10 (до уровня огненного урона. Базовый используется только при детонации плазменных боеприпасов)