### PR TITLE
Ore-some changes to ores and alloys

### DIFF
--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Alloys.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Alloys.xml
@@ -21,7 +21,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>15</count>
+				<count>20</count>
 			</li>
 			<li>
 				<filter>
@@ -68,7 +68,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>15</count>
+				<count>20</count>
 			</li>
 			<li>
 				<filter>
@@ -248,7 +248,7 @@
 						<li>Nickel</li>
 					</thingDefs>
 				</filter>
-				<count>15</count>
+				<count>30</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -283,7 +283,7 @@
 						<li>Steel</li>
 					</thingDefs>
 				</filter>
-				<count>75</count>
+				<count>25</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -319,7 +319,7 @@
 						<li>Wolframite</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>15</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -355,7 +355,7 @@
 						<li>Ilmenite</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>15</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -437,7 +437,7 @@
 						<li>Plasteel</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>20</count>
 			</li>
 			<li>
 				<filter>
@@ -445,7 +445,7 @@
 						<li>Silicon</li>
 					</thingDefs>
 				</filter>
-				<count>15</count>
+				<count>5</count>
 			</li>
 			<li>
 				<filter>
@@ -576,21 +576,13 @@
 	<RecipeDef>
 		<defName>MakeAlnicoAlloy</defName>
 		<label>Smelt alnico alloy</label>
-		<description>Smelts alnico, an alloy of steel, nickel, aluminum and cobalt. Alnico is used in the creation of strong permanent magnets, and can be magnetised to produce strong magnetic fields. Produces 20.</description>
+		<description>Smelts alnico, an alloy nickel, aluminum and cobalt. Alnico is used in the creation of strong permanent magnets, and can be magnetised to produce strong magnetic fields. Produces 20.</description>
 		<jobString>Smelting alnico alloy.</jobString>
 		<workAmount>1650</workAmount>
 		<workSpeedStat>SmeltingSpeed</workSpeedStat>
 		<effectWorking>Smelt</effectWorking>
 		<soundWorking>Recipe_Smelt</soundWorking>
 		<ingredients>
-			<li>
-				<filter>
-					<thingDefs>
-						<li>Plasteel</li>
-					</thingDefs>
-				</filter>
-				<count>10</count>
-			</li>
 			<li>
 				<filter>
 					<thingDefs>
@@ -613,7 +605,7 @@
 						<li>NickelBar</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>10</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>
@@ -799,7 +791,7 @@
 						<li>Silver</li>
 					</thingDefs>
 				</filter>
-				<count>7</count>
+				<count>14</count>
 			</li>
 			<li>
 				<filter>
@@ -846,7 +838,7 @@
 						<li>Silver</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>20</count>
 			</li>
 			<li>
 				<filter>
@@ -918,7 +910,7 @@
 		<label>Smelt copper alloy</label>
 		<description>Smelts copper alloy from copper ore. Produces 20.</description>
 		<jobString>Smelting copper alloy.</jobString>
-		<workAmount>600</workAmount>
+		<workAmount>500</workAmount>
 		<workSpeedStat>SmeltingSpeed</workSpeedStat>
 		<effectWorking>Smelt</effectWorking>
 		<soundWorking>Recipe_Smelt</soundWorking>
@@ -1149,7 +1141,7 @@
 						<li>Plasteel</li>
 					</thingDefs>
 				</filter>
-				<count>15</count>
+				<count>12</count>
 			</li>
 			<li>
 				<filter>
@@ -1284,7 +1276,7 @@
 						<li>Uranium</li>
 					</thingDefs>
 				</filter>
-				<count>20</count>
+				<count>10</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/RecipeDefs/Recipes_Alloys.xml
+++ b/Mods/Core_SK/Defs/RecipeDefs/Recipes_Alloys.xml
@@ -576,7 +576,7 @@
 	<RecipeDef>
 		<defName>MakeAlnicoAlloy</defName>
 		<label>Smelt alnico alloy</label>
