### PR TITLE
Updated biotech scenario's starting resources

### DIFF
--- a/Mods/Core_SK/Biotech/Patches/Scenarios/Scenario.xml
+++ b/Mods/Core_SK/Biotech/Patches/Scenarios/Scenario.xml
@@ -1,0 +1,73 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ScenarioDef[defName="Mechanitor"]/scenario/parts/li[13]/thingDef</xpath>
+		<value>
+			<thingDef>Plasteel</thingDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ScenarioDef[defName="Mechanitor"]/scenario/parts/li[14]/thingDef</xpath>
+		<value>
+			<thingDef>Glass</thingDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ScenarioDef[defName="Mechanitor"]/scenario/parts</xpath>
+		<value>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>Plastic</thingDef>
+			  <count>90</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>Rubber</thingDef>
+			  <count>80</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>Silicon</thingDef>
+			  <count>25</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>Mechanism</thingDef>
+			  <count>15</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>ElectronicComponents</thingDef>
+			  <count>10</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>Electronics</thingDef>
+			  <count>7</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>Ammo_556x45mmNATO_FMJ</thingDef>
+			  <count>300</count>
+			</li>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ScenarioDef[defName="Sanguophage"]/scenario/parts/li[10]/thingDef</xpath>
+		<value>
+			<thingDef>Plasteel</thingDef>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ScenarioDef[defName="Sanguophage"]/scenario/parts/li[11]/stuff</xpath>
+		<value>
+			<stuff>Plasteel</stuff>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
Replaced iron ore to steel.
Added few resources for build some starting mechanitor buildings.
Added few ammo for one of the mech (mechanitor scenario).

Железная руда заменена на стальной сплав.
Для сценария механитора добавлено немного ресурсов, необходимых для постройки некоторых стартовых построек. Также добавлено немного боеприпасов для одного из стартовых механоидов механитора.
