### PR TITLE
Delete all "Beauty: n" in floor descriptions

### DIFF
--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorBrick.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorBrick.xml
@@ -4,8 +4,7 @@
 
 	<TerrainDef Abstract="True" ParentName="SK_TileStoneBase" Name="MediumBrickBase">
 		<renderPrecedence>220</renderPrecedence>
-		<description>Bricks laid in an interlocking pattern.
-	Beauty: 2.</description>
+		<description>Bricks laid in an interlocking pattern.</description>
 		<texturePath>Terrain/Surfaces/BrickFloor</texturePath>
 		<statBases>
 			<WorkToBuild>600</WorkToBuild>
@@ -18,8 +17,7 @@
 
 	<TerrainDef Abstract="True" ParentName="SK_TileStoneBase" Name="SmallBrickBase">
 		<renderPrecedence>221</renderPrecedence>
-		<description>Smaller bricks laid in an interlocking pattern. Takes slightly longer to make than the regular variety.
-	Beauty: 2.</description>
+		<description>Smaller bricks laid in an interlocking pattern. Takes slightly longer to make than the regular variety.</description>
 		<texturePath>Terrain/Surfaces/SmallBricks</texturePath>
 		<statBases>
 			<WorkToBuild>600</WorkToBuild>
@@ -31,8 +29,7 @@
 
 	<TerrainDef Abstract="True" ParentName="SK_TileStoneBase" Name="MedBrickBase">
 		<renderPrecedence>220</renderPrecedence>
-		<description>Bricks laid in a circular interlocking pattern.
-	Beauty: 3.</description>
+		<description>Bricks laid in a circular interlocking pattern.</description>
 		<texturePath>Terrain/Surfaces/MedStone</texturePath>
 		<statBases>
 			<WorkToBuild>600</WorkToBuild>
@@ -45,8 +42,7 @@
 	<TerrainDef Abstract="True" ParentName="SK_TileStoneBase" Name="CobblestoneBase">
 		<renderPrecedence>223</renderPrecedence>
 		<constructEffect>ConstructDirt</constructEffect>
-		<description>Simple cobblestone flooring constructed only using small rocks found nearby.
-	Beauty: 1.</description>
+		<description>Simple cobblestone flooring constructed only using small rocks found nearby.</description>
 		<texturePath>Terrain/Surfaces/CobblestoneFloor</texturePath>
 		<statBases>
 			<WorkToBuild>800</WorkToBuild>
@@ -58,8 +54,7 @@
 
 	<TerrainDef Abstract="True" ParentName="SK_TileStoneBase" Name="BrickUnevenBase">
 		<renderPrecedence>224</renderPrecedence>
-		<description>Bricks of various sizes laid on the floor. Perfect for that rustic look.
-	Beauty: 2.</description>
+		<description>Bricks of various sizes laid on the floor. Perfect for that rustic look.</description>
 		<texturePath>Terrain/Surfaces/BrickUneven</texturePath>
 		<pathCost>1</pathCost>
 		<statBases>
@@ -72,8 +67,7 @@
 
 	<TerrainDef Abstract="True" ParentName="SK_TileStoneBase" Name="StoneTileBase">
 		<renderPrecedence>225</renderPrecedence>
-		<description>Smoothed and polished stone tiles. Time-consuming to make, but easy to keep clean.
-	Beauty: 2.</description>
+		<description>Smoothed and polished stone tiles. Time-consuming to make, but easy to keep clean.</description>
 		<texturePath>Terrain/Surfaces/TileFloor</texturePath>
 		<statBases>
 			<WorkToBuild>600</WorkToBuild>
@@ -86,8 +80,7 @@
 
 	<TerrainDef Abstract="True" ParentName="SK_TileStoneBase" Name="BrickHerringboneBase">
 		<renderPrecedence>226</renderPrecedence>
-		<description>Bricks laid in an interlocking pattern.
-	Beauty: 3.</description>
+		<description>Bricks laid in an interlocking pattern.</description>
 		<texturePath>Terrain/Surfaces/BrickHerringbone</texturePath>
 		<statBases>
 			<WorkToBuild>500</WorkToBuild>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorCarpet.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorCarpet.xml
@@ -38,8 +38,7 @@
 		<defName>CarpetBeige</defName>
 		<label>beige carpet</label>
 		<renderPrecedence>197</renderPrecedence>
-		<description>Stunning beige carpet that is soft and relaxing. 
-Beauty: 3.</description>
+		<description>Stunning beige carpet that is soft and relaxing. </description>
 		<texturePath>Terrain/Surfaces/CarpetBeige</texturePath>
 	</TerrainDef>	
 <!--
@@ -47,8 +46,7 @@ Beauty: 3.</description>
 		<defName>CarpetRed</defName>
 		<label>red carpet</label>
 		<renderPrecedence>200</renderPrecedence>
-		<description>Plush carpet in a lovely rose hue. 
-Beauty: 3.</description>
+		<description>Plush carpet in a lovely rose hue. </description>
 		<color>(118,49,57)</color>
 	</TerrainDef>
 
@@ -56,8 +54,7 @@ Beauty: 3.</description>
 		<defName>CarpetGreen</defName>
 		<label>green carpet</label>
 		<renderPrecedence>199</renderPrecedence>
-		<description>Naturalistic-feeling green carpet. 
-Beauty: 3.</description>
+		<description>Naturalistic-feeling green carpet. </description>
 		<color>(89,105,62)</color>
 	</TerrainDef>
 
@@ -65,8 +62,7 @@ Beauty: 3.</description>
 		<defName>CarpetBlue</defName>
 		<label>blue carpet</label>
 		<renderPrecedence>198</renderPrecedence>
-		<description>Toe-hugging plush carpet in a cool blue color. 
-Beauty: 3.</description>
+		<description>Toe-hugging plush carpet in a cool blue color. </description>
 		<color>(24,65,121)</color>
 	</TerrainDef>
 
@@ -74,8 +70,7 @@ Beauty: 3.</description>
 		<defName>CarpetCream</defName>
 		<label>cream carpet</label>
 		<renderPrecedence>197</renderPrecedence>
-		<description>Inviting cream-colored carpet. 
-Beauty: 3.</description>
+		<description>Inviting cream-colored carpet. </description>
 		<color>(195,192,176)</color>
 	</TerrainDef>
 -->
@@ -83,8 +78,7 @@ Beauty: 3.</description>
 		<defName>CarpetDark</defName>
 		<label>dark carpet</label>
 		<renderPrecedence>196</renderPrecedence>
-		<description>Professional-looking dark gray carpet. 
-Beauty: 3.</description>
+		<description>Professional-looking dark gray carpet. </description>
 		<color>(81,81,81)</color>
 	</TerrainDef>
 
@@ -102,8 +96,7 @@ Beauty: 3.</description>
 		<defName>CarpetOrange</defName>
 		<label>orange carpet</label>
 		<renderPrecedence>199</renderPrecedence>
-		<description>Soft carpet with a vivid marigold tint. 
-Beauty: 3.</description>
+		<description>Soft carpet with a vivid marigold tint. </description>
 		<color>(160,95,60)</color>
 	</TerrainDef>
 -->
@@ -111,8 +104,7 @@ Beauty: 3.</description>
 		<defName>CarpetYellow</defName>
 		<label>yellow carpet</label>
 		<renderPrecedence>198</renderPrecedence>
-		<description>A summer yellow-coloured carpet. 
-Beauty: 3.</description>
+		<description>A summer yellow-coloured carpet. </description>
 		<color>(160,150,60)</color>
 	</TerrainDef>
 
@@ -120,8 +112,7 @@ Beauty: 3.</description>
 		<defName>CarpetTurquoise</defName>
 		<label>turquoise carpet</label>
 		<renderPrecedence>197</renderPrecedence>
-		<description>A soothing blue-green carpet. 
-Beauty: 3.</description>
+		<description>A soothing blue-green carpet. </description>
 		<color>(60,158,160)</color>
 	</TerrainDef>
 <!--
@@ -129,8 +120,7 @@ Beauty: 3.</description>
 		<defName>CarpetPurple</defName>
 		<label>purple carpet</label>
 		<renderPrecedence>196</renderPrecedence>
-		<description>Carpet in a majestic purple shade. 
-Beauty: 3.</description>
+		<description>Carpet in a majestic purple shade. </description>
 		<color>(111,60,160)</color>
 	</TerrainDef>
 
@@ -138,16 +128,14 @@ Beauty: 3.</description>
 		<defName>CarpetWhite</defName>
 		<label>white carpet</label>
 		<renderPrecedence>195</renderPrecedence>
-		<description>Undyed white carpet. Comfortable underfoot but stains easily. 
-Beauty: 3.</description>
+		<description>Undyed white carpet. Comfortable underfoot but stains easily. </description>
 	</TerrainDef>
 
 	<TerrainDef ParentName="ColoredCarpet">
 		<defName>CarpetBlack</defName>
 		<label>black Carpet</label>
 		<renderPrecedence>194</renderPrecedence>