-		<description>Smelts alnico, an alloy nickel, aluminum and cobalt. Alnico is used in the creation of strong permanent magnets, and can be magnetised to produce strong magnetic fields. Produces 20.</description>
+		<description>Smelts alnico, an alloy of iron, nickel, aluminum and cobalt. Alnico is used in the creation of strong permanent magnets, and can be magnetised to produce strong magnetic fields. Produces 20.</description>
 		<jobString>Smelting alnico alloy.</jobString>
 		<workAmount>1650</workAmount>
 		<workSpeedStat>SmeltingSpeed</workSpeedStat>
@@ -586,10 +586,18 @@
 			<li>
 				<filter>
 					<thingDefs>
+						<li>Plasteel</li>
+					</thingDefs>
+				</filter>
+				<count>8</count>
+			</li>
+			<li>
+				<filter>
+					<thingDefs>
 						<li>AluminiumBar</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>3</count>
 			</li>
 			<li>
 				<filter>
@@ -597,7 +605,7 @@
 						<li>Cobalt</li>
 					</thingDefs>
 				</filter>
-				<count>5</count>
+				<count>3</count>
 			</li>
 			<li>
 				<filter>
@@ -605,7 +613,7 @@
 						<li>NickelBar</li>
 					</thingDefs>
 				</filter>
-				<count>10</count>
+				<count>6</count>
 			</li>
 		</ingredients>
 		<fixedIngredientFilter>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_SK.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Misc_SK.xml
@@ -203,6 +203,12 @@
 			<uninstallWork>300</uninstallWork>
 			<paintable>true</paintable>
 		</building>
+		<comps>
+			<li Class="CompProperties_AffectedByFacilities">
+				<linkableFacilities>
+				</linkableFacilities>
+			</li>
+		</comps>
 		<interactionCellOffset>(0,0,-1)</interactionCellOffset>
 		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
 		<designationCategory>Misc</designationCategory>

--- a/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Natural.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Buildings/Buildings_Natural.xml
@@ -437,8 +437,8 @@
 			<mineableYield>50</mineableYield>
 			<mineableScatterCommonality>0.4</mineableScatterCommonality>
 			<mineableScatterLumpSizeRange>
-				<min>6</min>
-				<max>13</max>
+				<min>5</min>
+				<max>10</max>
 			</mineableScatterLumpSizeRange>
 		</building>
 	</ThingDef>
@@ -569,8 +569,8 @@
 			<mineableYield>75</mineableYield>
 			<mineableScatterCommonality>0.25</mineableScatterCommonality>
 			<mineableScatterLumpSizeRange>
-				<min>7</min>
-				<max>14</max>
+				<min>3</min>
+				<max>9</max>
 			</mineableScatterLumpSizeRange>
 		</building>
 	</ThingDef>
@@ -661,8 +661,8 @@
 			<mineableYield>50</mineableYield>
 			<mineableScatterCommonality>0.35</mineableScatterCommonality>
 			<mineableScatterLumpSizeRange>
-				<min>6</min>
-				<max>13</max>
+				<min>3</min>
+				<max>6</max>
 			</mineableScatterLumpSizeRange>
 		</building>
 		<comps>
@@ -690,8 +690,8 @@
 		<building>
 			<isResourceRock>true</isResourceRock>
 			<mineableThing>Salt</mineableThing>
-			<mineableYield>75</mineableYield>
-			<mineableScatterCommonality>0.9</mineableScatterCommonality>
+			<mineableYield>150</mineableYield>
+			<mineableScatterCommonality>1.2</mineableScatterCommonality>
 			<mineableScatterLumpSizeRange>
 				<min>5</min>
 				<max>10</max>
@@ -720,8 +720,8 @@
 			<mineableYield>50</mineableYield>
 			<mineableScatterCommonality>0.3</mineableScatterCommonality>
 			<mineableScatterLumpSizeRange>
