### PR TITLE
Fixed rimatomic's smelt turbine blades recipe

### DIFF
--- a/Mods/Rimatomics_SK/Defs/RecipeDefs/Recipes_Production.xml
+++ b/Mods/Rimatomics_SK/Defs/RecipeDefs/Recipes_Production.xml
@@ -26,7 +26,7 @@
       </thingDefs>
     </fixedIngredientFilter>
     <products>
-      <Steel>1</Steel>
+      <Titanium>5</Titanium>
     </products>
     <recipeUsers>
       <li>ElectricSmelter</li>


### PR DESCRIPTION
Fixed rimatomic's smelt turbine blades recipe (dropped iron ore instead of titanium)

Исправлен рецепт на переплавку лопастей турбин (вместо титана выпадала железная руда)