### PR TITLE
Fix Scorcher and Apocriton missing inventory 

### DIFF
--- a/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Medium.xml
+++ b/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Medium.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
-	<ThingDef ParentName="SK_MechanoidThingBase" Name="MediumMechanoidBase" Abstract="True">
+	<ThingDef ParentName="SK_MechanoidThingBase" Name="SK_BaseMechanoidWalker" Abstract="True">
 		<statBases>
 			<MoveSpeed>4.7</MoveSpeed>
 			<ArmorRating_Blunt>0.20</ArmorRating_Blunt>
@@ -201,26 +201,8 @@
 		<techHediffsMoney>6000~6000</techHediffsMoney>
 	</PawnKindDef>
 
-	<!-- Currently only for Scorcher and Apocriton to add the missing comp-->
-	<ThingDef ParentName="BaseMechanoidWalker" Name="BaseMachanoidFixClass" Abstract="True">
-		<comps>
-			<li>
-				<compClass>CombatExtended.CompPawnGizmo</compClass>
-			</li>
-			<li Class="CombatExtended.CompProperties_Inventory" />
-			<li>
-				<compClass>CombatExtended.CompAmmoGiver</compClass>
-			</li>
-			<li Class="CombatExtended.CompProperties_MechAmmo">
-				<gizmoIconSetMagCount>UI/Buttons/SetMagCount</gizmoIconSetMagCount>
-				<gizmoIconTakeAmmoNow>UI/Buttons/TakeAmmoNow</gizmoIconTakeAmmoNow>
-			</li>
-		</comps>
-	</ThingDef> -->
-
-
 	<!-- Scorcher -->
-	<ThingDef ParentName="MediumMechanoidBase">
+	<ThingDef ParentName="SK_BaseMechanoidWalker">
 		<defName>Mech_Scorcher</defName>
 		<label>scorcher</label>
 		<description>A close-approach war mechanoid that specializes in incendiary attacks. Its flame burst attack has little reach, but once it closes on a group of defenders it can ignite and disrupt them with blasts of searing flame.</description>
@@ -343,7 +325,7 @@
 	</PawnKindDef>
 
 	<!-- Apocriton -->
-	<ThingDef ParentName="MediumMechanoidBase">
+	<ThingDef ParentName="SK_BaseMechanoidWalker">
 		<defName>Mech_Apocriton</defName>
 		<label>apocriton</label>
 		<description>A mechanoid commander designed to coordinate and motivate other mechs during long extermination campaigns. Its most obvious power is its ability to resurrect recently-killed mechs by supercharging their self-repair processes. Less obviously, it is intelligent and psychically present, radiating hatred into the minds of anyone in a wide radius.\n\nWhile all mechanoids have a dim psychically-present intelligence, only the apocriton and a few others truly feel hatred for their victims and understand the suffering they inflict.</description>

--- a/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Medium.xml
+++ b/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Medium.xml
@@ -1,6 +1,39 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
+	<ThingDef ParentName="SK_MechanoidThingBase" Name="MediumMechanoidBase" Abstract="True">
+		<statBases>
+			<MoveSpeed>4.7</MoveSpeed>
+			<ArmorRating_Blunt>0.20</ArmorRating_Blunt>
+			<ArmorRating_Sharp>0.40</ArmorRating_Sharp>
+		</statBases>
+		<race>
+			<intelligence>ToolUser</intelligence>
+			<thinkTreeMain>Mechanoid</thinkTreeMain>
+			<baseBodySize>1.0</baseBodySize>
+			<lifeStageAges>
+				<li>
+					<def>MechanoidFullyFormed</def>
+					<minAge>0</minAge>
+					<soundWounded>Pawn_Mech_Scyther_Wounded</soundWounded>
+					<soundDeath>Pawn_Mech_Scyther_Death</soundDeath>
+					<soundCall>Pawn_Mech_Scyther_Call</soundCall>
+				</li>
+				<li MayRequire="Ludeon.RimWorld.Biotech">
+					<def>MechanoidFullyFormed</def>
+					<minAge>100</minAge>
+					<soundWounded>Pawn_Mech_Scyther_Wounded</soundWounded>
+					<soundDeath>Pawn_Mech_Scyther_Death</soundDeath>
+					<soundCall>Pawn_Mech_Scyther_Call</soundCall>
+				</li>
+			</lifeStageAges>
+		</race>
+		<butcherProducts>
+			<TitaniumBar>8</TitaniumBar>
+			<DepletedUranium>9</DepletedUranium>
+			<CarbonAlloy>6</CarbonAlloy>
+		</butcherProducts>
+	</ThingDef>
 	<!-- Legionary -->
 	<ThingDef ParentName="LancerMechanoidWalker">
 		<defName>Mech_Legionary</defName>
@@ -183,11 +216,11 @@
 				<gizmoIconTakeAmmoNow>UI/Buttons/TakeAmmoNow</gizmoIconTakeAmmoNow>
 			</li>
 		</comps>
-	</ThingDef>
+	</ThingDef> -->
 
 
 	<!-- Scorcher -->