-				<min>6</min>
-				<max>14</max>
+				<min>4</min>
+				<max>7</max>
 			</mineableScatterLumpSizeRange>
 		</building>
 		<comps>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Hightech.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Hightech.xml
@@ -15,7 +15,7 @@
 		<stackLimit>150</stackLimit>
 		<techLevel>Spacer</techLevel>
 		<statBases>
-			<MarketValue>50</MarketValue>
+			<MarketValue>40</MarketValue>
 			<StuffPower_Armor_Blunt>1.15</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.4</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.166</StuffPower_Armor_Heat>
@@ -49,7 +49,7 @@
 		<stackLimit>150</stackLimit>
 		<techLevel>Spacer</techLevel>
 		<statBases>
-			<MarketValue>36</MarketValue>
+			<MarketValue>30</MarketValue>
 			<StuffPower_Armor_Blunt>1.5</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.44</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.125</StuffPower_Armor_Heat>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
@@ -15,7 +15,7 @@
 		<stackLimit>150</stackLimit>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>15</MarketValue>
+			<MarketValue>10</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>0</Flammability>
 			<Mass>0.4</Mass>
@@ -39,7 +39,7 @@
 		<soundDrop>Metal_Drop</soundDrop>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>5</MarketValue>
+			<MarketValue>6</MarketValue>
 			<StuffPower_Armor_Blunt>1.3</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.04</StuffPower_Armor_Heat>
@@ -109,7 +109,7 @@
 		<stackLimit>150</stackLimit>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>15</MarketValue>
+			<MarketValue>12</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>0</Flammability>
 			<Mass>0.45</Mass>
@@ -183,7 +183,7 @@
 		<stackLimit>300</stackLimit>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>4</MarketValue>
+			<MarketValue>3</MarketValue>
 			<StuffPower_Armor_Blunt>0.8</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.8</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.07</StuffPower_Armor_Heat>
@@ -251,7 +251,7 @@
 		<stackLimit>600</stackLimit>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>2.0</MarketValue>
+			<MarketValue>3</MarketValue>
 			<StuffPower_Armor_Blunt>0.9</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.8</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.07</StuffPower_Armor_Heat>
@@ -456,7 +456,7 @@
 		<stackLimit>150</stackLimit>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>9</MarketValue>
+			<MarketValue>8</MarketValue>
 			<StuffPower_Armor_Blunt>1.2</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.2</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.08</StuffPower_Armor_Heat>
@@ -523,7 +523,7 @@
 		<stackLimit>150</stackLimit>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>13</MarketValue>
+			<MarketValue>15</MarketValue>
 			<StuffPower_Armor_Blunt>1.24</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.21</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.121</StuffPower_Armor_Heat>
@@ -589,7 +589,7 @@
 		<stackLimit>75</stackLimit>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>28</MarketValue>
+			<MarketValue>18</MarketValue>
 			<StuffPower_Armor_Blunt>1.52</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.55</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.126</StuffPower_Armor_Heat>
@@ -653,7 +653,7 @@
 		<stackLimit>75</stackLimit>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>135</MarketValue>
+			<MarketValue>40</MarketValue>
 			<StuffPower_Armor_Blunt>1.32</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.49</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.135</StuffPower_Armor_Heat>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Industrial.xml
@@ -523,7 +523,7 @@
 		<stackLimit>150</stackLimit>
 		<techLevel>Industrial</techLevel>
 		<statBases>
-			<MarketValue>15</MarketValue>
+			<MarketValue>11</MarketValue>
 			<StuffPower_Armor_Blunt>1.24</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>1.21</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.121</StuffPower_Armor_Heat>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Alloys_Medieval.xml
@@ -85,7 +85,7 @@
 		<stackLimit>300</stackLimit>
 		<techLevel>Medieval</techLevel>
 		<statBases>
-			<MarketValue>2</MarketValue>
+			<MarketValue>3</MarketValue>
 			<StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.7</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.07</StuffPower_Armor_Heat>
