### PR TITLE
Diseases tweaks

### DIFF
--- a/Mods/Core_SK/Defs/HediffDefs/HediffDefs_Diseases.xml
+++ b/Mods/Core_SK/Defs/HediffDefs/HediffDefs_Diseases.xml
@@ -172,7 +172,7 @@
 				<becomeVisible>false</becomeVisible>
 			</li>
 			<li>
-				<minSeverity>0.333</minSeverity>
+				<minSeverity>0.1</minSeverity>
 				<label>minor</label>
 				<painOffset>0.05</painOffset>
 				<capMods>
@@ -260,7 +260,7 @@
 				<becomeVisible>false</becomeVisible>
 			</li>
 			<li>
-				<minSeverity>0.25</minSeverity>
+				<minSeverity>0.10</minSeverity>
 				<label>minor</label>
 				<painOffset>0.05</painOffset>
 				<capMods>
@@ -343,7 +343,7 @@
 				<becomeVisible>false</becomeVisible>
 			</li>
 			<li>
-				<minSeverity>0.30</minSeverity>
+				<minSeverity>0.10</minSeverity>
 				<label>minor</label>
 				<painOffset>0.05</painOffset>
 				<capMods>
@@ -427,7 +427,7 @@
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.06</offset>
+						<offset>-0.05</offset>
 					</li>
 				</capMods>
 			</li>
@@ -438,7 +438,23 @@
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.12</offset>
+						<offset>-0.15</offset>
+					</li>
+				</capMods>
+			</li>
+			<li>
+				<minSeverity>0.666</minSeverity>
+				<label>major</label>
+				<painOffset>0.07</painOffset>
+				<vomitMtbDays>1.3</vomitMtbDays>
+				<capMods>
+					<li>
+						<capacity>Moving</capacity>
+						<offset>-0.2</offset>
+					</li>
+					<li>
+						<capacity>Consciousness</capacity>
+						<offset>-0.2</offset>
 					</li>
 				</capMods>
 				<hediffGivers>
@@ -459,22 +475,6 @@
 				</hediffGivers>
 			</li>
 			<li>
-				<minSeverity>0.666</minSeverity>
-				<label>major</label>
-				<painOffset>0.07</painOffset>
-				<vomitMtbDays>1.3</vomitMtbDays>
-				<capMods>
-					<li>
-						<capacity>Moving</capacity>
-						<offset>-0.2</offset>
-					</li>
-					<li>
-						<capacity>Consciousness</capacity>
-						<offset>-0.18</offset>
-					</li>
-				</capMods>
-			</li>
-			<li>
 				<minSeverity>0.833</minSeverity>
 				<label>extreme</label>
 				<lifeThreatening>true</lifeThreatening>
@@ -483,7 +483,7 @@
 				<capMods>
 					<li>
 						<capacity>Consciousness</capacity>
-						<offset>-0.22</offset>
+						<offset>-0.25</offset>
 					</li>
 					<li>
 						<capacity>Moving</capacity>
@@ -494,6 +494,22 @@
 						<offset>-0.2</offset>
 					</li>
 				</capMods>
+				<hediffGivers>
+					<li Class="HediffGiver_Random">
+						<hediff>Pneumonia</hediff>
+						<mtbDays>3</mtbDays>
+						<partsToAffect>
+							<li>Lung</li>
+						</partsToAffect>
+					</li>
+					<li Class="HediffGiver_Random">
+						<hediff>Pneumonia</hediff>
+						<mtbDays>3</mtbDays>
+						<partsToAffect>
+							<li>Lung</li>
+						</partsToAffect>
+					</li>
+				</hediffGivers>
 			</li>
 		</stages>
 	</HediffDef>


### PR DESCRIPTION
- Lowered threshold for diseases to become visible - hidden diseases only make sense with communicable diseases because player still gets notification, but has to use workarounds to tuck pawns in beds. Questionable mechanic, but hopefully will be a pain in the ass without too big of a mechanical hinderance.
- Covid causes Pneumonia at later stages of disease (caused it only at earlier stages before) - treat your pawns quickly.