### PR TITLE
Update Mechanitor Scenario and Mechtech researches

### DIFF
--- a/Mods/Core_SK/Biotech/Patches/RecipeDefs/Mechinator.xml
+++ b/Mods/Core_SK/Biotech/Patches/RecipeDefs/Mechinator.xml
@@ -899,7 +899,7 @@
 							<li>USLDBar</li>
 						</categories>
 					</filter>
-					<count>80</count>
+					<count>50</count>
 				</li>
 				<li>
 					<filter>
@@ -936,7 +936,7 @@
 				<li>
 					<filter>
 						<thingDefs>
-							<li>SubcoreHigh</li>
+							<li>SubcoreBasic</li>
 						</thingDefs>
 					</filter>
 					<count>1</count>
@@ -952,7 +952,7 @@
 					<li>ComponentIndustrial</li>
 					<li>Mechanism</li>
 					<li>Carbon</li>
-					<li>SubcoreHigh</li>
+					<li>SubcoreBasic</li>
 				</thingDefs>
 			</fixedIngredientFilter>
 		</value>
@@ -1006,7 +1006,7 @@
 				<li>
 					<filter>
 						<thingDefs>
-							<li>SubcoreHigh</li>
+							<li>SubcoreBasic</li>
 						</thingDefs>
 					</filter>
 					<count>1</count>
@@ -1022,9 +1022,16 @@
 					<li>ComponentIndustrial</li>
 					<li>Mechanism</li>
 					<li>SyntheticFibers</li>
-					<li>SubcoreHigh</li>
+					<li>SubcoreBasic</li>
 				</thingDefs>
 			</fixedIngredientFilter>
+		</value>
+	</Operation>
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/RecipeDef[defName="Fabricor" or defName="Paramedic"]/researchPrerequisite</xpath>
+		<value>
+			<researchPrerequisite>BasicMechtech</researchPrerequisite>
 		</value>
 	</Operation>
 

--- a/Mods/Core_SK/Biotech/Patches/Research/Research.xml
+++ b/Mods/Core_SK/Biotech/Patches/Research/Research.xml
@@ -65,7 +65,7 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ResearchProjectDef[defName="BasicMechtech"]/researchViewY</xpath>
 					<value>
-						<researchViewY>21.00</researchViewY>
+						<researchViewY>18.00</researchViewY>
 					</value>
 				</li>
 				
@@ -73,7 +73,12 @@
 					<xpath>Defs/ResearchProjectDef[defName="BasicMechtech"]/prerequisites</xpath>
 					<value>
 						<prerequisites>
+						  <li>Machining</li>
 						  <li>Electronics_C2</li>
+						  <li>SolarPanels</li>
+						  <li>Research_table_C1</li>
+						  <li>Electrical_engineering_C2</li>
+						  <li>Oil_Industry_C6</li>
 						</prerequisites>
 					</value>
 				</li>
@@ -127,13 +132,13 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ResearchProjectDef[defName="StandardMechtech"]/researchViewX</xpath>
 					<value>
-						<researchViewX>15.00</researchViewX>
+						<researchViewX>13.00</researchViewX>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ResearchProjectDef[defName="StandardMechtech"]/researchViewY</xpath>
 					<value>
-						<researchViewY>21.00</researchViewY>
+						<researchViewY>18.00</researchViewY>
 					</value>
 				</li>
 				<!--
@@ -194,25 +199,23 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ResearchProjectDef[defName="HighMechtech"]/researchViewX</xpath>
 					<value>
-						<researchViewX>19.00</researchViewX>
+						<researchViewX>18.00</researchViewX>
 					</value>
 				</li>
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ResearchProjectDef[defName="HighMechtech"]/researchViewY</xpath>
 					<value>
-						<researchViewY>25.00</researchViewY>
+						<researchViewY>18.00</researchViewY>
 					</value>
 				</li>
-				<!--
+				
 			<li Class="PatchOperationAdd">
-                <xpath>Defs/ResearchProjectDef[defName="HighMechtech"]</xpath>
+                <xpath>Defs/ResearchProjectDef[defName="HighMechtech"]/prerequisites</xpath>
                 <value>
-                    <prerequisites>
-					  <li>Components_D3</li>
-					</prerequisites>
+					<li>Electronics_D1</li>
                 </value>
             </li>
--->
+
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ResearchProjectDef[defName="UltraMechtech"]</xpath>
@@ -275,19 +278,17 @@
 				<li Class="PatchOperationReplace">
 					<xpath>Defs/ResearchProjectDef[defName="UltraMechtech"]/researchViewY</xpath>
 					<value>
-						<researchViewY>25.00</researchViewY>
+						<researchViewY>18.00</researchViewY>
 					</value>
 				</li>
-				<!--
+				
 			<li Class="PatchOperationAdd">
