### PR TITLE
Set Ogre's trainability to None

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mutant.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Mutant.xml
@@ -9,6 +9,7 @@
 			<SmokeSensitivity>0.7</SmokeSensitivity>
 		</statBases>
 		<race>
+			<trainability>None</trainability>
 			<meatColor>(200,135,100)</meatColor>
 			<hasGenders>false</hasGenders>
 			<foodType>OmnivoreAnimal, OvivoreAnimal</foodType>


### PR DESCRIPTION
Should prevent said error from popping:
```
Could not do PostLoadInit on RimWorld.Pawn_TrainingTracker: System.NullReferenceException: Object reference not set to an instance of an object
  at (wrapper dynamic-method) RimWorld.Pawn_TrainingTracker.RimWorld.Pawn_TrainingTracker.CanAssignToTrain_Patch1(RimWorld.Pawn_TrainingTracker,RimWorld.TrainableDef,bool&)
  at RimWorld.Pawn_TrainingTracker.CanAssignToTrain (RimWorld.TrainableDef td) [0x00000] in <95de19971c5d40878d8742747904cdcd>:0 
  at Verse.BackCompatibility.PawnTrainingTrackerPostLoadInit (RimWorld.Pawn_TrainingTracker tracker, Verse.DefMap`2[RimWorld.TrainableDef,System.Boolean]& wantedTrainables, Verse.DefMap`2[RimWorld.TrainableDef,System.Int32]& steps, Verse.DefMap`2[RimWorld.TrainableDef,System.Boolean]& learned) [0x00082] in <95de19971c5d40878d8742747904cdcd>:0 
  at RimWorld.Pawn_TrainingTracker.ExposeData () [0x00059] in <95de19971c5d40878d8742747904cdcd>:0 
  at Verse.PostLoadIniter.DoAllPostLoadInits () [0x00032] in <95de19971c5d40878d8742747904cdcd>:0  
(Filename: C:\buildslave\unity\build\Runtime/Export/Debug/Debug.bindings.h Line: 39)
```