-		<description>A carpet in brooding black. 
-Beauty: 3.</description>
+		<description>A carpet in brooding black. </description>
 		<color>(48,48,48)</color>
 	</TerrainDef>
 -->
@@ -165,8 +153,7 @@ Beauty: 3.</description>
 		<defName>CheckCarpetRed</defName>
 		<label>red checkered carpet</label>
 		<renderPrecedence>190</renderPrecedence>
-		<description>Checker board pattern carpet in a lovely rose hue. 
-Beauty: 3.</description>
+		<description>Checker board pattern carpet in a lovely rose hue. </description>
 		<color>(162,63,73)</color>
 	</TerrainDef>
 
@@ -174,8 +161,7 @@ Beauty: 3.</description>
 		<defName>CheckCarpetOrange</defName>
 		<label>orange checkered carpet</label>
 		<renderPrecedence>189</renderPrecedence>
-		<description>Carpeting with a checker board pattern in a vivid marigold tint. 
-Beauty: 3.</description>
+		<description>Carpeting with a checker board pattern in a vivid marigold tint. </description>
 		<color>(160,95,60)</color>
 	</TerrainDef>
 
@@ -183,8 +169,7 @@ Beauty: 3.</description>
 		<defName>CheckCarpetYellow</defName>
 		<label>yellow checkered carpet</label>
 		<renderPrecedence>188</renderPrecedence>
-		<description>Summer yellow-colored checker board pattern carpet.
-Beauty: 3.</description>
+		<description>Summer yellow-colored checker board pattern carpet.</description>
 		<color>(160,150,60)</color>
 	</TerrainDef>
 
@@ -192,8 +177,7 @@ Beauty: 3.</description>
 		<defName>CheckCarpetGreen</defName>
 		<label>green checkered carpet</label>
 		<renderPrecedence>187</renderPrecedence>
-		<description>Naturalistic-feeling green checker board pattern carpet. 
-Beauty: 3.</description>
+		<description>Naturalistic-feeling green checker board pattern carpet. </description>
 		<color>(130,150,84)</color>
 	</TerrainDef>
 
@@ -201,8 +185,7 @@ Beauty: 3.</description>
 		<defName>CheckCarpetTurquoise</defName>
 		<label>turquoise checkered carpet</label>
 		<renderPrecedence>186</renderPrecedence>
-		<description>A soothing blue-green checker board pattern carpet. 
-Beauty: 3.</description>
+		<description>A soothing blue-green checker board pattern carpet. </description>
 		<color>(60,158,160)</color>
 	</TerrainDef>
 
@@ -210,8 +193,7 @@ Beauty: 3.</description>
 		<defName>CheckCarpetBlue</defName>
 		<label>blue checkered carpet</label>
 		<renderPrecedence>185</renderPrecedence>
-		<description>Toe-hugging plush checker board pattern carpet in a cool blue color. 
-Beauty: 3.</description>
+		<description>Toe-hugging plush checker board pattern carpet in a cool blue color. </description>
 		<color>(33,88,170)</color>
 	</TerrainDef>
 
@@ -219,8 +201,7 @@ Beauty: 3.</description>
 		<defName>CheckCarpetPurple</defName>
 		<label>purple checkered carpet</label>
 		<renderPrecedence>184</renderPrecedence>
-		<description>Checker board pattern carpet in a majestic purple shade. 
-Beauty: 3.</description>
+		<description>Checker board pattern carpet in a majestic purple shade. </description>
 		<color>(111,60,160)</color>
 	</TerrainDef>
 
@@ -228,16 +209,14 @@ Beauty: 3.</description>
 		<defName>CheckCarpetWhite</defName>
 		<label>white checkered carpet</label>
 		<renderPrecedence>183</renderPrecedence>
-		<description>Undyed white checker board pattern carpet. Comfortable underfoot but stains easily. 
-Beauty: 3.</description>
+		<description>Undyed white checker board pattern carpet. Comfortable underfoot but stains easily. </description>
 	</TerrainDef>
 
 	<TerrainDef ParentName="CheckCarpet">
 		<defName>CheckCarpetBlack</defName>
 		<label>black checkered carpet</label>
 		<renderPrecedence>182</renderPrecedence>
-		<description>A checker board pattern carpet in brooding black. 
-Beauty: 3.</description>
+		<description>A checker board pattern carpet in brooding black. </description>
 		<color>(48,48,48)</color>
 	</TerrainDef>
 <!--

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorCarpet.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorCarpet.xml
@@ -38,7 +38,7 @@
 		<defName>CarpetBeige</defName>
 		<label>beige carpet</label>
 		<renderPrecedence>197</renderPrecedence>
-		<description>Stunning beige carpet that is soft and relaxing. </description>
+		<description>Stunning beige carpet that is soft and relaxing.</description>
 		<texturePath>Terrain/Surfaces/CarpetBeige</texturePath>
 	</TerrainDef>	
 <!--
@@ -46,7 +46,7 @@
 		<defName>CarpetRed</defName>
 		<label>red carpet</label>
 		<renderPrecedence>200</renderPrecedence>
-		<description>Plush carpet in a lovely rose hue. </description>
+		<description>Plush carpet in a lovely rose hue.</description>
 		<color>(118,49,57)</color>
 	</TerrainDef>
 
@@ -54,7 +54,7 @@
 		<defName>CarpetGreen</defName>
 		<label>green carpet</label>
 		<renderPrecedence>199</renderPrecedence>
-		<description>Naturalistic-feeling green carpet. </description>
+		<description>Naturalistic-feeling green carpet.</description>
 		<color>(89,105,62)</color>
 	</TerrainDef>
 
@@ -62,7 +62,7 @@
 		<defName>CarpetBlue</defName>
 		<label>blue carpet</label>
 		<renderPrecedence>198</renderPrecedence>
-		<description>Toe-hugging plush carpet in a cool blue color. </description>
+		<description>Toe-hugging plush carpet in a cool blue color.</description>
 		<color>(24,65,121)</color>
 	</TerrainDef>
 
@@ -70,7 +70,7 @@
 		<defName>CarpetCream</defName>
 		<label>cream carpet</label>
 		<renderPrecedence>197</renderPrecedence>
-		<description>Inviting cream-colored carpet. </description>
+		<description>Inviting cream-colored carpet.</description>
 		<color>(195,192,176)</color>
 	</TerrainDef>
 -->
@@ -78,7 +78,7 @@
 		<defName>CarpetDark</defName>
 		<label>dark carpet</label>
 		<renderPrecedence>196</renderPrecedence>
-		<description>Professional-looking dark gray carpet. </description>
+		<description>Professional-looking dark gray carpet.</description>
 		<color>(81,81,81)</color>
 	</TerrainDef>
 
@@ -96,7 +96,7 @@
 		<defName>CarpetOrange</defName>
 		<label>orange carpet</label>
 		<renderPrecedence>199</renderPrecedence>
-		<description>Soft carpet with a vivid marigold tint. </description>
+		<description>Soft carpet with a vivid marigold tint.</description>
 		<color>(160,95,60)</color>
 	</TerrainDef>
 -->
@@ -104,7 +104,7 @@
 		<defName>CarpetYellow</defName>
 		<label>yellow carpet</label>
 		<renderPrecedence>198</renderPrecedence>
-		<description>A summer yellow-coloured carpet. </description>
+		<description>A summer yellow-coloured carpet.</description>
 		<color>(160,150,60)</color>
 	</TerrainDef>
 
@@ -112,7 +112,7 @@
 		<defName>CarpetTurquoise</defName>
 		<label>turquoise carpet</label>
 		<renderPrecedence>197</renderPrecedence>
-		<description>A soothing blue-green carpet. </description>
+		<description>A soothing blue-green carpet.</description>
 		<color>(60,158,160)</color>
 	</TerrainDef>
 <!--
@@ -120,7 +120,7 @@
 		<defName>CarpetPurple</defName>
 		<label>purple carpet</label>
 		<renderPrecedence>196</renderPrecedence>
-		<description>Carpet in a majestic purple shade. </description>
+		<description>Carpet in a majestic purple shade.</description>
 		<color>(111,60,160)</color>
 	</TerrainDef>
 
@@ -128,14 +128,14 @@
 		<defName>CarpetWhite</defName>
 		<label>white carpet</label>
 		<renderPrecedence>195</renderPrecedence>
-		<description>Undyed white carpet. Comfortable underfoot but stains easily. </description>
+		<description>Undyed white carpet. Comfortable underfoot but stains easily.</description>
 	</TerrainDef>
 
 	<TerrainDef ParentName="ColoredCarpet">
 		<defName>CarpetBlack</defName>
 		<label>black Carpet</label>
 		<renderPrecedence>194</renderPrecedence>
-		<description>A carpet in brooding black. </description>
+		<description>A carpet in brooding black.</description>
 		<color>(48,48,48)</color>
 	</TerrainDef>
 -->
