### PR TITLE
Remove ShieldPawn class from animals

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_CatGroup.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_CatGroup.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 	<ThingDef ParentName="SK_AnimalThingBase" Name="AnimalDomesticCatBase" Abstract="True">
-		<thingClass>SK.ShieldPawn</thingClass>
 		<devNote>cat</devNote>
 		<statBases>
 			<Mass>3</Mass>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_DogGroup.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_DogGroup.xml
@@ -1,7 +1,6 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <Defs>
 	<ThingDef ParentName="SK_AnimalThingBase" Name="AnimalDogBase" Abstract="True">
-		<thingClass>SK.ShieldPawn</thingClass>
 		<devNote>cat-1</devNote>
 		<statBases>
 			<Mass>40</Mass>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Hyena.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Hyena.xml
@@ -2,7 +2,6 @@
 <Defs>
 
 	<ThingDef ParentName="SK_AnimalThingBase">
-		<thingClass>SK.ShieldPawn</thingClass>
 		<defName>SpottedHyena</defName>
 		<label>Spotted Hyena</label>
 		<description>A mid sized, Spotted Hyena that hunt in packs. Its mouth-grip strength is very powerful.</description>

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_WildCanines.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_WildCanines.xml
@@ -2,7 +2,6 @@
 <Defs>
 	<!-- ========================== WildCanines ============================ -->
 	<ThingDef ParentName="SK_AnimalThingBase">
-		<thingClass>SK.ShieldPawn</thingClass>
 		<defName>Warg</defName>
 		<label>warg</label>
 		<devNote>warg</devNote>
@@ -212,7 +211,6 @@
 	</PawnKindDef>
 
 	<ThingDef ParentName="SK_AnimalThingBase">
-		<thingClass>SK.ShieldPawn</thingClass>
 		<defName>Nightling</defName>
 		<label>nightling</label>
 		<description>A large deformed beast with rows of quills on its back.

--- a/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Wolfs.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Races/Races_Animal_Wolfs.xml
@@ -2,7 +2,6 @@
 <Defs>
 	<!-- ========================== Wolves ================================= -->
 	<ThingDef Name="SK_WolfThingBase" ParentName="SK_AnimalThingBase" Abstract="True">
-		<thingClass>SK.ShieldPawn</thingClass>
 		<devNote>warg-1</devNote>
 		<statBases>
 			<Mass>60</Mass>


### PR DESCRIPTION
Allows them to use Rocketman performance optimization, but they will stop using nanite shields (hopefully I will modernize it later)