### PR TITLE
Added deterioration to Snow blocks

### DIFF
--- a/Mods/MineralsFrozen/Defs/ThingsDefs_Resources/Item_Resource_Frozen.xml
+++ b/Mods/MineralsFrozen/Defs/ThingsDefs_Resources/Item_Resource_Frozen.xml
@@ -25,7 +25,7 @@
     <statBases>
       <MaxHitPoints>50</MaxHitPoints>
       <MarketValue>0.1</MarketValue>
-      <DeteriorationRate>0</DeteriorationRate>
+      <DeteriorationRate>15</DeteriorationRate>
       <Flammability>0</Flammability>
       <Mass>1</Mass>
       <Beauty>0</Beauty>


### PR DESCRIPTION
Snow blocks sometimes pile up on the map without any real need for them when snow piles are destroyed by _something_. It seems that to tweak blocks drop from snow piles destroyed by something like a meteor one needs to delve into C#. Treat it like snow not being firm enough and being blown away by the wind. 