### PR TITLE
Update Stats_Pawns_WorkRecipes.xml

### DIFF
--- a/Mods/Core_SK/Languages/Russian/DefInjected/StatDefs/Stats_Pawns_WorkRecipes.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/StatDefs/Stats_Pawns_WorkRecipes.xml
@@ -25,6 +25,9 @@
 	
 	<CleaningSpeed.label>скорость уборки</CleaningSpeed.label>
 	<CleaningSpeed.description>скорость, с которой персонаж занимается убокой, чистит снег.</CleaningSpeed.description>
-	
+	  
+	<GeneralLaborSpeed.label>скорость простой работы</GeneralLaborSpeed.label>
+	<GeneralLaborSpeed.description>Скорость, с которой персонаж выполняет простую работу, такую как работа с перегонным аппаратом, сжигание и создание предметов искусства. Этот показатель применяется как к занятиям, не требующим специальных навыков, так и к тем, в которых навык влияет на качество конечного продукта вместо скорости работы.</GeneralLaborSpeed.description>
+	  
 </LanguageData>
 <!-- edited by Hardcore-SK team -->


### PR DESCRIPTION
Added a more correct name and description of the General Labor Speed parameter to the Russian localization. I added it to the translation of the Core SK to prevent rewriting with future translation updates.

Добавлено более корректное наименование и описание параметра General Labor Speed в русскую локализацию.
В оригинальной игре этот параметр отвечает за большое количество типов работ (в т.ч. ковка, переплавка, шитье, которые в хск вынесены отдельно и в результате он отвечает всего за 2-3 типа работ (в основном ваяние скульптур и сжигание трупов)). 
Также его название очень похоже на общую скорость работы, что часто путает во время игры.
Добавил перевод в Core SK, т.к. обновления перевода будут постоянно его затирать на ванильный вариант.