### PR TITLE
Some ideology headgear tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_IdeologyHeadgear.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingDefs_Misc/Apparel_IdeologyHeadgear.xml
@@ -6,7 +6,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Headwrap" or defName="Apparel_Broadwrap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>1.2</StuffEffectMultiplierArmor>
+		  <StuffEffectMultiplierArmor>1.1</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -15,7 +15,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_VisageMask"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-      <StuffEffectMultiplierArmor>1.35</StuffEffectMultiplierArmor>
+      <StuffEffectMultiplierArmor>1.25</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -24,7 +24,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Slicecap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>1.2</StuffEffectMultiplierArmor>
+		  <StuffEffectMultiplierArmor>1.1</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -51,7 +51,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_AuthorityCap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>1.15</StuffEffectMultiplierArmor>
+		  <StuffEffectMultiplierArmor>1.05</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -60,7 +60,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Tailcap"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>1.15</StuffEffectMultiplierArmor>
+		  <StuffEffectMultiplierArmor>1.05</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 
@@ -69,7 +69,17 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Shadecone"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>1.3</StuffEffectMultiplierArmor>
+		  <StuffEffectMultiplierArmor>1.2</StuffEffectMultiplierArmor>
+    </value>
+  </Operation>
+
+  <Operation Class="PatchOperationAdd">
+    <xpath>Defs/ThingDef[defName="Apparel_Shadecone"]/apparel</xpath>
+    <value>
+		<tags>
+			<li>Tribal</li>
+			<li>Tribal_TraderTag</li>
+		</tags>
     </value>
   </Operation>
 
@@ -78,7 +88,7 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/ThingDef[defName="Apparel_Flophat"]/statBases/StuffEffectMultiplierArmor</xpath>
     <value>
-		  <StuffEffectMultiplierArmor>1.25</StuffEffectMultiplierArmor>
+		  <StuffEffectMultiplierArmor>1.15</StuffEffectMultiplierArmor>
     </value>
   </Operation>
 


### PR DESCRIPTION
1 slightly reduced stuff armor multiplier for textiles headgear (~8-9%);
2 added some tribal tags to some textiles headgear (many of them haven't any apparel tag).

1 немного снижен множитель брони для текстильных головных уборов идеологии (~на 8-9%);
2 добавлены некоторые теги племенных фракций для некоторых текстильных головных уборов идеологии (большинство вообще не имеет каких-либо тегов).