### PR TITLE
Update Mechanoid.xml

### DIFF
--- a/Mods/Core_SK/Biotech/Patches/WorkType/Mechanoid.xml
+++ b/Mods/Core_SK/Biotech/Patches/WorkType/Mechanoid.xml
@@ -61,6 +61,7 @@
             <li>Misc</li>
             <li>Processing</li>
             <li>BiotechHauling</li>
+            <li>BasicWorker</li>
         </value>
     </Operation>
     


### PR DESCRIPTION
Fixed mech lifter inability to refuel some building (like torches) due to the lack of a basic worker tag

Исправлена невозможность заправки некоторых построек (вроде факела) у транспортного дрона из-за отсутствия тега базовых работ.

![image](https://github.com/skyarkhangel/Hardcore-SK/assets/62516232/b1efa401-ae6f-445c-adf5-51b6c90e88c9)
