### PR TITLE
Fixed overvalued ratkin wooden shield armor params

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
@@ -2588,8 +2588,8 @@
 			<Mass>3</Mass>
 			<Bulk>2.5</Bulk>
 			<WornBulk>1.5</WornBulk>
-			<ArmorRating_Sharp>2.8</ArmorRating_Sharp>
-			<ArmorRating_Blunt>4.6</ArmorRating_Blunt>
+			<ArmorRating_Sharp>1.8</ArmorRating_Sharp>
+			<ArmorRating_Blunt>4</ArmorRating_Blunt>
 			<ArmorRating_Heat>0.1</ArmorRating_Heat>
 			<StuffEffectMultiplierArmor>1.0</StuffEffectMultiplierArmor>
 			<Flammability>0.8</Flammability>


### PR DESCRIPTION
Исправлено завышенное значение защиты деревянного щита раткинов