### PR TITLE
Revert default Bomb param

### DIFF
--- a/Mods/CombatExtended/Patches/Core/DamageDefs/Damages_LocalInjury.xml
+++ b/Mods/CombatExtended/Patches/Core/DamageDefs/Damages_LocalInjury.xml
@@ -142,14 +142,14 @@
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/DamageDef[defName="Bomb"]/defaultDamage</xpath>
     <value>
-      <defaultDamage>200</defaultDamage>
+      <defaultDamage>100</defaultDamage>
     </value>
   </Operation>
   
   <Operation Class="PatchOperationReplace">
     <xpath>Defs/DamageDef[defName="Bomb"]/defaultArmorPenetration</xpath>
     <value>
-      <defaultArmorPenetration>58</defaultArmorPenetration>
+      <defaultArmorPenetration>20</defaultArmorPenetration>
     </value>
   </Operation>
   


### PR DESCRIPTION
Cuz this param used only by terminator suicide dmg and non HSK items (from other mods for example. Should increase other mods compatability)

https://github.com/skyarkhangel/Hardcore-SK/commit/a384c8f1fc1cb87818fa6e66c732a9d463ad5bd3