### PR TITLE
Add Pick Up And Haul back into ModsConfig load order

### DIFF
--- a/ModsConfig.xml
+++ b/ModsConfig.xml
@@ -63,6 +63,7 @@
     <li>fluffy.areaunlocker</li>
     <li>chippedchap.blueprinttotalstooltip</li>
     <li>jkluch.haultostack</li>
+	<li>mehni.pickupandhaul</li>
     <li>likeafox.haulexplicitly</li>
     <li>doug.nojobauthors</li>
     <li>oblitus.animalslogic</li>


### PR DESCRIPTION
Forgot to add it back into the default ModsConfig after fixing it