-	<ThingDef ParentName="BaseMachanoidFixClass">
+	<ThingDef ParentName="MediumMechanoidBase">
 		<defName>Mech_Scorcher</defName>
 		<label>scorcher</label>
 		<description>A close-approach war mechanoid that specializes in incendiary attacks. Its flame burst attack has little reach, but once it closes on a group of defenders it can ignite and disrupt them with blasts of searing flame.</description>
@@ -310,7 +343,7 @@
 	</PawnKindDef>
 
 	<!-- Apocriton -->
-	<ThingDef ParentName="BaseMachanoidFixClass">
+	<ThingDef ParentName="MediumMechanoidBase">
 		<defName>Mech_Apocriton</defName>
 		<label>apocriton</label>
 		<description>A mechanoid commander designed to coordinate and motivate other mechs during long extermination campaigns. Its most obvious power is its ability to resurrect recently-killed mechs by supercharging their self-repair processes. Less obviously, it is intelligent and psychically present, radiating hatred into the minds of anyone in a wide radius.\n\nWhile all mechanoids have a dim psychically-present intelligence, only the apocriton and a few others truly feel hatred for their victims and understand the suffering they inflict.</description>

--- a/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Medium.xml
+++ b/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Medium.xml
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 
 	<!-- Legionary -->
@@ -60,7 +60,7 @@
 		</modExtensions>
 	</ThingDef>
 
-	<PawnKindDef ParentName="BaseMechanoidKind">
+	<PawnKindDef ParentName="SK_BaseMechanoidKind">
 		<defName>Mech_Legionary</defName>
 		<label>legionary</label>
 		<race>Mech_Legionary</race>
@@ -135,7 +135,7 @@
 		</modExtensions>
 	</ThingDef>
 
-	<PawnKindDef ParentName="BaseMechanoidKind">
+	<PawnKindDef ParentName="SK_BaseMechanoidKind">
 		<defName>Mech_Tesseron</defName>
 		<label>tesseron</label>
 		<race>Mech_Tesseron</race>
@@ -168,8 +168,26 @@
 		<techHediffsMoney>6000~6000</techHediffsMoney>
 	</PawnKindDef>
 
+	<!-- Currently only for Scorcher and Apocriton to add the missing comp-->
+	<ThingDef ParentName="BaseMechanoidWalker" Name="BaseMachanoidFixClass" Abstract="True">
+		<comps>
+			<li>
+				<compClass>CombatExtended.CompPawnGizmo</compClass>
+			</li>
+			<li Class="CombatExtended.CompProperties_Inventory" />
+			<li>
+				<compClass>CombatExtended.CompAmmoGiver</compClass>
+			</li>
+			<li Class="CombatExtended.CompProperties_MechAmmo">
+				<gizmoIconSetMagCount>UI/Buttons/SetMagCount</gizmoIconSetMagCount>
+				<gizmoIconTakeAmmoNow>UI/Buttons/TakeAmmoNow</gizmoIconTakeAmmoNow>
+			</li>
+		</comps>
+	</ThingDef>
+
+
 	<!-- Scorcher -->
-	<ThingDef ParentName="BaseMechanoidWalker">
+	<ThingDef ParentName="BaseMachanoidFixClass">
 		<defName>Mech_Scorcher</defName>
 		<label>scorcher</label>
 		<description>A close-approach war mechanoid that specializes in incendiary attacks. Its flame burst attack has little reach, but once it closes on a group of defenders it can ignite and disrupt them with blasts of searing flame.</description>
@@ -249,7 +267,7 @@
 		</modExtensions>
 	</ThingDef>
 
-	<PawnKindDef ParentName="BaseMechanoidKind">
+	<PawnKindDef ParentName="SK_BaseMechanoidKind">
 		<defName>Mech_Scorcher</defName>
 		<label>scorcher</label>
 		<labelPlural>scorchers</labelPlural>
@@ -292,7 +310,7 @@
 	</PawnKindDef>
 
 	<!-- Apocriton -->
-	<ThingDef ParentName="BaseMechanoidWalker">
+	<ThingDef ParentName="BaseMachanoidFixClass">
 		<defName>Mech_Apocriton</defName>
 		<label>apocriton</label>
 		<description>A mechanoid commander designed to coordinate and motivate other mechs during long extermination campaigns. Its most obvious power is its ability to resurrect recently-killed mechs by supercharging their self-repair processes. Less obviously, it is intelligent and psychically present, radiating hatred into the minds of anyone in a wide radius.\n\nWhile all mechanoids have a dim psychically-present intelligence, only the apocriton and a few others truly feel hatred for their victims and understand the suffering they inflict.</description>
@@ -377,7 +395,7 @@
 		</modExtensions>
 	</ThingDef>
 
-	<PawnKindDef ParentName="BaseMechanoidKind">
+	<PawnKindDef ParentName="SK_BaseMechanoidKind">
 		<defName>Mech_Apocriton</defName>
 		<label>apocriton</label>
 		<race>Mech_Apocriton</race>


### PR DESCRIPTION
As well as other comps that may be useful.
Notice that currently Apocriton says "Sabot" instead of "Toxic", but it can only use toxic needle. (Still, normally player cannot have Aporciton as colony mech)