@@ -153,7 +153,7 @@
 		<defName>CheckCarpetRed</defName>
 		<label>red checkered carpet</label>
 		<renderPrecedence>190</renderPrecedence>
-		<description>Checker board pattern carpet in a lovely rose hue. </description>
+		<description>Checker board pattern carpet in a lovely rose hue.</description>
 		<color>(162,63,73)</color>
 	</TerrainDef>
 
@@ -161,7 +161,7 @@
 		<defName>CheckCarpetOrange</defName>
 		<label>orange checkered carpet</label>
 		<renderPrecedence>189</renderPrecedence>
-		<description>Carpeting with a checker board pattern in a vivid marigold tint. </description>
+		<description>Carpeting with a checker board pattern in a vivid marigold tint.</description>
 		<color>(160,95,60)</color>
 	</TerrainDef>
 
@@ -177,7 +177,7 @@
 		<defName>CheckCarpetGreen</defName>
 		<label>green checkered carpet</label>
 		<renderPrecedence>187</renderPrecedence>
-		<description>Naturalistic-feeling green checker board pattern carpet. </description>
+		<description>Naturalistic-feeling green checker board pattern carpet.</description>
 		<color>(130,150,84)</color>
 	</TerrainDef>
 
@@ -185,7 +185,7 @@
 		<defName>CheckCarpetTurquoise</defName>
 		<label>turquoise checkered carpet</label>
 		<renderPrecedence>186</renderPrecedence>
-		<description>A soothing blue-green checker board pattern carpet. </description>
+		<description>A soothing blue-green checker board pattern carpet.</description>
 		<color>(60,158,160)</color>
 	</TerrainDef>
 
@@ -193,7 +193,7 @@
 		<defName>CheckCarpetBlue</defName>
 		<label>blue checkered carpet</label>
 		<renderPrecedence>185</renderPrecedence>
-		<description>Toe-hugging plush checker board pattern carpet in a cool blue color. </description>
+		<description>Toe-hugging plush checker board pattern carpet in a cool blue color.</description>
 		<color>(33,88,170)</color>
 	</TerrainDef>
 
@@ -201,7 +201,7 @@
 		<defName>CheckCarpetPurple</defName>
 		<label>purple checkered carpet</label>
 		<renderPrecedence>184</renderPrecedence>
-		<description>Checker board pattern carpet in a majestic purple shade. </description>
+		<description>Checker board pattern carpet in a majestic purple shade.</description>
 		<color>(111,60,160)</color>
 	</TerrainDef>
 
@@ -209,14 +209,14 @@
 		<defName>CheckCarpetWhite</defName>
 		<label>white checkered carpet</label>
 		<renderPrecedence>183</renderPrecedence>
-		<description>Undyed white checker board pattern carpet. Comfortable underfoot but stains easily. </description>
+		<description>Undyed white checker board pattern carpet. Comfortable underfoot but stains easily.</description>
 	</TerrainDef>
 
 	<TerrainDef ParentName="CheckCarpet">
 		<defName>CheckCarpetBlack</defName>
 		<label>black checkered carpet</label>
 		<renderPrecedence>182</renderPrecedence>
-		<description>A checker board pattern carpet in brooding black. </description>
+		<description>A checker board pattern carpet in brooding black.</description>
 		<color>(48,48,48)</color>
 	</TerrainDef>
 <!--

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorMetallic.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorMetallic.xml
@@ -20,7 +20,7 @@
 		<defName>SilverTile</defName>
 		<label>silver tile</label>
 		<renderPrecedence>241</renderPrecedence>
-		<description>Expensive and slow to build. Soft grey tiles with a grey bordering. </description>
+		<description>Expensive and slow to build. Soft grey tiles with a grey bordering.</description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<color>(0.71, 0.68, 0.59)</color>
 		<statBases>
@@ -44,7 +44,7 @@
 		<defName>SterileTile</defName>
 		<label>sterile tile</label>
 		<renderPrecedence>243</renderPrecedence>
-		<description>Sterile tiles are clean, light grey squares. Very useful in hospitals to help prevent infections. Quite slow to build. </description>
+		<description>Sterile tiles are clean, light grey squares. Very useful in hospitals to help prevent infections. Quite slow to build.</description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<pollutionTintColor>(0.95, 0.95, 0.93, 1)</pollutionTintColor>
 		<color>(0.71, 0.71, 0.71)</color>
@@ -67,7 +67,7 @@
 		<defName>TinTile</defName>
 		<label>white tin tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>White tin square tiles. </description>
+		<description>White tin square tiles.</description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<color>(0.86, 0.86, 0.86)</color>
 		<statBases>
@@ -86,7 +86,7 @@
 		<defName>CopperTile</defName>
 		<label>simple copper tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Simple copper square tiles. </description>
+		<description>Simple copper square tiles.</description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<color>(0.62, 0.45, 0.17)</color>
 		<statBases>
@@ -105,7 +105,7 @@
 		<defName>MetalTile</defName>
 		<label>grey metal tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Grey metal square tiles, for that spaceship look. </description>
+		<description>Grey metal square tiles, for that spaceship look.</description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<color>(0.54, 0.52, 0.53)</color>
 		<statBases>
@@ -123,7 +123,7 @@
 		<defName>MetalTileTwo</defName>
 		<label>black metal tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Black metal square tiles, for that spaceship look. </description>
+		<description>Black metal square tiles, for that spaceship look.</description>
 		<texturePath>Terrain/Surfaces/MetalTileTwo</texturePath>
 		<statBases>
 			<Beauty>4</Beauty>
@@ -140,7 +140,7 @@
 		<defName>MetalTileThree</defName>
 		<label>grey metal tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Square grey metal tiles with thin borders. </description>
+		<description>Square grey metal tiles with thin borders.</description>
 		<texturePath>Terrain/Surfaces/MetalTileThree</texturePath>
 		<statBases>
 			<Beauty>4</Beauty>
@@ -157,7 +157,7 @@
 		<defName>MetalTileFour</defName>
 		<label>patterned metal tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Grey metal tiles with fancy patterns. </description>
+		<description>Grey metal tiles with fancy patterns.</description>
 		<texturePath>Terrain/Surfaces/MetalTileFour</texturePath>
 		<statBases>
 			<Beauty>4</Beauty>
@@ -176,7 +176,7 @@
 		<defName>GoldTile</defName>
 		<label>gold tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Gold tiles, because you're worth it. </description>
+		<description>Gold tiles, because you're worth it.</description>
 		<texturePath>Terrain/Surfaces/GoldTile</texturePath>
 		<statBases>
 			<Beauty>12</Beauty>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorMetallic.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorMetallic.xml
@@ -20,8 +20,7 @@
 		<defName>SilverTile</defName>
 		<label>silver tile</label>
 		<renderPrecedence>241</renderPrecedence>
-		<description>Expensive and slow to build. Soft grey tiles with a grey bordering. 
-Beauty: 8.</description>
+		<description>Expensive and slow to build. Soft grey tiles with a grey bordering. </description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<color>(0.71, 0.68, 0.59)</color>
 		<statBases>
@@ -45,8 +44,7 @@ Beauty: 8.</description>
 		<defName>SterileTile</defName>
 		<label>sterile tile</label>
 		<renderPrecedence>243</renderPrecedence>
-		<description>Sterile tiles are clean, light grey squares. Very useful in hospitals to help prevent infections. Quite slow to build. 
-Beauty: 1.</description>
+		<description>Sterile tiles are clean, light grey squares. Very useful in hospitals to help prevent infections. Quite slow to build. </description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<pollutionTintColor>(0.95, 0.95, 0.93, 1)</pollutionTintColor>
 		<color>(0.71, 0.71, 0.71)</color>
@@ -69,8 +67,7 @@ Beauty: 1.</description>
 		<defName>TinTile</defName>
 		<label>white tin tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>White tin square tiles. 
-Beauty: 3.</description>
+		<description>White tin square tiles. </description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<color>(0.86, 0.86, 0.86)</color>
 		<statBases>
@@ -89,8 +86,7 @@ Beauty: 3.</description>
 		<defName>CopperTile</defName>
 		<label>simple copper tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Simple copper square tiles. 
-Beauty: 3.</description>
+		<description>Simple copper square tiles. </description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<color>(0.62, 0.45, 0.17)</color>
 		<statBases>
@@ -109,8 +105,7 @@ Beauty: 3.</description>
 		<defName>MetalTile</defName>
 		<label>grey metal tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Grey metal square tiles, for that spaceship look. 
-Beauty: 4.</description>
+		<description>Grey metal square tiles, for that spaceship look. </description>
 		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
 		<color>(0.54, 0.52, 0.53)</color>
 		<statBases>
@@ -128,8 +123,7 @@ Beauty: 4.</description>
 		<defName>MetalTileTwo</defName>
 		<label>black metal tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Black metal square tiles, for that spaceship look. 