@@ -153,7 +153,7 @@
 		<stackLimit>600</stackLimit>
 		<techLevel>Medieval</techLevel>
 		<statBases>
-			<MarketValue>2.0</MarketValue>
+			<MarketValue>4</MarketValue>
 			<StuffPower_Armor_Blunt>1.0</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.06</StuffPower_Armor_Heat>
@@ -220,7 +220,7 @@
 		<healthAffectsPrice>false</healthAffectsPrice>
 		<techLevel>Medieval</techLevel>
 		<statBases>
-			<MarketValue>50</MarketValue>
+			<MarketValue>35</MarketValue>
 			<StuffPower_Armor_Blunt>0.6</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.5</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.06</StuffPower_Armor_Heat>
@@ -292,7 +292,7 @@
 		<healthAffectsPrice>false</healthAffectsPrice>
 		<techLevel>Medieval</techLevel>
 		<statBases>
-			<MarketValue>4</MarketValue>
+			<MarketValue>5</MarketValue>
 			<StuffPower_Armor_Blunt>0.7</StuffPower_Armor_Blunt>
 			<StuffPower_Armor_Sharp>0.6</StuffPower_Armor_Sharp>
 			<StuffPower_Armor_Heat>0.06</StuffPower_Armor_Heat>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Extracted.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Extracted.xml
@@ -48,7 +48,7 @@
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
 		<statBases>
-			<MarketValue>50</MarketValue>
+			<MarketValue>25</MarketValue>
 			<SellPriceFactor>0.50</SellPriceFactor>
 			<Mass>0.2</Mass>
 			<Bulk>0.2</Bulk>
@@ -85,7 +85,7 @@
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
 		<statBases>
-			<MarketValue>150</MarketValue>
+			<MarketValue>40</MarketValue>
 			<SellPriceFactor>0.50</SellPriceFactor>
 			<Mass>0.2</Mass>
 			<Bulk>0.2</Bulk>
@@ -198,12 +198,12 @@
 		<statBases>
 			<MaxHitPoints>5</MaxHitPoints>
 			<MarketValue>3</MarketValue>
-			<DeteriorationRate>0.01</DeteriorationRate>
+			<DeteriorationRate>0.1</DeteriorationRate>
 			<Flammability>5</Flammability>
 			<Mass>0.1</Mass>
 			<Bulk>0.1</Bulk>
 		</statBases>
-		<tickerType>Normal</tickerType>
+		<tickerType>Rare</tickerType>
 		<comps>
 			<li Class="CompProperties_Explosive">
 				<explosiveRadius>1.2</explosiveRadius>
@@ -248,14 +248,14 @@
 		<statBases>
 			<MaxHitPoints>10</MaxHitPoints>
 			<MarketValue>2</MarketValue>
-			<DeteriorationRate>0.01</DeteriorationRate>
+			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>3</Flammability>
 			<MaxBurningTempCelsius>1500</MaxBurningTempCelsius>
 			<BurnDurationHours>1.4</BurnDurationHours>
 			<Mass>0.2</Mass>
 			<Bulk>0.2</Bulk>
 		</statBases>
-		<tickerType>Normal</tickerType>
+		<tickerType>Rare</tickerType>
 		<thingCategories>
 			<li>Coal</li>
 		</thingCategories>
@@ -286,7 +286,7 @@
 		<statBases>
 			<MaxHitPoints>15</MaxHitPoints>
 			<MarketValue>2</MarketValue>
-			<DeteriorationRate>0.01</DeteriorationRate>
+			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>3</Flammability>
 			<MaxBurningTempCelsius>700</MaxBurningTempCelsius>
 			<BurnDurationHours>1.2</BurnDurationHours>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Ore.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Ore.xml
@@ -57,7 +57,7 @@
 		<soundInteract>Silver_Drop</soundInteract>
 		<soundDrop>Silver_Drop</soundDrop>
 		<useHitPoints>false</useHitPoints>
