### PR TITLE
 The  leave no meds outside update

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Medicine.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Medicine.xml
@@ -87,6 +87,14 @@
 				</filter>
 				<count>2</count>
 			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
+				</filter>
+				<count>10</count>
+			</li>			
 		</ingredients>
 		<products>
 			<MedicineIndustrial>1</MedicineIndustrial>
@@ -97,6 +105,7 @@
 				<li>MedicineHerbal</li>
 				<li>SyntheticFibers</li>
 				<li>Paraffins</li>
+				<li>Plastic</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<skillRequirements>
@@ -166,6 +175,14 @@
 				</filter>
 				<count>5</count>
 			</li>
+			<li>
+				<filter>
+					<thingDefs>
+						<li>Plastic</li>
+					</thingDefs>
+				</filter>
+				<count>20</count>
+			</li>				
 		</ingredients>
 		<products>
 			<MedicineUltratech>1</MedicineUltratech>
@@ -178,6 +195,7 @@
 				<li>Paraffins</li>
 				<li>SyntheticFibers</li>
 				<li>SyntheticAmmonia</li>
+				<li>Plastic</li>
 			</thingDefs>
 		</fixedIngredientFilter>
 		<skillRequirements>
@@ -229,6 +247,48 @@
 		<workSkillLearnFactor>0.8</workSkillLearnFactor>
 		<researchPrerequisite>Medicine_A1</researchPrerequisite>
 	</RecipeDef>
+	
+	<RecipeDef>
+		<defName>MakeBandagekitcrudeBulk</defName>
+		<label>craft crude bandage kit bulk</label>
+		<description>A pack of 3 makeshift bandages. Looks bad, probably bad for your wounds. Good for stopping bleeding but nothing more. Produces 3.</description>
+		<jobString>Crafting crude bandage kit bulk.</jobString>
+		<workAmount>450</workAmount>
+		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
+		<soundWorking>Chemlab_Herbal</soundWorking>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>BTextiles</li>
+					</categories>
+				</filter>
+				<count>21</count>
+			</li>
+		</ingredients>
+		<products>
+			<Bandagekitcrude>3</Bandagekitcrude>
+		</products>
+		<recipeUsers>
+			<li>CraftingSpot</li>
+			<li>LeatherworkerTable</li>
+			<li>meditable</li>
+			<li>HandTailoringBench</li>
+			<li>ElectricTailoringBench</li>
+		</recipeUsers>
+		<fixedIngredientFilter>
+			<categories>
+				<li>BTextiles</li>
+			</categories>
+		</fixedIngredientFilter>
+		<skillRequirements>
+			<Medicine>1</Medicine>
+			<Crafting>1</Crafting>
+		</skillRequirements>
+		<workSkill>Medicine</workSkill>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<researchPrerequisite>Medicine_A1</researchPrerequisite>
+	</RecipeDef>	
 
 	<RecipeDef>
 		<defName>MakeBandageKit</defName>
@@ -250,6 +310,46 @@
 		</ingredients>
 		<products>
 			<Bandagekit>1</Bandagekit>
+		</products>
+		<recipeUsers>
+			<li>meditable</li>
+			<li>HandTailoringBench</li>
+			<li>ElectricTailoringBench</li>
+		</recipeUsers>
+		<fixedIngredientFilter>
+			<categories>
+				<li>BTextiles</li>
+			</categories>
+		</fixedIngredientFilter>
+		<skillRequirements>
+			<Medicine>2</Medicine>
+			<Crafting>2</Crafting>
+		</skillRequirements>
+		<workSkill>Medicine</workSkill>
+		<workSkillLearnFactor>0.8</workSkillLearnFactor>
+		<researchPrerequisite>Medicine_A2</researchPrerequisite>
+	</RecipeDef>
+	
+		<RecipeDef>
+		<defName>MakeBandageKitBulk</defName>
+		<label>craft bandage kit bulk</label>
+		<description>A pack of 3 bandages made from cloth. Less potent than medical kits. Produces 3.</description>
+		<jobString>Crafting bandage kit bulk.</jobString>
+		<workAmount>750</workAmount>
+		<workSpeedStat>DrugSynthesisSpeed</workSpeedStat>
+		<soundWorking>Chemlab_Herbal</soundWorking>
+		<ingredients>
+			<li>
+				<filter>
+					<categories>
+						<li>BTextiles</li>
+					</categories>
+				</filter>
+				<count>30</count>
+			</li>
+		</ingredients>
+		<products>
+			<Bandagekit>3</Bandagekit>
 		</products>
 		<recipeUsers>
 			<li>meditable</li>

