### PR TITLE
Fix duplicate armor comp on non-combat mech

### DIFF
--- a/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Light.xml
+++ b/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Light.xml
@@ -44,6 +44,8 @@
 	</ThingDef>
 
 	<!-- Used for different durability in armor comp -->
+	<ThingDef Name="CombatLightMechanoidBase" ParentName="LightMechanoid" Abstract="True"/>
+	
 	<ThingDef Name="NonCombatLightMechanoidBase" ParentName="LightMechanoid" Abstract="True"/>
 
 	<PawnKindDef Name="LightMechanoidKind" ParentName="SK_BaseMechanoidKind" Abstract="True">

--- a/Mods/Core_SK/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
+++ b/Mods/Core_SK/Biotech/Patches/ThingDefs_Races/Races_Mechanoids_Light.xml
@@ -2,9 +2,9 @@
 <Patch>
 
 	<Operation Class="PatchOperationConditional">
-		<xpath>Defs/ThingDef[@Name="LightMechanoid"]/comps</xpath>
+		<xpath>Defs/ThingDef[@Name="CombatLightMechanoidBase"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
-			<xpath>Defs/ThingDef[@Name="LightMechanoid"]</xpath>
+			<xpath>Defs/ThingDef[@Name="CombatLightMechanoidBase"]</xpath>
 			<value>
 				<comps/>
 			</value>
@@ -13,7 +13,7 @@
 	
 	<!-- Was a bunch of A or B or C, but patches are applied before inheritance, so patch the parent class instead -->
 	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="LightMechanoid"]/comps</xpath>
+		<xpath>Defs/ThingDef[@Name="CombatLightMechanoidBase"]/comps</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>700</Durability>


### PR DESCRIPTION
Real fix. Didn't consider inheritance last time