-		<stackLimit>600</stackLimit>
+		<stackLimit>300</stackLimit>
 		<healthAffectsPrice>false</healthAffectsPrice>
 		<statBases>
 			<MarketValue>25</MarketValue>
@@ -136,7 +136,7 @@
 		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
-		<stackLimit>600</stackLimit>
+		<stackLimit>300</stackLimit>
 		<statBases>
 			<MarketValue>8</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -239,7 +239,7 @@
 		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
-		<stackLimit>600</stackLimit>
+		<stackLimit>300</stackLimit>
 		<statBases>
 			<MarketValue>4</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -305,7 +305,7 @@
 		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
-		<stackLimit>600</stackLimit>
+		<stackLimit>300</stackLimit>
 		<statBases>
 			<MarketValue>16</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -335,7 +335,7 @@
 		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
-		<stackLimit>600</stackLimit>
+		<stackLimit>300</stackLimit>
 		<statBases>
 			<MarketValue>18</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Ore.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Ore.xml
@@ -25,7 +25,7 @@
 		<thingCategories>
 			<li>PRS</li>
 		</thingCategories>
-		<stackLimit>1500</stackLimit>
+		<stackLimit>1800</stackLimit>
 		<smallVolume>true</smallVolume>
 		<smeltable>true</smeltable>
 		<possessionCount>40</possessionCount>
@@ -57,7 +57,7 @@
 		<soundInteract>Silver_Drop</soundInteract>
 		<soundDrop>Silver_Drop</soundDrop>
 		<useHitPoints>false</useHitPoints>
-		<stackLimit>150</stackLimit>
+		<stackLimit>600</stackLimit>
 		<healthAffectsPrice>false</healthAffectsPrice>
 		<statBases>
 			<MarketValue>25</MarketValue>
@@ -117,7 +117,7 @@
 			</statFactors>
 		</stuffProps>
 		<terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
-		<deepCommonality>2.5</deepCommonality>
+		<deepCommonality>3.2</deepCommonality>
 		<deepCountPerCell>1000</deepCountPerCell>
 		<deepCountPerPortion>35</deepCountPerPortion>
 		<deepLumpSizeRange>
@@ -136,9 +136,9 @@
 		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
-		<stackLimit>75</stackLimit>
+		<stackLimit>600</stackLimit>
 		<statBases>
-			<MarketValue>18</MarketValue>
+			<MarketValue>8</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>0</Flammability>
 			<Mass>0.4</Mass>
@@ -239,9 +239,9 @@
 		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
-		<stackLimit>300</stackLimit>
+		<stackLimit>600</stackLimit>
 		<statBases>
-			<MarketValue>6</MarketValue>
+			<MarketValue>4</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>0</Flammability>
 			<SharpDamageMultiplier>0.4</SharpDamageMultiplier>
@@ -272,7 +272,7 @@
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
 		<statBases>
-			<MarketValue>3</MarketValue>
+			<MarketValue>2</MarketValue>
 			<SharpDamageMultiplier>0.6</SharpDamageMultiplier>
 			<BluntDamageMultiplier>0.9</BluntDamageMultiplier>
 			<DeteriorationRate>0</DeteriorationRate>
@@ -305,9 +305,9 @@
 		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
-		<stackLimit>75</stackLimit>
+		<stackLimit>600</stackLimit>
 		<statBases>
-			<MarketValue>60</MarketValue>
+			<MarketValue>16</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>0</Flammability>
 			<Mass>0.15</Mass>
@@ -335,9 +335,9 @@
 		</graphicData>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
-		<stackLimit>75</stackLimit>
+		<stackLimit>600</stackLimit>
 		<statBases>
-			<MarketValue>70</MarketValue>
+			<MarketValue>18</MarketValue>
 			<DeteriorationRate>0</DeteriorationRate>
 			<Flammability>0</Flammability>
 			<Mass>0.2</Mass>

