### PR TITLE
HedSweetbun is only for Sweetbun, not for the others.

### DIFF
--- a/Mods/Core_SK/Defs/HediffDefs/Meal/Hediffs_Food.xml
+++ b/Mods/Core_SK/Defs/HediffDefs/Meal/Hediffs_Food.xml
@@ -101,7 +101,7 @@
 
 	<HediffDef>
 		<defName>HedSweetbun</defName>
-		<label>ate a baked good.</label>
+		<label>ate a sweetbun.</label>
 		<description>I'm full of energy and moving like a Flash</description>
 		<isBad>false</isBad>
 		<initialSeverity>1</initialSeverity>
@@ -114,7 +114,7 @@
 		<stages>
 			<li>
 				<minSeverity>0</minSeverity>
-				<label>Well Fed: Baked Good</label>
+				<label>Well Fed: Sweetbun</label>
 				<painFactor>0.9</painFactor>
 				<capMods>
 					<li>


### PR DESCRIPTION
Except the Sweetbun, all baked goods don't give the hediff named HedSweetbun.  The `label` should be corrected.