-                <xpath>Defs/ResearchProjectDef[defName="UltraMechtech"]</xpath>
+                <xpath>Defs/ResearchProjectDef[defName="UltraMechtech"]/prerequisites</xpath>
                 <value>
-                    <prerequisites>
-					  <li>Components_D3</li>
-					</prerequisites>
+					<li>Components_D3</li>
                 </value>
             </li>
--->
+
 
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ResearchProjectDef[defName="WastepackAtomizer"]</xpath>

--- a/Mods/Core_SK/Biotech/Patches/Scenarios/Scenario.xml
+++ b/Mods/Core_SK/Biotech/Patches/Scenarios/Scenario.xml
@@ -28,32 +28,42 @@
 			<li Class="ScenPart_StartingThing_Defined">
 			  <def>StartingThing_Defined</def>
 			  <thingDef>Plastic</thingDef>
-			  <count>90</count>
+			  <count>150</count>
 			</li>
 			<li Class="ScenPart_StartingThing_Defined">
 			  <def>StartingThing_Defined</def>
 			  <thingDef>Rubber</thingDef>
+			  <count>120</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>CopperBar</thingDef>
+			  <count>100</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+			  <def>StartingThing_Defined</def>
+			  <thingDef>LeadBar</thingDef>
 			  <count>80</count>
 			</li>
 			<li Class="ScenPart_StartingThing_Defined">
 			  <def>StartingThing_Defined</def>
 			  <thingDef>Silicon</thingDef>
-			  <count>25</count>
+			  <count>40</count>
 			</li>
 			<li Class="ScenPart_StartingThing_Defined">
 			  <def>StartingThing_Defined</def>
 			  <thingDef>Mechanism</thingDef>
-			  <count>15</count>
+			  <count>25</count>
 			</li>
 			<li Class="ScenPart_StartingThing_Defined">
 			  <def>StartingThing_Defined</def>
 			  <thingDef>ElectronicComponents</thingDef>
-			  <count>10</count>
+			  <count>20</count>
 			</li>
 			<li Class="ScenPart_StartingThing_Defined">
 			  <def>StartingThing_Defined</def>
 			  <thingDef>Electronics</thingDef>
-			  <count>7</count>
+			  <count>15</count>
 			</li>
 			<li Class="ScenPart_StartingThing_Defined">
 			  <def>StartingThing_Defined</def>
@@ -63,7 +73,19 @@
 			<li Class="ScenPart_StartingThing_Defined">
 				<def>StartingThing_Defined</def>
 				<thingDef>Carbon</thingDef>
-				<count>10</count>
+				<count>20</count>
+			</li>
+			<li Class="ScenPart_StartingThing_Defined">
+				<def>StartingThing_Defined</def>
+				<thingDef>SyntheticFibers</thingDef>
+				<count>20</count>
+			</li>
+
+			<!-- Starting mechs -->
+			<li Class="ScenPart_StartingMech">
+			  <def>StartingMech</def>
+			  <mechKind>Mech_Fabricor</mechKind>
+			  <overseenByPlayerPawnChance>1</overseenByPlayerPawnChance>
 			</li>
 		</value>
 	</Operation>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ScenarioDefs/ScenariosPatch.xml
@@ -348,25 +348,9 @@
 				<li Class="PatchOperationAdd">
 					<xpath>Defs/ScenarioDef[defName="Mechanitor"]/scenario/parts</xpath>
 					<value>
-
 						<li Class="ScenPart_StartingThing_Defined">
 							<def>StartingThing_Defined</def>
-							<thingDef>TFJ_Tool_Woodcutting_Handaxe</thingDef>
-							<stuff>Plasteel</stuff>
-						</li>
-						<li Class="ScenPart_StartingThing_Defined">
-							<def>StartingThing_Defined</def>
-							<thingDef>TFJ_Tool_Building_Hammer</thingDef>
-							<stuff>Plasteel</stuff>
-						</li>
-						<li Class="ScenPart_StartingThing_Defined">
-							<def>StartingThing_Defined</def>
-							<thingDef>TFJ_Tool_Sickle</thingDef>
-							<stuff>Plasteel</stuff>
-						</li>
-						<li Class="ScenPart_StartingThing_Defined">
-							<def>StartingThing_Defined</def>
-							<thingDef>TFJ_Tool_Mining_Pickaxe</thingDef>
+							<thingDef>TFJ_Tool_Multitool</thingDef>
 							<stuff>Plasteel</stuff>
 						</li>
 					</value>


### PR DESCRIPTION
1 starting set of Mechanitor's resources, researches and items has been revised to be more consistent with his backstory and to eliminate cases where it is impossible to create mechanoids at the start of the game;
2 all lightweight mechanoids are now available for creation from the very beginning of the game in this scenario;

1 пересмотрен набор стартовых ресурсов, исследований и предметов механитора для большего соответствия его предыстории и исключения случаев невозможности создавать механоидов на старте игры;
2 все легковесные механоиды теперь доступны для создания в самом начале игры на этом сценарии.