-Beauty: 4.</description>
+		<description>Black metal square tiles, for that spaceship look. </description>
 		<texturePath>Terrain/Surfaces/MetalTileTwo</texturePath>
 		<statBases>
 			<Beauty>4</Beauty>
@@ -146,8 +140,7 @@ Beauty: 4.</description>
 		<defName>MetalTileThree</defName>
 		<label>grey metal tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Square grey metal tiles with thin borders. 
-Beauty: 4.</description>
+		<description>Square grey metal tiles with thin borders. </description>
 		<texturePath>Terrain/Surfaces/MetalTileThree</texturePath>
 		<statBases>
 			<Beauty>4</Beauty>
@@ -164,8 +157,7 @@ Beauty: 4.</description>
 		<defName>MetalTileFour</defName>
 		<label>patterned metal tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Grey metal tiles with fancy patterns. 
-Beauty: 4.</description>
+		<description>Grey metal tiles with fancy patterns. </description>
 		<texturePath>Terrain/Surfaces/MetalTileFour</texturePath>
 		<statBases>
 			<Beauty>4</Beauty>
@@ -184,8 +176,7 @@ Beauty: 4.</description>
 		<defName>GoldTile</defName>
 		<label>gold tile</label>
 		<renderPrecedence>240</renderPrecedence>
-		<description>Gold tiles, because you're worth it. 
-Beauty: 5.</description>
+		<description>Gold tiles, because you're worth it. </description>
 		<texturePath>Terrain/Surfaces/GoldTile</texturePath>
 		<statBases>
 			<Beauty>12</Beauty>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorStone.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorStone.xml
@@ -6,7 +6,7 @@
 		<label>sandstone slabs</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Sandstone flooring made with square slabs. </description>
+		<description>Sandstone flooring made with square slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -46,7 +46,7 @@
 		<label>limestone slabs</label>
 		<color>(158,153,135)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Limestone flooring made with square slabs. </description>
+		<description>Limestone flooring made with square slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -66,7 +66,7 @@
 		<label>slate slabs</label>
 		<color>(70,70,70)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Slate flooring made with square slabs. </description>
+		<description>Slate flooring made with square slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -86,7 +86,7 @@
 		<label>marble slabs</label>
 		<color>(151,156,151)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Marble flooring made with square slabs. </description>
+		<description>Marble flooring made with square slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -106,7 +106,7 @@
 		<label>Ceramic slabs</label>
 		<color>(255,255,255)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Ceramics flooring made with square slabs. </description>
+		<description>Ceramics flooring made with square slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -126,7 +126,7 @@
 		<label>sandstone hex paving</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Sandstone paving with hexagonal tiles. </description>
+		<description>Sandstone paving with hexagonal tiles.</description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -166,7 +166,7 @@
 		<label>limestone hex paving</label>
 		<color>(158,153,135)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Limestone paving with hexagonal tiles. </description>
+		<description>Limestone paving with hexagonal tiles.</description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -186,7 +186,7 @@
 		<label>slate hex paving</label>
 		<color>(70,70,70)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Slate paving with hexagonal tiles. </description>
+		<description>Slate paving with hexagonal tiles.</description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -206,7 +206,7 @@
 		<label>marble hex paving</label>
 		<color>(151,156,151)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Marble paving with hexagonal tiles. </description>
+		<description>Marble paving with hexagonal tiles.</description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -226,7 +226,7 @@
 		<label>Ceramic hex paving</label>
 		<color>(255,255,255)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Ceramics paving with hexagonal tiles. </description>
+		<description>Ceramics paving with hexagonal tiles.</description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -248,7 +248,7 @@
 		<label>sandstone mosaic paving</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Sandstone paving with a light/dark mosaic. </description>
+		<description>Sandstone paving with a light/dark mosaic.</description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -268,7 +268,7 @@
 		<label>granite mosaic paving</label>
 		<color>(105,95,97)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Granite paving with a light/dark mosaic. </description>
+		<description>Granite paving with a light/dark mosaic.</description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -288,7 +288,7 @@
 		<label>limestone mosaic paving</label>
 		<color>(158,153,135)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Limestone paving with a light/dark mosaic. </description>
+		<description>Limestone paving with a light/dark mosaic.</description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -308,7 +308,7 @@
 		<label>slate mosaic paving</label>
 		<color>(70,70,70)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Slate paving with a light/dark mosaic. </description>
+		<description>Slate paving with a light/dark mosaic.</description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -328,7 +328,7 @@
 		<label>marble mosaic paving</label>
 		<color>(151,156,151)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Marble paving with a light/dark mosaic. </description>
+		<description>Marble paving with a light/dark mosaic.</description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -348,7 +348,7 @@
 		<label>Clay brick mosaic paving</label>
 		<color>(153,87,61)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Clay brick paving with a light/dark mosaic. </description>
+		<description>Clay brick paving with a light/dark mosaic.</description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -368,7 +368,7 @@
 		<label>Ceramics mosaic paving</label>
 		<color>(255,255,255)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Ceramic paving with a light/dark mosaic. </description>
+		<description>Ceramic paving with a light/dark mosaic.</description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -390,7 +390,7 @@
 		<label>rough sandstone paving</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>267</renderPrecedence>
-		<description>Sandstone stone paving. </description>
+		<description>Sandstone stone paving.</description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B2</li>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorStone.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorStone.xml
@@ -6,8 +6,7 @@
 		<label>sandstone slabs</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Sandstone flooring made with square slabs. 
-Beauty: 4.</description>
+		<description>Sandstone flooring made with square slabs. </description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -27,8 +26,7 @@ Beauty: 4.</description>
 		<label>granite slabs</label>
 		<color>(105,95,97)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Granite flooring made with square slabs.
-Beauty: 4.</description>
+		<description>Granite flooring made with square slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -48,8 +46,7 @@ Beauty: 4.</description>
 		<label>limestone slabs</label>
 		<color>(158,153,135)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Limestone flooring made with square slabs. 
-Beauty: 4.</description>
+		<description>Limestone flooring made with square slabs. </description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -69,8 +66,7 @@ Beauty: 4.</description>
 		<label>slate slabs</label>
 		<color>(70,70,70)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Slate flooring made with square slabs. 
-Beauty: 5.</description>
+		<description>Slate flooring made with square slabs. </description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -90,8 +86,7 @@ Beauty: 5.</description>
 		<label>marble slabs</label>
 		<color>(151,156,151)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Marble flooring made with square slabs. 
-Beauty: 5.</description>
+		<description>Marble flooring made with square slabs. </description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -111,8 +106,7 @@ Beauty: 5.</description>
 		<label>Ceramic slabs</label>
 		<color>(255,255,255)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Ceramics flooring made with square slabs. 
-Beauty: 5.</description>
+		<description>Ceramics flooring made with square slabs. </description>
 		<texturePath>Terrain/Surfaces/StoneSlabs</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -132,8 +126,7 @@ Beauty: 5.</description>
 		<label>sandstone hex paving</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Sandstone paving with hexagonal tiles. 
-Beauty: 4.</description>
+		<description>Sandstone paving with hexagonal tiles. </description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -153,8 +146,7 @@ Beauty: 4.</description>
 		<label>granite hex paving</label>
 		<color>(105,95,97)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Granite paving with hexagonal tiles.
-Beauty: 4.</description>
+		<description>Granite paving with hexagonal tiles.</description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -174,8 +166,7 @@ Beauty: 4.</description>
 		<label>limestone hex paving</label>
 		<color>(158,153,135)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Limestone paving with hexagonal tiles. 
-Beauty: 4.</description>
+		<description>Limestone paving with hexagonal tiles. </description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -195,8 +186,7 @@ Beauty: 4.</description>
 		<label>slate hex paving</label>
 		<color>(70,70,70)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Slate paving with hexagonal tiles. 
-Beauty: 5.</description>
+		<description>Slate paving with hexagonal tiles. </description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -216,8 +206,7 @@ Beauty: 5.</description>
 		<label>marble hex paving</label>
 		<color>(151,156,151)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Marble paving with hexagonal tiles. 
-Beauty: 5.</description>
+		<description>Marble paving with hexagonal tiles. </description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -237,8 +226,7 @@ Beauty: 5.</description>
 		<label>Ceramic hex paving</label>
 		<color>(255,255,255)</color>
 		<renderPrecedence>269</renderPrecedence>
-		<description>Ceramics paving with hexagonal tiles. 
-Beauty: 5.</description>
+		<description>Ceramics paving with hexagonal tiles. </description>
 		<texturePath>Terrain/Surfaces/StoneHex</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -260,8 +248,7 @@ Beauty: 5.</description>
 		<label>sandstone mosaic paving</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Sandstone paving with a light/dark mosaic. 
-Beauty: 4.</description>
+		<description>Sandstone paving with a light/dark mosaic. </description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -281,8 +268,7 @@ Beauty: 4.</description>
 		<label>granite mosaic paving</label>
 		<color>(105,95,97)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Granite paving with a light/dark mosaic. 
