### PR TITLE
Fix cleansweeper has duplicate armor comp

### DIFF
--- a/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Light.xml
+++ b/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Light.xml
@@ -43,6 +43,9 @@
 		</race>
 	</ThingDef>
 
+	<!-- Used for different durability in armor comp -->
+	<ThingDef Name="NonCombatLightMechanoidBase" ParentName="LightMechanoid" Abstract="True"/>
+
 	<PawnKindDef Name="LightMechanoidKind" ParentName="SK_BaseMechanoidKind" Abstract="True">
 		<weaponMoney>8000~8000</weaponMoney>
 		<combatPower>200</combatPower>
@@ -149,7 +152,7 @@
 	</PawnKindDef>
 
 	<!-- Lifter -->  
-	<ThingDef ParentName="LightMechanoid">
+	<ThingDef ParentName="NonCombatLightMechanoidBase">
 		<defName>Mech_Lifter</defName>
 		<label>lifter</label>
 		<description>A small mechanoid designed for hauling. Lacking a ranged weapon, it can make only weak melee attacks.</description>
@@ -218,7 +221,7 @@
 	</PawnKindDef>
 
 	<!-- Constructoid -->  
-	<ThingDef ParentName="LightMechanoid">
+	<ThingDef ParentName="NonCombatLightMechanoidBase">
 		<defName>Mech_Constructoid</defName>
 		<label>constructoid</label>
 		<description>A small mechanoid designed to perform construction tasks. It is equipped with a small slug gun for light defense. It can also perform blunt melee attacks if necessary.</description>
@@ -312,7 +315,7 @@
 	</PawnKindDef>
 
 	<!-- Fabricor -->  
-	<ThingDef ParentName="LightMechanoid">
+	<ThingDef ParentName="NonCombatLightMechanoidBase">
 		<defName>Mech_Fabricor</defName>
 		<label>fabricor</label>
 		<description>A small work mechanoid designed to craft all manner of manufactured objects. It is equipped with a small slug gun for light defense.</description>
@@ -395,7 +398,7 @@
 	</PawnKindDef>
 
 	<!-- Agrihand -->  
-	<ThingDef ParentName="LightMechanoid">
+	<ThingDef ParentName="NonCombatLightMechanoidBase">
 		<defName>Mech_Agrihand</defName>
 		<label>agrihand</label>
 		<description>A small mechanoid designed to sow and harvest crops. While it is better suited to labor than combat, it can fight with built-in cutting blades if necessary.</description>
@@ -493,7 +496,7 @@
 	</PawnKindDef>
 
 	<!-- Cleansweeper -->  
-	<ThingDef ParentName="LightMechanoid">
+	<ThingDef ParentName="NonCombatLightMechanoidBase">
 		<defName>Mech_Cleansweeper</defName>
 		<label>cleansweeper</label>
 		<description>A light mechanoid designed for cleaning. Lacking a ranged weapon, it can make only weak melee attacks.</description>

--- a/Mods/Core_SK/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Mods/Core_SK/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -22,22 +22,23 @@
 				<RegenValue>5</RegenValue>
 				<Repairable>true</Repairable>
 				<RepairIngredients>
-					<TitaniumBar>4</TitaniumBar>
-					<CarbonAlloy>4</CarbonAlloy>
+					<TitaniumBar>8</TitaniumBar>
+					<CarbonAlloy>8</CarbonAlloy>
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>70</MaxOverHeal>
-				<MinArmorPct>0.75</MinArmorPct>
+				<MinArmorPct>0.5</MinArmorPct>
 			</li>
 		</value>
 	</Operation>
 
+
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[defName="Mech_Cleansweeper"]/comps</xpath>
+		<xpath>Defs/ThingDef[@Name="NonCombatLightMechanoidBase"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[defName="Mech_Cleansweeper"]</xpath>
+			<xpath>Defs/ThingDef[@Name="NonCombatLightMechanoidBase"]</xpath>
 			<value>
 				<comps/>
 			</value>
@@ -45,23 +46,23 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Cleansweeper"]/comps</xpath>
+		<xpath>Defs/ThingDef[@Name="NonCombatLightMechanoidBase"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>500</Durability>
-				<Regenerates>true</Regenerates>
-				<RegenInterval>1250</RegenInterval>
-				<RegenValue>5</RegenValue>
+				<Regenerates>false</Regenerates>
+				<!-- <RegenInterval>1250</RegenInterval>
+				<RegenValue>5</RegenValue> -->
 				<Repairable>true</Repairable>
 				<RepairIngredients>
-					<TitaniumBar>4</TitaniumBar>
-					<CarbonAlloy>4</CarbonAlloy>
+					<TitaniumBar>2</TitaniumBar>
+					<CarbonAlloy>2</CarbonAlloy>
 				</RepairIngredients>
 				<RepairTime>300</RepairTime>
 				<RepairValue>200</RepairValue>
 				<CanOverHeal>true</CanOverHeal>
 				<MaxOverHeal>50</MaxOverHeal>
-				<MinArmorPct>0.75</MinArmorPct>
+				<MinArmorPct>0.2</MinArmorPct>
 			</li>
 		</value>
 	</Operation>


### PR DESCRIPTION
### In addition to the title:
- Non-combat mech's armor needs to be manually repaired. It no longer regenerates by itself;
- Reduced minimal armor percentage of light mech