### PR TITLE
Removed heat generation from centrifuges

### DIFF
--- a/Mods/Rimatomics_SK/Defs/ThingDefs_Buildings/Buildings_G_HSK.xml
+++ b/Mods/Rimatomics_SK/Defs/ThingDefs_Buildings/Buildings_G_HSK.xml
@@ -47,11 +47,6 @@
 				<compClass>SK.CompPowerLowIdleDraw</compClass>
 				<idlePowerFactor>0.1</idlePowerFactor>
 			</li>
-			<li Class="CompProperties_HeatPusher">
-				<compClass>CompHeatPusherPowered</compClass>
-				<heatPerSecond>75</heatPerSecond>
-				<heatPushMaxTemperature>1500</heatPushMaxTemperature>
-			</li>
 
 			<li Class="CompProperties_Flickable"/>
 			<li Class="CompProperties_Breakdownable"/>


### PR DESCRIPTION
Don't want to be such a party breaker - it is very much open for debate. But what was the idea behind giving them heat emission? Mechanical parts heating up from friction? But we have a lot of other heavy machinery that can do that as well, and the numbers are also insane (I don't think we have anything that can heat up to 1500C)