-Beauty: 4.</description>
+		<description>Granite paving with a light/dark mosaic. </description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -302,8 +288,7 @@ Beauty: 4.</description>
 		<label>limestone mosaic paving</label>
 		<color>(158,153,135)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Limestone paving with a light/dark mosaic. 
-Beauty: 4.</description>
+		<description>Limestone paving with a light/dark mosaic. </description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -323,8 +308,7 @@ Beauty: 4.</description>
 		<label>slate mosaic paving</label>
 		<color>(70,70,70)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Slate paving with a light/dark mosaic. 
-Beauty: 5.</description>
+		<description>Slate paving with a light/dark mosaic. </description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -344,8 +328,7 @@ Beauty: 5.</description>
 		<label>marble mosaic paving</label>
 		<color>(151,156,151)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Marble paving with a light/dark mosaic. 
-Beauty: 5.</description>
+		<description>Marble paving with a light/dark mosaic. </description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -365,8 +348,7 @@ Beauty: 5.</description>
 		<label>Clay brick mosaic paving</label>
 		<color>(153,87,61)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Clay brick paving with a light/dark mosaic. 
-Beauty: 5.</description>
+		<description>Clay brick paving with a light/dark mosaic. </description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -386,8 +368,7 @@ Beauty: 5.</description>
 		<label>Ceramics mosaic paving</label>
 		<color>(255,255,255)</color>
 		<renderPrecedence>268</renderPrecedence>
-		<description>Ceramic paving with a light/dark mosaic. 
-Beauty: 5.</description>
+		<description>Ceramic paving with a light/dark mosaic. </description>
 		<texturePath>Terrain/Surfaces/StoneMosaic</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -409,8 +390,7 @@ Beauty: 5.</description>
 		<label>rough sandstone paving</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>267</renderPrecedence>
-		<description>Sandstone stone paving. 
-Beauty: 2.</description>
+		<description>Sandstone stone paving. </description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B2</li>
@@ -430,8 +410,7 @@ Beauty: 2.</description>
 		<label>rough granite paving</label>
 		<color>(105,95,97)</color>
 		<renderPrecedence>267</renderPrecedence>
-		<description>Rough stone paving.
-Beauty: 2.</description>
+		<description>Rough stone paving.</description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B2</li>
@@ -451,8 +430,7 @@ Beauty: 2.</description>
 		<label>rough limestone paving</label>
 		<color>(158,153,135)</color>
 		<renderPrecedence>267</renderPrecedence>
-		<description>Rough stone paving.
-Beauty: 2.</description>
+		<description>Rough stone paving.</description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B2</li>
@@ -472,8 +450,7 @@ Beauty: 2.</description>
 		<label>rough slate paving</label>
 		<color>(70,70,70)</color>
 		<renderPrecedence>267</renderPrecedence>
-		<description>Rough stone paving.
-Beauty: 2.</description>
+		<description>Rough stone paving.</description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B2</li>
@@ -493,8 +470,7 @@ Beauty: 2.</description>
 		<label>rough marble paving</label>
 		<color>(151,156,151)</color>
 		<renderPrecedence>267</renderPrecedence>
-		<description>Rough stone paving.
-Beauty: 2.</description>
+		<description>Rough stone paving.</description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B2</li>
@@ -514,8 +490,7 @@ Beauty: 2.</description>
 		<label>rough Ceramic paving</label>
 		<color>(255,255,255)</color>
 		<renderPrecedence>267</renderPrecedence>
-		<description>Rough stone paving.
-Beauty: 2.</description>
+		<description>Rough stone paving.</description>
 		<texturePath>Terrain/Surfaces/StoneRough</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B2</li>
@@ -537,8 +512,7 @@ Beauty: 2.</description>
 		<label>random sandstone paving</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>266</renderPrecedence>
-		<description>Stone paving with random square and rectangular slabs.
-Beauty: 4.</description>
+		<description>Stone paving with random square and rectangular slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -558,8 +532,7 @@ Beauty: 4.</description>
 		<label>random granite paving</label>
 		<color>(105,95,97)</color>
 		<renderPrecedence>266</renderPrecedence>
-		<description>Stone paving with random square and rectangular slabs.
-Beauty: 4.</description>
+		<description>Stone paving with random square and rectangular slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -579,8 +552,7 @@ Beauty: 4.</description>
 		<label>random limestone paving</label>
 		<color>(158,153,135)</color>
 		<renderPrecedence>266</renderPrecedence>
-		<description>Stone paving with random square and rectangular slabs.
-Beauty: 4.</description>
+		<description>Stone paving with random square and rectangular slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -600,8 +572,7 @@ Beauty: 4.</description>
 		<label>random slate paving</label>
 		<color>(70,70,70)</color>
 		<renderPrecedence>266</renderPrecedence>
-		<description>Stone paving with random square and rectangular slabs.
-Beauty: 5.</description>
+		<description>Stone paving with random square and rectangular slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -621,8 +592,7 @@ Beauty: 5.</description>
 		<label>random marble paving</label>
 		<color>(151,156,151)</color>
 		<renderPrecedence>266</renderPrecedence>
-		<description>Stone paving with random square and rectangular slabs.
-Beauty: 5.</description>
+		<description>Stone paving with random square and rectangular slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -642,8 +612,7 @@ Beauty: 5.</description>
 		<label>random clay brick paving</label>
 		<color>(153,87,61)</color>
 		<renderPrecedence>266</renderPrecedence>
-		<description>Stone paving with random square and rectangular slabs.
-Beauty: 5.</description>
+		<description>Stone paving with random square and rectangular slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -663,8 +632,7 @@ Beauty: 5.</description>
 		<label>random Ceramic paving</label>
 		<color>(255,255,255)</color>
 		<renderPrecedence>266</renderPrecedence>
-		<description>Stone paving with random square and rectangular slabs.
-Beauty: 5.</description>
+		<description>Stone paving with random square and rectangular slabs.</description>
 		<texturePath>Terrain/Surfaces/StoneRandom</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -684,8 +652,7 @@ Beauty: 5.</description>
 		<label>sandstone staggered tiles</label>
 		<color>(126,104,94)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Sandstone tiles with rounded corners laid in a staggered pattern.
-Beauty: 5.</description>
+		<description>Sandstone tiles with rounded corners laid in a staggered pattern.</description>
 		<texturePath>Terrain/Surfaces/StoneStaggered</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -705,8 +672,7 @@ Beauty: 5.</description>
 		<label>granite slabs</label>
 		<color>(105,95,97)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Granite tiles with rounded corners laid in a staggered pattern.
-Beauty: 5.</description>
+		<description>Granite tiles with rounded corners laid in a staggered pattern.</description>
 		<texturePath>Terrain/Surfaces/StoneStaggered</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -726,8 +692,7 @@ Beauty: 5.</description>
 		<label>limestone slabs</label>
 		<color>(158,153,135)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Limestone tiles with rounded corners laid in a staggered pattern.
-Beauty: 5.</description>
+		<description>Limestone tiles with rounded corners laid in a staggered pattern.</description>
 		<texturePath>Terrain/Surfaces/StoneStaggered</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -747,8 +712,7 @@ Beauty: 5.</description>
 		<label>slate slabs</label>
 		<color>(70,70,70)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Slate tiles with rounded corners laid in a staggered pattern.
-Beauty: 5.</description>
+		<description>Slate tiles with rounded corners laid in a staggered pattern.</description>
 		<texturePath>Terrain/Surfaces/StoneStaggered</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -768,8 +732,7 @@ Beauty: 5.</description>
 		<label>marble slabs</label>
 		<color>(151,156,151)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Marble tiles with rounded corners laid in a staggered pattern.
-Beauty: 5.</description>
+		<description>Marble tiles with rounded corners laid in a staggered pattern.</description>
 		<texturePath>Terrain/Surfaces/StoneStaggered</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -789,8 +752,7 @@ Beauty: 5.</description>
 		<label>Ceramic slabs</label>
 		<color>(255,255,255)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Ceramics tiles with rounded corners laid in a staggered pattern.
-Beauty: 5.</description>
+		<description>Ceramics tiles with rounded corners laid in a staggered pattern.</description>
 		<texturePath>Terrain/Surfaces/StoneStaggered</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>
@@ -810,8 +772,7 @@ Beauty: 5.</description>
 		<label>Clay brick slabs</label>
 		<color>(153,87,61)</color>
 		<renderPrecedence>270</renderPrecedence>
-		<description>Clay brick tiles with rounded corners laid in a staggered pattern.
-Beauty: 5.</description>
+		<description>Clay brick tiles with rounded corners laid in a staggered pattern.</description>
 		<texturePath>Terrain/Surfaces/StoneStaggered</texturePath>
 		<researchPrerequisites>
 			<li>Stone_floor_B4</li>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