--- a/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Medical.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Meals/Items_Meals_Medical.xml
@@ -17,7 +17,7 @@
 			<MarketValue>5</MarketValue>
 			<Flammability>1.0</Flammability>
 			<MedicalPotency>0.3</MedicalPotency>
-			<DeteriorationRate>2</DeteriorationRate>
+			<DeteriorationRate>20</DeteriorationRate>
 			<WorkToMake>250</WorkToMake>
 			<Bulk>0.3</Bulk>
 			<Mass>0.2</Mass>
@@ -28,7 +28,7 @@
 		<tickerType>Rare</tickerType>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>50</daysToRotStart>
+				<daysToRotStart>30</daysToRotStart>
 			</li>
 		</comps>
 	</ThingDef>
@@ -49,7 +49,7 @@
 			<MarketValue>5</MarketValue>
 			<Flammability>1.0</Flammability>
 			<MedicalPotency>0.4</MedicalPotency>
-			<DeteriorationRate>2</DeteriorationRate>
+			<DeteriorationRate>20</DeteriorationRate>
 			<WorkToMake>350</WorkToMake>
 			<Bulk>0.4</Bulk>
 			<Mass>0.25</Mass>
@@ -60,7 +60,7 @@
 		<tickerType>Rare</tickerType>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>150</daysToRotStart>
+				<daysToRotStart>30</daysToRotStart>
 			</li>
 		</comps>
 		<thingSetMakerTags>
@@ -85,7 +85,7 @@
 			<MarketValue>10</MarketValue>
 			<Flammability>1.0</Flammability>
 			<MedicalPotency>0.85</MedicalPotency>
-			<DeteriorationRate>5</DeteriorationRate>
+			<DeteriorationRate>20</DeteriorationRate>
 			<WorkToMake>600</WorkToMake>
 			<Bulk>3</Bulk>
 			<Mass>2</Mass>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Crops.xml
@@ -351,7 +351,7 @@
 			<MarketValue>5</MarketValue>
 			<Flammability>1.0</Flammability>
 			<MedicalPotency>0.45</MedicalPotency>
-			<DeteriorationRate>5</DeteriorationRate>
+			<DeteriorationRate>20</DeteriorationRate>
 		</statBases>
 		<thingCategories>
 			<li>PlantMatter</li>
@@ -359,7 +359,7 @@
 		</thingCategories>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>25</daysToRotStart>
+				<daysToRotStart>10</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Medicine.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Medicine.xml
@@ -21,7 +21,7 @@
 			<Mass>0.1</Mass>
 			<Bulk>0.1</Bulk>
 			<Flammability>1.3</Flammability>
-			<DeteriorationRate>6</DeteriorationRate>
+			<DeteriorationRate>15</DeteriorationRate>
 			<MedicalPotency>0.30</MedicalPotency>
 			<MedicalQualityMax>0.60</MedicalQualityMax>
 		</statBases>
@@ -33,7 +33,7 @@
 		<tickerType>Rare</tickerType>
 		<comps>
 			<li Class="CompProperties_Rottable">
-				<daysToRotStart>150</daysToRotStart>
+				<daysToRotStart>30</daysToRotStart>
 				<rotDestroys>true</rotDestroys>
 			</li>
 		</comps>
@@ -64,8 +64,14 @@
 			<Flammability>1.0</Flammability>
 			<MedicalPotency>0.60</MedicalPotency>
 			<MedicalQualityMax>0.70</MedicalQualityMax>
-			<DeteriorationRate>6</DeteriorationRate>
+			<DeteriorationRate>15</DeteriorationRate>
 		</statBases>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>60</daysToRotStart>
+				<rotDestroys>true</rotDestroys>
+			</li>
+		</comps>		
 		<stackLimit>25</stackLimit>
 		<thingCategories>
 			<li>Medicine</li>
@@ -93,10 +99,16 @@
 			<Bulk>0.6</Bulk>
 			<MedicalPotency>1.00</MedicalPotency>
 			<MedicalQualityMax>1.00</MedicalQualityMax>
-			<DeteriorationRate>3</DeteriorationRate>
+			<DeteriorationRate>10</DeteriorationRate>
 			<Flammability>1</Flammability>
 		</statBases>
 		<stackLimit>25</stackLimit>
+		<comps>
+			<li Class="CompProperties_Rottable">
+				<daysToRotStart>120</daysToRotStart>
+				<rotDestroys>true</rotDestroys>
+			</li>
+		</comps>		
 		<thingCategories>
 			<li>Medicine</li>
 		</thingCategories>


### PR DESCRIPTION
Added bulk recipes for bandages.
changed rot time for all medicines to be shorter(make sure you put them way  now)
Added long rot timer to industrial medicine.
All meds  have had their deterioration outside tripled(glitter tech is magic so its untouched)
Added some plastic to  glitter and industrial meds.