--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Radioactive.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Radioactive.xml
@@ -20,7 +20,7 @@
 		<pathCost>15</pathCost>
 		<soundInteract>Metal_Drop</soundInteract>
 		<soundDrop>Metal_Drop</soundDrop>
-		<stackLimit>75</stackLimit>
+		<stackLimit>300</stackLimit>
 		<tickerType>Normal</tickerType>
 		<techLevel>Industrial</techLevel>
 		<statBases>

--- a/Mods/Minerals/Defs/ThingsDefs_Fossils/Fossils.xml
+++ b/Mods/Minerals/Defs/ThingsDefs_Fossils/Fossils.xml
@@ -248,9 +248,9 @@
     <comps>
       <li Class="CompProperties_Facility">
         <statOffsets>
-          <ResearchSpeedFactor>0.05</ResearchSpeedFactor>
+          <ResearchSpeedFactor>0.10</ResearchSpeedFactor>
         </statOffsets>
-        <maxSimultaneous>3</maxSimultaneous>
+        <maxSimultaneous>2</maxSimultaneous>
       </li>
     </comps>
     <placeWorkers>
@@ -410,9 +410,9 @@
     <comps>
       <li Class="CompProperties_Facility">
         <statOffsets>
-          <ResearchSpeedFactor>0.1</ResearchSpeedFactor>
+          <ResearchSpeedFactor>0.25</ResearchSpeedFactor>
         </statOffsets>
-        <maxSimultaneous>3</maxSimultaneous>
+        <maxSimultaneous>1</maxSimultaneous>
       </li>
     </comps>
     <placeWorkers>

--- a/Mods/Minerals/Patches/01_HardcoreSK/Research.xml
+++ b/Mods/Minerals/Patches/01_HardcoreSK/Research.xml
@@ -1,6 +1,21 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
-  
+  <Operation Class="PatchOperationFindMod">
+    <mods>
+      <li>Core SK</li>
+    </mods>
+    <match Class="PatchOperationAdd">
+  	  <xpath>Defs/ThingDef[defName = "PrimitiveResearchBench"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
+  	  <value>
+        <li>MediumFossilTrophy</li>
+        <li>LargeFossilTrophy</li>
+        <li>BigGlowstoneCrystalTrophy</li>
+        <li>BigColdstoneCrystalTrophy</li>
+        <li>BigQuartzCrystalTrophy</li>
+        <li>BigAmethystCrystalTrophy</li>
+  	  </value>
+    </match>
+  </Operation>
 
   <Operation Class="PatchOperationFindMod">
     <mods>
@@ -26,8 +41,12 @@
     <match Class="PatchOperationAdd">
   	  <xpath>Defs/ThingDef[defName = "HiTechResearchBench"]/comps/li[@Class="CompProperties_AffectedByFacilities"]/linkableFacilities</xpath>
   	  <value>
+        <li>MediumFossilTrophy</li>
+        <li>LargeFossilTrophy</li>
         <li>BigGlowstoneCrystalTrophy</li>
         <li>BigColdstoneCrystalTrophy</li>
+        <li>BigQuartzCrystalTrophy</li>
+        <li>BigAmethystCrystalTrophy</li>
   	  </value>
     </match>
   </Operation>


### PR DESCRIPTION
- Ore smelting conversion rate is almost universally 1 to 1 now, with exception for some alloys that exist in parent ores in very small quantites (like cobalt in nickel).
- More streamlined ore stacking - now most ores are stored in stacks of 600 (more of a QOL than persuit of realism)
- Coal doesn't spoil outside (maybe there was some intention behind it, but better make it more clear next time)
- Ore and alloy prices are normalized with main changes: coldstone, glowstone, wolframite and ilmenite ores are not as ridiculously expensive now (I swear, some ores were almost more expensive than their respective alloys). Still can bloat your colony wealth, but less deadly. Carbon alloy is now also more in line with other materials.
- Fossil buildings now boost for more and also affect primitive and industrial research tables, but can't be stacked as much. Go hunt for those juicy bones, now they are useful in mid game too!