@@ -149,7 +149,7 @@
 		<defName>ParquetFloor</defName>
 		<label>parquet</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>Herringbone flooring. Regal elegance for the sophisticated colonist. Takes some time to build. </description>
+		<description>Herringbone flooring. Regal elegance for the sophisticated colonist. Takes some time to build.</description>
 		<texturePath>Terrain/Surfaces/Parquet</texturePath>
 		<statBases>
 			<Beauty>3</Beauty>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorWood.xml
@@ -27,8 +27,7 @@
 		<defName>ClutterWoodTileA</defName>
 		<label>dark wood tiles</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Dark wood panels with a dark border around each tile.
-Beauty: 3.</description>
+		<description>Dark wood panels with a dark border around each tile.</description>
 		<texturePath>Terrain/Surfaces/FloorA</texturePath>
 		<uiIconPath>Terrain/Surfaces/FloorAI</uiIconPath>
 		<statBases>
@@ -46,8 +45,7 @@ Beauty: 3.</description>
 		<defName>WoodPlankFloor</defName>
 		<label>oak planks</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>Unfinished oak. Long horizontal planks with a light coloring.
-Beauty: 2.</description>
+		<description>Unfinished oak. Long horizontal planks with a light coloring.</description>
 		<texturePath>Terrain/Surfaces/WoodFloor2</texturePath>
 		<statBases>
 			<Beauty>2</Beauty>
@@ -65,8 +63,7 @@ Beauty: 2.</description>
 		<defName>WoodPlankFloorTwo</defName>
 		<label>brown wood floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>Thin vertical brown planks. For that warm homey feeling.
-Beauty: 2.</description>
+		<description>Thin vertical brown planks. For that warm homey feeling.</description>
 		<texturePath>Terrain/Surfaces/WoodFloor</texturePath>
 		<statBases>
 			<Beauty>2</Beauty>
@@ -83,8 +80,7 @@ Beauty: 2.</description>
 		<defName>WoodPlankFloorThree</defName>
 		<label>light wood planks</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>Staggered joint, light colored wood flooring in short, horizontal planks.
-Beauty: 2.</description>
+		<description>Staggered joint, light colored wood flooring in short, horizontal planks.</description>
 		<texturePath>Terrain/Surfaces/WoodFloor3</texturePath>
 		<statBases>
 			<Beauty>2</Beauty>
@@ -101,8 +97,7 @@ Beauty: 2.</description>
 		<defName>WoodPlankFloorFour</defName>
 		<label>styled wood floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>Three small planks per tile that alternate from horizontal to vertical every other tile. Reddish brown in color.
-Beauty: 3.</description>
+		<description>Three small planks per tile that alternate from horizontal to vertical every other tile. Reddish brown in color.</description>
 		<texturePath>Terrain/Surfaces/WoodFloor4</texturePath>
 		<statBases>
 			<Beauty>3</Beauty>
@@ -120,8 +115,7 @@ Beauty: 3.</description>
 		<defName>WoodPlankFloorFive</defName>
 		<label>brown wood planks</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>Vertical medium sized planks with staggered joints. Brown in color.
-Beauty: 4.</description>
+		<description>Vertical medium sized planks with staggered joints. Brown in color.</description>
 		<texturePath>Terrain/Surfaces/WoodFloor5</texturePath>
 		<statBases>
 			<Beauty>4</Beauty>
@@ -138,8 +132,7 @@ Beauty: 4.</description>
 		<defName>WoodPlankFloorSix</defName>
 		<label>tan wood planks</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>Medium sized planks in a horizontal pattern with a tanned wood look.
-Beauty: 4.</description>
+		<description>Medium sized planks in a horizontal pattern with a tanned wood look.</description>
 		<texturePath>Terrain/Surfaces/WoodFloor1</texturePath>
 		<statBases>
 			<Beauty>4</Beauty>
@@ -156,8 +149,7 @@ Beauty: 4.</description>
 		<defName>ParquetFloor</defName>
 		<label>parquet</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>Herringbone flooring. Regal elegance for the sophisticated colonist. Takes some time to build. 
-Beauty: 3.</description>
+		<description>Herringbone flooring. Regal elegance for the sophisticated colonist. Takes some time to build. </description>
 		<texturePath>Terrain/Surfaces/Parquet</texturePath>
 		<statBases>
 			<Beauty>3</Beauty>
@@ -174,8 +166,7 @@ Beauty: 3.</description>
 		<defName>BambooFloor</defName>
 		<label>Bamboo panels</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Bamboo panels.
-Beauty: 3.</description>
+		<description>Bamboo panels.</description>
 		<texturePath>Terrain/Surfaces/bamboo_floor_a</texturePath>
 		<uiIconPath>Terrain/Surfaces/bamboo_floor_ai</uiIconPath>
 		<statBases>
@@ -193,8 +184,7 @@ Beauty: 3.</description>
 		<defName>BambooFloorB</defName>
 		<label>Bamboo Floor</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Woven bamboo flooring.
-Beauty: 3.</description>
+		<description>Woven bamboo flooring.</description>
 		<texturePath>Terrain/Surfaces/bamboo_floor_a2</texturePath>
 		<uiIconPath>Terrain/Surfaces/bamboo_floor_a2i</uiIconPath>
 		<statBases>
@@ -212,8 +202,7 @@ Beauty: 3.</description>
 		<defName>BambooFloorC</defName>
 		<label>Polished bamboo </label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Flooring made of polished bamboo planks.
-Beauty: 4.</description>
+		<description>Flooring made of polished bamboo planks.</description>
 		<texturePath>Terrain/Surfaces/bamboo_floor_b2</texturePath>
 		<uiIconPath>Terrain/Surfaces/bamboo_floor_b2i</uiIconPath>
 		<statBases>
@@ -230,8 +219,7 @@ Beauty: 4.</description>
 		<defName>BambooFloorD</defName>
 		<label>Bamboo parquet</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Bamboo planks neatly framed in the pattern.
-Beauty: 4.</description>
+		<description>Bamboo planks neatly framed in the pattern.</description>
 		<texturePath>Terrain/Surfaces/bamboo_floor_a3</texturePath>
 		<uiIconPath>Terrain/Surfaces/Bamboo_floor_a3i</uiIconPath>
 		<statBases>
@@ -249,8 +237,7 @@ Beauty: 4.</description>
 		<defName>BambooFloorE</defName>
 		<label>Hexagonal parquet</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Parquet made of hexagonal tiles.
-Beauty: 5.</description>
+		<description>Parquet made of hexagonal tiles.</description>
 		<texturePath>Terrain/Surfaces/Bamboo_floor_b</texturePath>
 		<uiIconPath>Terrain/Surfaces/Bamboo_floor_bi</uiIconPath>
 		<statBases>
@@ -268,8 +255,7 @@ Beauty: 5.</description>
 		<defName>BambooFloorF</defName>
 		<label>Art bamboo parquet</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Parquet with an abstract pattern of triangles.
-Beauty: 5.</description>
+		<description>Parquet with an abstract pattern of triangles.</description>
 		<texturePath>Terrain/Surfaces/bamboo_floor_b1</texturePath>
 		<uiIconPath>Terrain/Surfaces/bamboo_floor_b1i</uiIconPath>
 		<statBases>
@@ -287,8 +273,7 @@ Beauty: 5.</description>
 		<defName>RedWoodFloor</defName>
 		<label>Mahogany floor</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>A floor of mahogany from roughly worked boards.
-Beauty: 3.</description>
+		<description>A floor of mahogany from roughly worked boards.</description>
 		<texturePath>Terrain/Surfaces/redwood_floor_a</texturePath>
 		<uiIconPath>Terrain/Surfaces/redwood_floor_ai</uiIconPath>
 		<statBases>
@@ -306,8 +291,7 @@ Beauty: 3.</description>
 		<defName>RedWoodFloorB</defName>
 		<label>Mahogany parquet</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Bright, red parquet from neatly crafted mahogany boards.
-Beauty: 5.</description>
+		<description>Bright, red parquet from neatly crafted mahogany boards.</description>
 		<texturePath>Terrain/Surfaces/redwood_floor_b</texturePath>
 		<uiIconPath>Terrain/Surfaces/redwood_floor_bi</uiIconPath>
 		<statBases>
@@ -325,8 +309,7 @@ Beauty: 5.</description>
 		<defName>RedWoodFloorC</defName>
 		<label>Pale mahogany parquet</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Pale, beautiful parquet made from neatly crafted mahogany planks.
-Beauty: 5.</description>
+		<description>Pale, beautiful parquet made from neatly crafted mahogany planks.</description>
 		<texturePath>Terrain/Surfaces/redwood_floor_b2</texturePath>
 		<uiIconPath>Terrain/Surfaces/redwood_floor_b2i</uiIconPath>
 		<statBases>
