### PR TITLE
Fixed incorrect cost (combatPower) of some biotech mech-s

### DIFF
--- a/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Light.xml
+++ b/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Light.xml
@@ -111,7 +111,7 @@
 		<defName>Mech_Militor</defName>
 		<label>militor</label>
 		<race>Mech_Militor</race>
-		<combatPower>60</combatPower>
+		<combatPower>240</combatPower>
 		<lifeStages>
 			<li>
 				<bodyGraphicData>

--- a/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Medium.xml
+++ b/Mods/Core_SK/Biotech/Defs/ThingDef_Races/Races_Mechanoids_Medium.xml
@@ -97,7 +97,7 @@
 		<defName>Mech_Legionary</defName>
 		<label>legionary</label>
 		<race>Mech_Legionary</race>
-		<combatPower>200</combatPower>
+		<combatPower>300</combatPower>
 		<allowInMechClusters>false</allowInMechClusters>
 		<lifeStages>
 			<li>
@@ -172,7 +172,7 @@
 		<defName>Mech_Tesseron</defName>
 		<label>tesseron</label>
 		<race>Mech_Tesseron</race>
-		<combatPower>200</combatPower>
+		<combatPower>300</combatPower>
 		<lifeStages>
 			<li>
 				<bodyGraphicData>
@@ -289,7 +289,7 @@
 		<label>scorcher</label>
 		<labelPlural>scorchers</labelPlural>
 		<race>Mech_Scorcher</race>
-		<combatPower>110</combatPower>
+		<combatPower>270</combatPower>
 		<lifeStages>
 			<li>
 				<bodyGraphicData>


### PR DESCRIPTION
Fixed incorrect cost (combatPower) of some biotech mech-s (was cheaper than crawler)

P.S. It’s probably worth reconsidering the cost of all mechanoids (especially the crawler), in my opinion the values are too high in some places, but for now let it be so.

![image](https://github.com/skyarkhangel/Hardcore-SK/assets/62516232/3960078b-e5c8-4e8c-a7c6-a5b02c133396)


Исправлена некорректная стоимость (combatPower) некоторых механоидов Biotech (стоили дешевле краба).

P.S. Вероятно стоит пересмотреть стоимость всех механоидов (особенно краба), по-моему значения местами завышены, но пока пусть будет так.
