### PR TITLE
Asari and Seeds Please DLC Checks, Better Pawn Control and Extended Loadout are incomatible with each other

### DIFF
--- a/Mods/AsariRace/Defs/FactionDefs/Factions_Asari.xml
+++ b/Mods/AsariRace/Defs/FactionDefs/Factions_Asari.xml
@@ -20,7 +20,7 @@
 		<melaninRange>0~1</melaninRange>
 		<xenotypeSet Inherit="False">
 		  <xenotypeChances>
-			<Baseline_Asari>999</Baseline_Asari>
+			<Baseline_Asari MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Asari>
 		  </xenotypeChances>
 		</xenotypeSet>
 		<mustStartOneEnemy>true</mustStartOneEnemy>

--- a/Mods/AsariRace/Defs/FactionDefs/Factions_Player.xml
+++ b/Mods/AsariRace/Defs/FactionDefs/Factions_Player.xml
@@ -17,7 +17,7 @@
 		<melaninRange>0~1</melaninRange>
 		<xenotypeSet Inherit="False">
 		  <xenotypeChances>
-			<Baseline_Asari>999</Baseline_Asari>
+			<Baseline_Asari MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Asari>
 		  </xenotypeChances>
 		</xenotypeSet>
 		<allowedCultures>

--- a/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_Asari.xml
+++ b/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_Asari.xml
@@ -14,7 +14,7 @@
 		<isFighter>true</isFighter>
 		<xenotypeSet>
 		  <xenotypeChances>
-			<Baseline_Asari>999</Baseline_Asari>
+			<Baseline_Asari MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Asari>
 		  </xenotypeChances>
 		</xenotypeSet>
 		<techHediffsChance>0</techHediffsChance>

--- a/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_AsariWanderers.xml
+++ b/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_AsariWanderers.xml
@@ -14,7 +14,7 @@
 		<isFighter>true</isFighter>
 		<xenotypeSet Inherit="False">
 		  <xenotypeChances>
-			<Baseline_Asari>999</Baseline_Asari>
+			<Baseline_Asari MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Asari>
 		  </xenotypeChances>
 		</xenotypeSet>
 		<techHediffsChance>0</techHediffsChance>

--- a/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_Player.xml
+++ b/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_Player.xml
@@ -17,7 +17,7 @@
 		<isFighter>false</isFighter>
 		<xenotypeSet Inherit="False">
 		  <xenotypeChances>
-			<Baseline_Asari>999</Baseline_Asari>
+			<Baseline_Asari MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Asari>
 		  </xenotypeChances>
 		</xenotypeSet>
 		<techHediffsChance>0</techHediffsChance>

--- a/Mods/Better Pawn Control/About/About.xml
+++ b/Mods/Better Pawn Control/About/About.xml
@@ -41,4 +41,7 @@ Mod Integrations List:
 		<li>UnlimitedHugs.HugsLib</li>
 		<li>CETeam.CombatExtended</li>
 	</loadAfter>
+	<incompatibleWith>
+		<li>pirateby.ce.extendedloadout</li>
+	</incompatibleWith>
 </ModMetaData>

--- a/Mods/SeedsPlease/Defs/RecipeDefs/Recipes_Plants_CoreSK.xml
+++ b/Mods/SeedsPlease/Defs/RecipeDefs/Recipes_Plants_CoreSK.xml
@@ -973,4 +973,29 @@
     </products>
   </RecipeDef>
 
+  <RecipeDef ParentName="ExtractSeed">
+    <defName>ExtractSeed_Tinctoria</defName>
+    <label>extract tinctoria seeds</label>
+    <description>Extract seeds from Dye</description>
+    <ingredients>
+      <li>
+        <filter>
+          <thingDefs>
+            <li>Dye</li>
+          </thingDefs>
+        </filter>
+        <count>1</count>
+      </li>
+    </ingredients>
+    <fixedIngredientFilter>
+      <thingDefs>
+        <li>Dye</li>
+      </thingDefs>
+    </fixedIngredientFilter>
+    <products>
+      <Seed_Tinctoria>2</Seed_Tinctoria>
+    </products>
+	<researchPrerequisite>Fabric_Plants_B1</researchPrerequisite>
+  </RecipeDef>
+
 </Defs>

--- a/Mods/SeedsPlease/Defs/ThingDefs/Items_Seeds_Core.xml
+++ b/Mods/SeedsPlease/Defs/ThingDefs/Items_Seeds_Core.xml
@@ -189,4 +189,13 @@
     <graphicData><texPath>Things/Item/Seeds/SaguaroCactus</texPath></graphicData>
   </SeedsPlease.SeedDef>
   
+  <SeedsPlease.SeedDef ParentName="SeedBase">
+    <defName>Seed_Tinctoria</defName>
+    <label>tinctoria seeds</label>
+    <sources>
+      <li>Plant_Tinctoria</li>
+    </sources>
+    <graphicData><texPath>Things/Item/Seeds/Tinctoria</texPath></graphicData>
+  </SeedsPlease.SeedDef>
+  
 </Defs>

--- a/Mods/SeedsPlease/Defs_OnDemand/ludeon.rimworld.ideology/Seeds.xml
+++ b/Mods/SeedsPlease/Defs_OnDemand/ludeon.rimworld.ideology/Seeds.xml
@@ -60,38 +60,4 @@
     <graphicData><texPath>Things/Item/Seeds/Timbershroom</texPath></graphicData>
   </SeedsPlease.SeedDef>
   
-  <SeedsPlease.SeedDef ParentName="SeedBase">
-    <defName>Seed_Tinctoria</defName>
-    <label>tinctoria seeds</label>
-    <sources>
-      <li>Plant_Tinctoria</li>
-    </sources>
-    <graphicData><texPath>Things/Item/Seeds/Tinctoria</texPath></graphicData>
-  </SeedsPlease.SeedDef>
-  
-  <RecipeDef ParentName="ExtractSeed">
-    <defName>ExtractSeed_Tinctoria</defName>
-    <label>extract tinctoria seeds</label>
-    <description>Extract seeds from Dye</description>
-    <ingredients>
-      <li>
-        <filter>
-          <thingDefs>
-            <li>Dye</li>
-          </thingDefs>
-        </filter>
-        <count>1</count>
-      </li>
-    </ingredients>
-    <fixedIngredientFilter>
-      <thingDefs>
-        <li>Dye</li>
-      </thingDefs>
-    </fixedIngredientFilter>
-    <products>
-      <Seed_Tinctoria>2</Seed_Tinctoria>
-    </products>
-	<researchPrerequisite>Fabric_Plants_B1</researchPrerequisite>
-  </RecipeDef>
-  
 </Defs>


### PR DESCRIPTION
- Added biotech checks for xenotypes
- Moved Tinctoria Seeds and recipes to Core (no longer Ideology)
- BPC and EL are currently incompatible with each other, added to incompatible list in About.xml