@@ -344,8 +327,7 @@ Beauty: 5.</description>
 		<defName>RedWoodFloorD</defName>
 		<label>Star mahogany parquet</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Luxurious mahogany flooring. For the most sophisticated rooms and demanding colonists.
-Beauty: 6.</description>
+		<description>Luxurious mahogany flooring. For the most sophisticated rooms and demanding colonists.</description>
 		<texturePath>Terrain/Surfaces/redwood_floor_c</texturePath>
 		<uiIconPath>Terrain/Surfaces/redwood_floor_ci</uiIconPath>
 		<statBases>
@@ -363,8 +345,7 @@ Beauty: 6.</description>
 		<defName>RedWoodFloorE</defName>
 		<label>Dark mahogany parquet</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Exquisite mahogany flooring. It will give an atmosphere of luxury and sophistication to any room.
-Beauty: 6.</description>
+		<description>Exquisite mahogany flooring. It will give an atmosphere of luxury and sophistication to any room.</description>
 		<texturePath>Terrain/Surfaces/redwood_floor_c2</texturePath>
 		<uiIconPath>Terrain/Surfaces/redwood_floor_c2i</uiIconPath>
 		<statBases>
@@ -382,8 +363,7 @@ Beauty: 6.</description>
 		<defName>RedWoodFloorF</defName>
 		<label>Pale Chequerwise parquet</label>
 		<renderPrecedence>245</renderPrecedence>
-		<description>Pale, beautiful сhequerwise parquet made from neatly crafted mahogany planks.
-Beauty: 5.</description>
+		<description>Pale, beautiful сhequerwise parquet made from neatly crafted mahogany planks.</description>
 		<texturePath>Terrain/Surfaces/redwood_floor_b3</texturePath>
 		<uiIconPath>Terrain/Surfaces/redwood_floor_b3i</uiIconPath>
 		<statBases>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_Floors_SK.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_Floors_SK.xml
@@ -28,8 +28,7 @@
 
 	<TerrainDef Abstract="True" ParentName="SK_FloorBase" Name="SK_TileStoneBase">
 		<renderPrecedence>220</renderPrecedence>
-		<description>Solid stone tiles for a castle feeling.
-Beauty: 2.</description>
+		<description>Solid stone tiles for a castle feeling.</description>
 		<texturePath>Terrain/Surfaces/TileStone</texturePath>
 		<pollutionShaderType MayRequire="Ludeon.RimWorld.Biotech">TerrainFadeRoughLinearBurn</pollutionShaderType>
 		<pollutionOverlayTexturePath>Terrain/Surfaces/PollutionFloorSmooth</pollutionOverlayTexturePath>
@@ -54,8 +53,7 @@ Beauty: 2.</description>
 	<TerrainDef ParentName="SK_FloorBase">
 		<defName>Concrete</defName>
 		<label>Concrete</label>
-		<description>Quick-poured concrete in a flat, grey surface. You'll need to be able to dig out the ground to pour this. 
-Beauty: 1.</description>
+		<description>Quick-poured concrete in a flat, grey surface. You'll need to be able to dig out the ground to pour this. </description>
 		<texturePath>Terrain/Surfaces/Concrete</texturePath>
 		<edgeType>Hard</edgeType>
 		<renderPrecedence>150</renderPrecedence>
@@ -78,8 +76,7 @@ Beauty: 1.</description>
 	<TerrainDef ParentName="SK_FloorBase">
 		<defName>DarkConcrete</defName>
 		<label>Dark Concrete</label>
-		<description>Dark concrete in a honeycomb pattern. You'll need to be able to dig out the ground to pour this. 
-Beauty: 1.</description>
+		<description>Dark concrete in a honeycomb pattern. You'll need to be able to dig out the ground to pour this. </description>
 		<texturePath>Terrain/Surfaces/DarkConcrete</texturePath>
 		<edgeType>Hard</edgeType>
 		<renderPrecedence>150</renderPrecedence>
@@ -103,8 +100,7 @@ Beauty: 1.</description>
 		<defName>CeramicTile</defName>
 		<label>Ceramic Tile</label>
 		<renderPrecedence>230</renderPrecedence>
-		<description>Small white ceramic tiles with a dark bordering. Quick to move around on. 
-Beauty: 3.</description>
+		<description>Small white ceramic tiles with a dark bordering. Quick to move around on. </description>
 		<texturePath>Terrain/Surfaces/CeramicTile</texturePath>
 		<statBases>
 			<WorkToBuild>400</WorkToBuild>
@@ -128,8 +124,7 @@ Beauty: 3.</description>
 		<defName>PavedTile</defName>
 		<label>Paved Tile</label>
 		<renderPrecedence>230</renderPrecedence>
-		<description>Large grey tiles with a thick, dark border. Quick to move around on. 
-Beauty: 2.</description>
+		<description>Large grey tiles with a thick, dark border. Quick to move around on. </description>
 		<texturePath>Terrain/Surfaces/PavedTile</texturePath>
 		<statBases>
 			<WorkToBuild>200</WorkToBuild>
@@ -336,8 +331,7 @@ Beauty: 2.</description>
 		<defName>RoughSandstoneFloor</defName>
 		<label>Rough Sandstone</label>
 		<renderPrecedence>190</renderPrecedence>
-		<description>Sandstone eroded by the elements.
-Beauty: 0.</description>
+		<description>Sandstone eroded by the elements.</description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>
@@ -366,8 +360,7 @@ Beauty: 0.</description>
 		<defName>RoughGraniteFloor</defName>
 		<label>Rough Granite</label>
 		<renderPrecedence>191</renderPrecedence>
-		<description>Granite eroded by the elements. 
-Beauty: 0.</description>
+		<description>Granite eroded by the elements. </description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>
@@ -396,8 +389,7 @@ Beauty: 0.</description>
 		<defName>RoughLimestoneFloor</defName>
 		<label>Rough Limestone</label>
 		<renderPrecedence>192</renderPrecedence>
-		<description>Limestone eroded by the elements. 
-Beauty: 0.</description>
+		<description>Limestone eroded by the elements. </description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>
@@ -426,8 +418,7 @@ Beauty: 0.</description>
 		<defName>RoughSlateFloor</defName>
 		<label>Rough Slate</label>
 		<renderPrecedence>193</renderPrecedence>
-		<description>Slate eroded by the elements. 
-Beauty: 0.</description>
+		<description>Slate eroded by the elements. </description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>
@@ -456,8 +447,7 @@ Beauty: 0.</description>
 		<defName>RoughMarbleFloor</defName>
 		<label>Rough Marble</label>
 		<renderPrecedence>194</renderPrecedence>
-		<description>Marble eroded by the elements. 
-Beauty: 0.</description>
+		<description>Marble eroded by the elements. </description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>
@@ -486,8 +476,7 @@ Beauty: 0.</description>
 		<defName>RoughCeramicsFloor</defName>
 		<label>Rough Ceramics</label>
 		<renderPrecedence>194</renderPrecedence>
-		<description>Ceramics eroded by the elements. 
-Beauty: 0.</description>
+		<description>Ceramics eroded by the elements. </description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_Floors_SK.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_Floors_SK.xml
@@ -53,7 +53,7 @@
 	<TerrainDef ParentName="SK_FloorBase">
 		<defName>Concrete</defName>
 		<label>Concrete</label>
-		<description>Quick-poured concrete in a flat, grey surface. You'll need to be able to dig out the ground to pour this. </description>
+		<description>Quick-poured concrete in a flat, grey surface. You'll need to be able to dig out the ground to pour this.</description>
 		<texturePath>Terrain/Surfaces/Concrete</texturePath>
 		<edgeType>Hard</edgeType>
 		<renderPrecedence>150</renderPrecedence>
@@ -76,7 +76,7 @@
 	<TerrainDef ParentName="SK_FloorBase">
 		<defName>DarkConcrete</defName>
 		<label>Dark Concrete</label>
-		<description>Dark concrete in a honeycomb pattern. You'll need to be able to dig out the ground to pour this. </description>
+		<description>Dark concrete in a honeycomb pattern. You'll need to be able to dig out the ground to pour this.</description>
 		<texturePath>Terrain/Surfaces/DarkConcrete</texturePath>
 		<edgeType>Hard</edgeType>
 		<renderPrecedence>150</renderPrecedence>
@@ -100,7 +100,7 @@
 		<defName>CeramicTile</defName>
 		<label>Ceramic Tile</label>
 		<renderPrecedence>230</renderPrecedence>
-		<description>Small white ceramic tiles with a dark bordering. Quick to move around on. </description>
+		<description>Small white ceramic tiles with a dark bordering. Quick to move around on.</description>
 		<texturePath>Terrain/Surfaces/CeramicTile</texturePath>
 		<statBases>
 			<WorkToBuild>400</WorkToBuild>
@@ -124,7 +124,7 @@
 		<defName>PavedTile</defName>
 		<label>Paved Tile</label>
 		<renderPrecedence>230</renderPrecedence>
