### PR TITLE
Ambient Armor Rework

### DIFF
--- a/Mods/CombatExtended/Defs/Stats/Stats_Apparel.xml
+++ b/Mods/CombatExtended/Defs/Stats/Stats_Apparel.xml
@@ -40,6 +40,20 @@
         <multiplierStat>StuffEffectMultiplierArmor</multiplierStat>
       </li>
     </parts>
+    <postProcessCurve>
+			<points>
+				<li>-1,0</li>
+				<li>0,0</li>
+				<li>0.1,0.15</li>
+				<li>0.2,0.29</li>
+				<li>0.3,0.42</li>
+				<li>0.4,0.54</li>
+				<li>0.5,0.65</li>
+				<li>0.6,0.75</li>
+				<li>1.0,0.80</li>
+				<li>10.0,0.99</li>
+			</points>
+		</postProcessCurve>
   </StatDef>
   
   <StatDef>

--- a/Mods/Core_SK/Defs/StatDefs/Stats_Apparel.xml
+++ b/Mods/Core_SK/Defs/StatDefs/Stats_Apparel.xml
@@ -75,6 +75,20 @@
 				<multiplierStat>StuffEffectMultiplierArmor</multiplierStat>
 			</li>
 		</parts>
+		<postProcessCurve>
+			<points>
+				<li>-1,0</li>
+				<li>0,0</li>
+				<li>0.1,0.15</li>
+				<li>0.2,0.29</li>
+				<li>0.3,0.42</li>
+				<li>0.4,0.54</li>
+				<li>0.5,0.65</li>
+				<li>0.6,0.75</li>
+				<li>1.0,0.80</li>
+				<li>10.0,0.99</li>
+			</points>
+		</postProcessCurve>
 	</StatDef>
 
 	<StatDef Name="InsulationBase" Abstract="True">


### PR DESCRIPTION
Heat & Electric armor no longer exceed 100%.
100% raw value provides 80% protection, but higher value provides significantly less armor