### PR TITLE
Update PawnKinds.xml

### DIFF
--- a/Mods/Core_SK/Biotech/Patches/PawnKindDefs_Biotech/PawnKinds.xml
+++ b/Mods/Core_SK/Biotech/Patches/PawnKindDefs_Biotech/PawnKinds.xml
@@ -326,4 +326,28 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[defName = "Mercenary_Gunner_Pig"]</xpath>
+		<value>	
+			<apparelTags Inherit="False">
+			  <li>IndustrialBasic</li>
+			  <li>IndustrialMilitaryBasic</li>
+			  <li>Outlander</li>
+			  <li>BanditsLight</li>
+			</apparelTags>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/PawnKindDef[defName = "Mercenary_Elite_Pig"]</xpath>
+		<value>	
+			<apparelTags Inherit="False">
+			  <li>IndustrialAdvanced</li>
+			  <li>IndustrialMilitaryAdvanced</li>
+			  <li>Outlander</li>
+			  <li>BanditsLight</li>
+			</apparelTags>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
Fixed apparel tags for pig gunner and pig elite raider pawns to prevent spacer apparel spawn.

Исправлены теги одежды для рейдеров стрелков и элитных наемников фракции свинолюдей для предотвращения спавна у них хайтек одежды и брони.