-		<description>Large grey tiles with a thick, dark border. Quick to move around on. </description>
+		<description>Large grey tiles with a thick, dark border. Quick to move around on.</description>
 		<texturePath>Terrain/Surfaces/PavedTile</texturePath>
 		<statBases>
 			<WorkToBuild>200</WorkToBuild>
@@ -258,7 +258,7 @@
 
 	<TerrainDef Abstract="True" ParentName="SK_FloorBase" Name="SK_FlagstoneBase">
 		<renderPrecedence>220</renderPrecedence>
-		<description>Roughly-cut stone tiles. Not super pretty, but they make good surfaces for roads and outdoor walkways. Deconstructing flagstone yields no resources. Beauty: 1.</description>
+		<description>Roughly-cut stone tiles. Not super pretty, but they make good surfaces for roads and outdoor walkways. Deconstructing flagstone yields no resources.</description>
 		<texturePath>Terrain/Surfaces/Flagstone</texturePath>
 		<pollutionShaderType MayRequire="Ludeon.RimWorld.Biotech">TerrainFadeRoughLinearBurn</pollutionShaderType>
 		<pollutionOverlayTexturePath>Terrain/Surfaces/PollutionFloorSmooth</pollutionOverlayTexturePath>
@@ -360,7 +360,7 @@
 		<defName>RoughGraniteFloor</defName>
 		<label>Rough Granite</label>
 		<renderPrecedence>191</renderPrecedence>
-		<description>Granite eroded by the elements. </description>
+		<description>Granite eroded by the elements.</description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>
@@ -389,7 +389,7 @@
 		<defName>RoughLimestoneFloor</defName>
 		<label>Rough Limestone</label>
 		<renderPrecedence>192</renderPrecedence>
-		<description>Limestone eroded by the elements. </description>
+		<description>Limestone eroded by the elements.</description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>
@@ -418,7 +418,7 @@
 		<defName>RoughSlateFloor</defName>
 		<label>Rough Slate</label>
 		<renderPrecedence>193</renderPrecedence>
-		<description>Slate eroded by the elements. </description>
+		<description>Slate eroded by the elements.</description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>
@@ -447,7 +447,7 @@
 		<defName>RoughMarbleFloor</defName>
 		<label>Rough Marble</label>
 		<renderPrecedence>194</renderPrecedence>
-		<description>Marble eroded by the elements. </description>
+		<description>Marble eroded by the elements.</description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>
@@ -476,7 +476,7 @@
 		<defName>RoughCeramicsFloor</defName>
 		<label>Rough Ceramics</label>
 		<renderPrecedence>194</renderPrecedence>
-		<description>Ceramics eroded by the elements. </description>
+		<description>Ceramics eroded by the elements.</description>
 		<texturePath>Terrain/Surfaces/RoughStone</texturePath>
 		<edgeType>Fade</edgeType>
 		<pathCost>0</pathCost>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
@@ -22,8 +22,7 @@
 		<defName>TikiFloorBamboo</defName>
 		<label>bamboo tiki floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A nice bamboo tiki floor. 
-Beauty: 1.</description>
+		<description>A nice bamboo tiki floor. </description>
 		<texturePath>Terrain/Surfaces/TikiFloorBamboo</texturePath>
 		<uiIconPath>Terrain/Surfaces/TikiFloorBambooIco</uiIconPath>
 		<costList>
@@ -35,8 +34,7 @@ Beauty: 1.</description>
 		<defName>TikiFloorDark</defName>
 		<label>dark tiki floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A nice dark tiki floor. 
-Beauty: 1.</description>
+		<description>A nice dark tiki floor. </description>
 		<texturePath>Terrain/Surfaces/TikiFloorDark</texturePath>
 		<uiIconPath>Terrain/Surfaces/TikiFloorDarkIco</uiIconPath>
 		<costList>
@@ -48,8 +46,7 @@ Beauty: 1.</description>
 		<defName>TikiFloorLight</defName>
 		<label>light tiki floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A nice light tiki floor.
-Beauty: 1.</description>
+		<description>A nice light tiki floor.</description>
 		<texturePath>Terrain/Surfaces/TikiFloorLight</texturePath>
 		<uiIconPath>Terrain/Surfaces/TikiFloorLightIco</uiIconPath>	
 		<costList>
@@ -61,8 +58,7 @@ Beauty: 1.</description>
 		<defName>TikiFloorFancy</defName>
 		<label>fancy tiki floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A nice fancy tiki floor with gold inlays.
-Beauty: 3.</description>
+		<description>A nice fancy tiki floor with gold inlays.</description>
 		<texturePath>Terrain/Surfaces/TikiFloorFancy</texturePath>
 		<uiIconPath>Terrain/Surfaces/TikiFloorFancyIco</uiIconPath>	
 		<statBases>
@@ -79,8 +75,7 @@ Beauty: 3.</description>
 		<defName>LogFloor</defName>
 		<label>log floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A simple log floor.
-Beauty: 1.</description>
+		<description>A simple log floor.</description>
 		<texturePath>Terrain/Surfaces/LogFloor</texturePath>
 		<uiIconPath>Terrain/Surfaces/LogFloorIco</uiIconPath>	
 		<costList>
@@ -92,8 +87,7 @@ Beauty: 1.</description>
 		<defName>ThatchFloor</defName>
 		<label>thatch floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A primitive thatch floor. It is cheap and accepts very little filth.
-Beauty: 1.</description>
+		<description>A primitive thatch floor. It is cheap and accepts very little filth.</description>
 		<texturePath>Terrain/Surfaces/ThatchFloor</texturePath>
 		<uiIconPath>Terrain/Surfaces/ThatchFloorIco</uiIconPath>	
 		<statBases>
@@ -112,8 +106,7 @@ Beauty: 1.</description>
 		<defName>WeaveFloor</defName>
 		<label>weave floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A nice woven floor. It is cheap and accepts very little filth.
-Beauty: 1.</description>
+		<description>A nice woven floor. It is cheap and accepts very little filth.</description>
 		<texturePath>Terrain/Surfaces/WeaveFloor</texturePath>
 		<uiIconPath>Terrain/Surfaces/WeaveFloorIco</uiIconPath>	
 		<statBases>
@@ -132,8 +125,7 @@ Beauty: 1.</description>
 		<defName>WovenLeafFloor</defName>
 		<label>woven leaf floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A nice woven leaf floor. It is cheap and accepts very little filth.
-Beauty: 1.</description>
+		<description>A nice woven leaf floor. It is cheap and accepts very little filth.</description>
 		<texturePath>Terrain/Surfaces/WovenLeafFloor</texturePath>
 		<uiIconPath>Terrain/Surfaces/WovenLeafFloorIco</uiIconPath>	
 		<statBases>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_PrimitiveFloors.xml
@@ -22,7 +22,7 @@
 		<defName>TikiFloorBamboo</defName>
 		<label>bamboo tiki floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A nice bamboo tiki floor. </description>
+		<description>A nice bamboo tiki floor.</description>
 		<texturePath>Terrain/Surfaces/TikiFloorBamboo</texturePath>
 		<uiIconPath>Terrain/Surfaces/TikiFloorBambooIco</uiIconPath>
 		<costList>
@@ -34,7 +34,7 @@
 		<defName>TikiFloorDark</defName>
 		<label>dark tiki floor</label>
 		<renderPrecedence>250</renderPrecedence>
-		<description>A nice dark tiki floor. </description>
+		<description>A nice dark tiki floor.</description>
 		<texturePath>Terrain/Surfaces/TikiFloorDark</texturePath>
 		<uiIconPath>Terrain/Surfaces/TikiFloorDarkIco</uiIconPath>
 		<costList>
@@ -143,8 +143,7 @@
 	<TerrainDef  ParentName="PrimitiveSK_FloorBase">
 		<defName>StrawMatting</defName>
 		<label>straw matting</label>
-		<description>Rough straw matting for use in animal barns. It is cheap and accepts very little filth.
-		Beauty: 0.</description>    
+		<description>Rough straw matting for use in animal barns. It is cheap and accepts very little filth.</description>    
 		<renderPrecedence>240</renderPrecedence>
 		<edgeType>Hard</edgeType>
 		<texturePath>Terrain/Surfaces/StrawMatting</texturePath>


### PR DESCRIPTION
In my branch, I Deleted all "Beauty: n" in descriptions. because they are unnecessary and some of them are outdated. 

Unnecessary: By the functions of Moreinfobox.dll in coreSK, it has already displayed the Beauty of buildings including floors.
Outdated: Some of those descriptions are inconsistent with the factual beauty since a [floor balance](https://github.com/skyarkhangel/Hardcore-SK/commit/fdea1b39dbb17f498bd75d606aeec50d77cbfb46) four years ago. 
As you can see in the screenshot below: 
![图片](https://github.com/skyarkhangel/Hardcore-SK/assets/97891812/a607f311-4822-4295-a079-4f27522ccc2d)