### PR TITLE
Changed terrible (red) and unique (purple) traits color to more readable on dark blue background

### DIFF
--- a/Mods/MultiLang Colorful Traits/Defs/ColorBase.xml
+++ b/Mods/MultiLang Colorful Traits/Defs/ColorBase.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Defs>
 	<Trait.ColorDef Abstract="true" Name="ColorUnique">
-		<color>#9370DB</color>
+		<color>#AF8BFF</color>
 	</Trait.ColorDef>
 	
 	<Trait.ColorDef Abstract="true" Name="ColorGood">
@@ -17,7 +17,7 @@
 	</Trait.ColorDef>
 	
 	<Trait.ColorDef Abstract="true" Name="ColorTerrible">
-		<color>#ED2939</color>
+		<color>#FF3D4D</color>
 	</Trait.ColorDef>
 	
 	


### PR DESCRIPTION
Changed terrible (red) and unique (purple) traits color to little more readable on dark blue background:
- before:

![image](https://user-images.githubusercontent.com/62516232/189159884-bbaf7413-6eb0-4fd8-915c-ef744cbb05db.png)

- after:

![image](https://user-images.githubusercontent.com/62516232/189159982-c4bb4462-d93e-491c-a9b4-90c24a2d716b.png)

Цвет ужасных (красных) и уникальных (фиолетовых) черт характера сделан более читабельным на темно-синем фоне (выше пример "До" и "После" соответственно).