### PR TITLE
Invisible Androids fix

### DIFF
--- a/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Androids.xml
@@ -314,9 +314,7 @@
 			</relationSettings>
 			<raceRestriction>
 				<blackEndoCategories>
-				  <li>HairColor</li>
 				  <li>Head</li>
-				  <li>Melanin</li>
 				  <li>Ears</li>
 				  <li>Nose</li>
 				  <li>Jaw</li>

--- a/Mods/Androids/Defs/AlienRace/AlienRace_Droids.xml
+++ b/Mods/Androids/Defs/AlienRace/AlienRace_Droids.xml
@@ -229,7 +229,6 @@
 			<blackEndoCategories>
 				<li>HairColor</li>
 				<li>BodyType</li>
-				<li>Melanin</li>
 				<li>Ears</li>
 				<li>Nose</li>
 				<li>Jaw</li>


### PR DESCRIPTION
Relating to issue: https://github.com/TheLoneTec/Hardcore-SK/issues/17

Cannot blacklist melanin genes, otherwise graphical errors will occur.