### PR TITLE
Fixed Wild fire rus translation

### DIFF
--- a/Mods/Core_SK/Languages/Russian/DefInjected/GameConditionDef/GameConditions_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/GameConditionDef/GameConditions_SK.xml
@@ -1,9 +1,9 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <LanguageData>
 
-	<Wildfire.label>Дикий огонь</Wildfire.label>
-	<Wildfire.description>Большой лесной пожар вспыхнул неподалеку и теперь распространяется.</Wildfire.description>
-	<Wildfire.endMessage>Дикий огонь закончился.</Wildfire.endMessage>
+	<Wildfire.label>Лесной пожар</Wildfire.label>
+	<Wildfire.description>Поблизости вспыхнул большой лесной пожар, который перекинулся на вашу территорию и вскоре может начать распространяться на ней.</Wildfire.description>
+	<Wildfire.endMessage>Лесной пожар закончился.</Wildfire.endMessage>
 
 	<ExtremeCold.label>Холодный шторм</ExtremeCold.label>
 	<ExtremeCold.description>Огромные тяжелые тучи покрыли вашу территорию, лишая вас солнечного света, и вызывая невероятные температурные феномены на вашей территории, включая тяжелые заморозки, град и угрозу гипотермии. Надевайте шапку!</ExtremeCold.description>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/IncidentDef/Incidents_SK_Events.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/IncidentDef/Incidents_SK_Events.xml
@@ -1,9 +1,9 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
-	<Wildfire.label>дикий огонь</Wildfire.label>
-	<Wildfire.letterText>Большой лесной пожар вспыхнул неподалеку и теперь распространяется.</Wildfire.letterText>
-	<Wildfire.letterLabel>Дикий огонь</Wildfire.letterLabel>
+	<Wildfire.label>лесной пожар</Wildfire.label>
+	<Wildfire.letterText>Поблизости вспыхнул большой лесной пожар, который перекинулся на вашу территорию и вскоре может начать распространяться на ней.</Wildfire.letterText>
+	<Wildfire.letterLabel>Лесной пожар</Wildfire.letterLabel>
 	
 	<SandTornado.label>песчаная буря</SandTornado.label>
 	<SandTornado.letterText>Мощные пылевые вихри проложат путь разрушения через область.</SandTornado.letterText>


### PR DESCRIPTION
Скорректирован перевод события Wild fire ("дикий огонь" заменен на более корректный и понятный "лесной пожар", также скорректировано его описание).