### PR TITLE
Adjusted pawns' backstories

### DIFF
--- a/Mods/Core_SK/Patches/BackstoryDefs/Backstories.xml
+++ b/Mods/Core_SK/Patches/BackstoryDefs/Backstories.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <Patch>
 
-    <Operation Class="PatchOperationReplace">
+<!--    <Operation Class="PatchOperationReplace">
         <xpath>Defs/BackstoryDef[defName="ExoticChef96"]/possessions/li[key="Meat_Thrumbo"]</xpath>
         <value>
 		    <li>
@@ -29,7 +29,7 @@
 			  <value>35</value>
 		    </li>
         </value>
-    </Operation>
+    </Operation>-->
 
     <!-- Tribal / Medieval -->
     <Operation Class="PatchOperationReplace">
@@ -58,7 +58,7 @@
 
     <!-- Industrial / Spacer -->
 
-    <Operation Class="PatchOperationAdd">
+<!--    <Operation Class="PatchOperationAdd">
         <xpath>Defs/BackstoryDef[defName="Bodyguard58"]/possessions</xpath>
         <value>
             <li>
@@ -96,7 +96,7 @@
                 <value>18</value>
             </li>
         </value>
-    </Operation>
+    </Operation>-->
 
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/BackstoryDef[defName="Hunter89"]/possessions</xpath>
@@ -109,5 +109,113 @@
 			</possessions>
 		</value>
 	</Operation>
+	
+	    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/BackstoryDef[defName="GlitterworldSurgeon15"]/possessions</xpath>
+        <value>
+			<possessions>
+			  <li>
+				<key>MedicineIndustrial</key>
+				<value>2</value>
+			  </li>
+			</possessions>
+        </value>
+    </Operation>
+	
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/BackstoryDef[defName="CropFarmer17"]/possessions</xpath>
+        <value>
+			<possessions>
+			  <li MayRequire="notfood.SeedsPlease">
+				<key>Seed_Potato</key>
+				<value>8</value>
+			  </li>
+			</possessions>
+        </value>
+    </Operation>
+
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/BackstoryDef[defName="Bodyguard58"]/possessions</xpath>
+        <value>
+			<possessions>
+			  <li>
+				<key>MeleeWeapon_Knife</key>
+				<value>1</value>
+			  </li>
+			</possessions>
+        </value>
+    </Operation>
+	
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/BackstoryDef[defName="SpaceNavyDoctor72"]/possessions</xpath>
+        <value>
+			<possessions>
+			  <li>
+				<key>Penoxycyline</key>
+				<value>4</value>
+			  </li>
+			</possessions>
+        </value>
+    </Operation>
+	
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/BackstoryDef[defName="StarshipDoctor37"]/possessions</xpath>
+        <value>
+			<possessions>
+			  <li>
+				<key>MedicineIndustrial</key>
+				<value>2</value>
+			  </li>
+			</possessions>
+        </value>
+    </Operation>
+	
+    <Operation Class="PatchOperationReplace">
+        <xpath>Defs/BackstoryDef[defName="UnethicalDoctor29"]/possessions</xpath>
+        <value>
+			<possessions>
+			  <li>
+				<key>MeleeWeapon_Bonesaw</key>
+				<value>1</value>
+			  </li>
+			</possessions>
+        </value>
+    </Operation>
+	
+	<Operation Class="PatchOperationRemove">
+        <xpath>Defs/BackstoryDef[defName="Butcher40"]/possessions</xpath>
+    </Operation>
+	
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/BackstoryDef[defName="AerospaceEngineer44"]/possessions</xpath>
+    </Operation>
+	
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/BackstoryDef[defName="OverwatchSniper42"]/possessions</xpath>
+    </Operation>
+	
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/BackstoryDef[defName="BushSniper94"]/possessions</xpath>
+    </Operation>
+	
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/BackstoryDef[defName="Gunfighter51"]/possessions</xpath>
+    </Operation>
+	
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/BackstoryDef[defName="ExoticChef96"]/possessions</xpath>
+    </Operation>
+	
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/BackstoryDef[defName="PirateDoctor0"]/possessions</xpath>
+    </Operation>
+	
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/BackstoryDef[defName="BloodyDentist9"]/possessions</xpath>
+    </Operation>
+	
+    <Operation Class="PatchOperationRemove">
+        <xpath>Defs/BackstoryDef[defName="Slaughterer58"]/possessions</xpath>
+    </Operation>
 
 </Patch>


### PR DESCRIPTION
Removed backstories with firearms - having additional firearms both in hands of enemies and player can throw off flow of the game. Also removed backstories with spoilable stuff like meat and organs (why would anyone bring a slab of meat into a cryocapsule and how is it not spoiled?). Replaced Sun lamp with potato seeds (were we crushlanded or is it organized colonization already?)