### PR TITLE
Biotech Mech Recipe Filter Fix

### DIFF
--- a/Mods/Core_SK/Biotech/Patches/RecipeDefs/MechRessurection.xml
+++ b/Mods/Core_SK/Biotech/Patches/RecipeDefs/MechRessurection.xml
@@ -52,6 +52,25 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[defName="ResurrectLightMech"]/fixedIngredientFilter/thingDefs</xpath>
+		<value>
+			<li>Electronics</li>
+			<li>ComponentIndustrial</li>
+			<li>Mechanism</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[defName="ResurrectLightMech"]/fixedIngredientFilter</xpath>
+		<value>
+			<categories>
+				<li>SLDBar</li>
+				<li>USLDBar</li>
+			</categories>
+		</value>
+	</Operation>
+
 	<!-- ========== Medium ========== -->
 
 	<Operation Class="PatchOperationReplace">
@@ -100,6 +119,25 @@
 					<count>2</count>
 				</li>
 			</ingredients>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[defName="ResurrectMediumMech"]/fixedIngredientFilter/thingDefs</xpath>
+		<value>
+			<li>Electronics</li>
+			<li>ComponentIndustrial</li>
+			<li>Mechanism</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[defName="ResurrectMediumMech"]/fixedIngredientFilter</xpath>
+		<value>
+			<categories>
+				<li>SLDBar</li>
+				<li>USLDBar</li>
+			</categories>
 		</value>
 	</Operation>
 
@@ -161,6 +199,25 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[defName="ResurrectHeavyMech"]/fixedIngredientFilter/thingDefs</xpath>
+		<value>
+			<li>Microchips</li>
+			<li>ComponentSpacer</li>
+			<li>AdvMechanism</li>
+			<li>Biomatter</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[defName="ResurrectHeavyMech"]/fixedIngredientFilter</xpath>
+		<value>
+			<categories>
+				<li>USLDBar</li>
+			</categories>
+		</value>
+	</Operation>
+
 	<!-- ========== Ultra ========== -->
 
 	<Operation Class="PatchOperationReplace">
@@ -216,6 +273,25 @@
 					<count>40</count>
 				</li>
 			</ingredients>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[defName="ResurrectUltraheavyMech"]/fixedIngredientFilter/thingDefs</xpath>
+		<value>
+			<li>BioMicrochips</li>
+			<li>ComponentUltra</li>
+			<li>AdvMechanism</li>
+			<li>Biomatter</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RecipeDef[defName="ResurrectUltraheavyMech"]/fixedIngredientFilter</xpath>
+		<value>
+			<categories>
+				<li>USLDBar</li>
+			</categories>
 		</value>
 	</Operation>
 

--- a/Mods/Core_SK/Biotech/Patches/RecipeDefs/Mechinator.xml
+++ b/Mods/Core_SK/Biotech/Patches/RecipeDefs/Mechinator.xml
@@ -74,6 +74,18 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>BioMicrochips</li>
+					<li>ComponentUltra</li>
+					<li>AdvMechanism</li>
+					<li>PowerfocusChip</li>
+					<li>SubcoreHigh</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -130,6 +142,18 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>BioMicrochips</li>
+					<li>ComponentUltra</li>
+					<li>AdvMechanism</li>
+					<li>NanostructuringChip</li>
+					<li>SubcoreHigh</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -181,6 +205,18 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>SLDBar</li>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Electronics</li>
+					<li>ComponentIndustrial</li>
+					<li>Mechanism</li>
+					<li>SubcoreRegular</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -229,6 +265,17 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Microchips</li>
+					<li>ComponentAdvanced</li>
+					<li>AdvMechanism</li>
+					<li>SubcoreRegular</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -293,6 +340,19 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Microchips</li>
+					<li>ComponentAdvanced</li>
+					<li>ComponentSpacer</li>
+					<li>AdvMechanism</li>
+					<li>SignalChip</li>
+					<li>SubcoreHigh</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -357,6 +417,19 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Microchips</li>
+					<li>ComponentAdvanced</li>
+					<li>ComponentSpacer</li>
+					<li>AdvMechanism</li>
+					<li>SignalChip</li>
+					<li>SubcoreHigh</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -415,6 +488,18 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>SLDBar</li>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Electronics</li>
+					<li>ComponentIndustrial</li>
+					<li>Mechanism</li>
+					<li>SubcoreRegular</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -463,6 +548,17 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Electronics</li>
+					<li>ComponentIndustrial</li>
+					<li>Mechanism</li>
+					<li>SubcoreRegular</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -519,6 +615,18 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Microchips</li>
+					<li>ComponentSpacer</li>
+					<li>AdvMechanism</li>
+					<li>Biomatter</li>
+					<li>SubcoreRegular</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -575,6 +683,18 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>BioMicrochips</li>
+					<li>ComponentUltra</li>
+					<li>Biomatter</li>
+					<li>AdvMechanism</li>
+					<li>SubcoreHigh</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -631,6 +751,18 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>BioMicrochips</li>
+					<li>ComponentUltra</li>
+					<li>Biomatter</li>
+					<li>AdvMechanism</li>
+					<li>SubcoreHigh</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -687,6 +819,18 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>BioMicrochips</li>
+					<li>ComponentUltra</li>
+					<li>Biomatter</li>
+					<li>AdvMechanism</li>
+					<li>SubcoreHigh</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -735,6 +879,17 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Electronics</li>
+					<li>ComponentIndustrial</li>
+					<li>Mechanism</li>
+					<li>SubcoreRegular</li>
+				</thingDefs>
+			</fixedIngredientFilter>		
 		</value>
 	</Operation>
 
@@ -794,6 +949,19 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>SLDBar</li>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Electronics</li>
+					<li>ComponentIndustrial</li>
+					<li>Mechanism</li>
+					<li>Carbon</li>
+					<li>SubcoreBasic</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -851,6 +1019,19 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>SLDBar</li>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Electronics</li>
+					<li>ComponentIndustrial</li>
+					<li>Mechanism</li>
+					<li>Carbon</li>
+					<li>SubcoreHigh</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 
@@ -908,6 +1089,19 @@
 					<count>1</count>
 				</li>
 			</ingredients>
+			<fixedIngredientFilter>
+				<categories>
+					<li>SLDBar</li>
+					<li>USLDBar</li>
+				</categories>
+				<thingDefs>
+					<li>Electronics</li>
+					<li>ComponentIndustrial</li>
+					<li>Mechanism</li>
+					<li>SyntheticFibers</li>
+					<li>SubcoreHigh</li>
+				</thingDefs>
+			</fixedIngredientFilter>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
they dont show up in the filters otherwise. This is actually an issue that all the RecipeDefs in HSK need to be looked at for. There are quite a few that arent included in the filters, which causes issues. I remember some others bringing up that some materials werent showing up and saw that some thingdefs were missing from the filters and thats probably why. Dont think it was an issue in the past but it is now. So most HSK Recipes need updating because of this.