### PR TITLE
Dragon Projectile Balance.

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs/Projectile_Dragon.xml
+++ b/Mods/Core_SK/Defs/ThingDefs/Projectile_Dragon.xml
@@ -13,8 +13,8 @@
 		<flyOverhead>false</flyOverhead>
 		<speed>16</speed>
 		<damageDef>Flame</damageDef>
-		<damageAmountBase>8</damageAmountBase>
-		<explosionRadius>2</explosionRadius>
+		<damageAmountBase>4</damageAmountBase>
+		<explosionRadius>0.5</explosionRadius>
 		<explosionChanceToStartFire>0.1</explosionChanceToStartFire>
 		<soundExplode>FlameThrower</soundExplode>
 		<suppressionFactor>12</suppressionFactor>
@@ -34,8 +34,8 @@
 		<flyOverhead>false</flyOverhead>
 		<speed>18</speed>
 		<damageDef>Flame</damageDef>
-		<damageAmountBase>12</damageAmountBase>
-		<explosionRadius>2</explosionRadius>
+		<damageAmountBase>8</damageAmountBase>
+		<explosionRadius>0.5</explosionRadius>
 		<explosionChanceToStartFire>0.125</explosionChanceToStartFire>
 		<soundExplode>FlameThrower</soundExplode>
 		<suppressionFactor>12</suppressionFactor>
@@ -56,8 +56,8 @@
 		<flyOverhead>false</flyOverhead>
 		<speed>20</speed>
 		<damageDef>Flame</damageDef>
-		<damageAmountBase>15</damageAmountBase>
-		<explosionRadius>2</explosionRadius>
+		<damageAmountBase>11</damageAmountBase>
+		<explosionRadius>1</explosionRadius>
 		<explosionChanceToStartFire>0.15</explosionChanceToStartFire>
 		<soundExplode>FlameThrower</soundExplode>
 		<suppressionFactor>12</suppressionFactor>
@@ -79,14 +79,14 @@
     </graphicData>
     <projectile Class="CombatExtended.ProjectilePropertiesCE">
 		<flyOverhead>false</flyOverhead>
-		<speed>18</speed>
+		<speed>10</speed>
 		<damageDef>Frostbite</damageDef>
-		<damageAmountBase>10</damageAmountBase>
+		<damageAmountBase>6</damageAmountBase>
 		<explosionRadius>2</explosionRadius>
 		<soundExplode>FlameThrower</soundExplode>
-		<suppressionFactor>12</suppressionFactor>
+		<suppressionFactor>6</suppressionFactor>
 		<dangerFactor>8</dangerFactor>
-		<airborneSuppressionFactor>11.5</airborneSuppressionFactor>
+		<airborneSuppressionFactor>5.5</airborneSuppressionFactor>
     </projectile>
   </ThingDef>
   
@@ -101,8 +101,8 @@
 		<flyOverhead>false</flyOverhead>
 		<speed>20</speed>
 		<damageDef>Flame</damageDef>
-		<damageAmountBase>18</damageAmountBase>
-		<explosionRadius>3</explosionRadius>
+		<damageAmountBase>14</damageAmountBase>
+		<explosionRadius>2</explosionRadius>
 		<explosionChanceToStartFire>0.4</explosionChanceToStartFire>
 		<soundExplode>FlameThrower</soundExplode>
 		<suppressionFactor>12</suppressionFactor>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Exotic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Exotic.xml
@@ -35,7 +35,7 @@
 				<accuracyLong>1</accuracyLong>
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>DragonFireBreathOmega</defaultProjectile>
-				<warmupTime>3</warmupTime>
+				<warmupTime>5</warmupTime>
 				<burstShotCount>18</burstShotCount>
 				<ticksBetweenBurstShots>3</ticksBetweenBurstShots>
 				<minRange>4</minRange>


### PR DESCRIPTION
- Nerfed them slightly.

At some point this needs switching from the custom SK projectile to the ProjectileCE_Bursting class. It essentially does what the custom class does, it will then have support for suppression and other CE mechanics.