### PR TITLE
Temporary removing badly working alien eating precepts and memes

### DIFF
--- a/Mods/Core_SK/Ideology/Patches/AlienRace/Removing_AlienCannibalism.xml
+++ b/Mods/Core_SK/Ideology/Patches/AlienRace/Removing_AlienCannibalism.xml
@@ -1,0 +1,82 @@
+<Patch>
+
+	<Operation Class="PatchOperationSequence">
+		<success>Normal</success>
+		<operations>
+			<!-- Temporary removing badly working alien eating precepts and memes -->
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/MemeDef[defName="HAR_Xenophilia"]/requireOne/li[4]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/MemeDef[defName="HAR_Xenophobia"]/requireOne/li[4]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/IssueDef[defName="HAR_EatingAliens"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/PreceptDef[defName="HAR_EatingAliens_Abhorrent"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/PreceptDef[defName="HAR_EatingAliens_Disapproved"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/PreceptDef[defName="HAR_EatingAliens_Acceptable"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/PreceptDef[defName="HAR_EatingAliens_Preferred"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/PreceptDef[defName="HAR_EatingAliens_RequiredStrong"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_AteAlienMeat_Abhorrent"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_AteAlienMeat_Know_Abhorrent"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_ButcheredAlien_Abhorrent"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_ButcheredAlien_Know_Abhorrent"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_ButcheredAlien_Know_Abhorrent_Opinion"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_AteAlienMeat_Disapproved"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_AteAlienMeat_Know_Disapproved"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_ButcheredAlien_Disapproved"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_ButcheredAlien_Know_Disapproved"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_ButcheredAlien_Know_Disapproved_Opinion"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_AteAlienMeat_Preferred"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_NoRecentAlienMeat_Preferred"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_AteNonAlienFood_Horrible"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_AteNonAlienFood_Know_Horrible"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_AteAlienMeat_RequiredStrong"]</xpath>
+			</li>
+			<li Class="PatchOperationRemove">
+				<xpath>Defs/ThoughtDef[defName="HAR_NoRecentAlienMeat_RequiredStrong"]</xpath>
+			</li>
+		</operations>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
It does not work well due to the unification of humanoid meat (all races have the same human meat, which is why the principle does not work for people and works strangely with aliens in some places (you can have both a penalty and a buff for eating humanoid flesh at the same time)). I suggest removing this until a suitable solution is found. Compatible with existing saves

Временное отключение плохо работающих принципов и мемов "Пожирание пришельцев".
Плохо работают из-за унификации гуманоидного мяса (все расы имеют одинаковое человеческое мясо, из-за чего принцип не работает для людей и местами странно работает с пришельцами (можно одновременно иметь и штраф и баф за поедание плоти гуманоида)). Предлагаю удалить их пока не будет найдено подходящее решение проблемы. Совместимо с существующими сохранениями.