### PR TITLE
Fixed missed earliestRaidDays (Biotech factions)

### DIFF
--- a/Mods/Core_SK/Biotech/Defs/Factions/Factions_Misc.xml
+++ b/Mods/Core_SK/Biotech/Defs/Factions/Factions_Misc.xml
@@ -10,7 +10,7 @@
     <settlementNameMaker>NamerSettlementTribalNeaderthal</settlementNameMaker>
     <pawnSingular>neanderthal</pawnSingular>
     <pawnsPlural>neanderthals</pawnsPlural>
-    <replacesFaction>TribeRough</replacesFaction>
+    <!-- <replacesFaction>TribeRough</replacesFaction> -->
     <melaninRange>0~0.5</melaninRange>
     <xenotypeSet Inherit="False">
       <xenotypeChances>

--- a/Mods/Core_SK/Biotech/Patches/Factions/Factions_Patch.xml
+++ b/Mods/Core_SK/Biotech/Patches/Factions/Factions_Patch.xml
@@ -1,0 +1,39 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/FactionDef[defName="TribeRoughNeanderthal"]</xpath>
+		<value>
+			<earliestRaidDays>48</earliestRaidDays>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/FactionDef[defName="PirateYttakin"]</xpath>
+		<value>
+			<earliestRaidDays>96</earliestRaidDays>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/FactionDef[defName="OutlanderRoughPig"]</xpath>
+		<value>
+			<earliestRaidDays>120</earliestRaidDays>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/FactionDef[defName="PirateWaster"]</xpath>
+		<value>
+			<earliestRaidDays>138</earliestRaidDays>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/FactionDef[defName="TribeSavageImpid"]/earliestRaidDays</xpath>
+		<value>
+			<earliestRaidDays>48</earliestRaidDays>
+		</value>
+	</Operation>
+
+</Patch>	


### PR DESCRIPTION
Added missed earliestRaidDays param to all Biotech factions (based on the HSK factions and taking into account the xenotype of the pawns).
The fierce neanderthal tribe faction no longer replaces the regular fierce tribe faction to avoid the lack of raiders in the first 30 days of the game and a smoother increase in difficulty during the same period.

Добавлены пропущенные параметры earliestRaidDays (мин. кол-во дней с момента старта колонии, которое должно пройти для возможности рейдов этих фракций) для всех фракций Биотеха (значения основаны на фракциях ХСК, с учетом ксенотипов пешек этих фракций).
Фракция враждебного племени неандертальцев более не заменяет обычную фракцию враждебного племени во избежание отсутствия рейдов в первые 30 дней игры и более плавного нарастания сложности в этот же период.