### PR TITLE
Added missing hair length tags

### DIFF
--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Ameiro.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Ameiro.xml
@@ -8,6 +8,7 @@
 		<category>Tribal</category>
 		<styleTags>
 			<li>Tribal</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -18,6 +19,7 @@
 		<category>Urban</category>
 		<styleTags>
 			<li>Urban</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -28,6 +30,7 @@
 		<category>Tribal</category>
 		<styleTags>
 			<li>Tribal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -38,6 +41,7 @@
 		<category>Urban</category>
 		<styleTags>
 			<li>Urban</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -49,6 +53,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -59,6 +64,7 @@
 		<category>Tribal</category>
 		<styleTags>
 			<li>Tribal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -69,6 +75,7 @@
 		<category>Urban</category>
 		<styleTags>
 			<li>Urban</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -79,6 +86,7 @@
 		<category>Rural</category>
 		<styleTags>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -89,6 +97,7 @@
 		<category>Urban</category>
 		<styleTags>
 			<li>Urban</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -100,6 +109,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Tribal</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -111,6 +121,7 @@
 		<styleTags>
 			<li>Rural</li>
 			<li>Tribal</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -122,6 +133,7 @@
 		<styleTags>
 			<li>Rural</li>
 			<li>Tribal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 </Defs>

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Animu.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Animu.xml
@@ -10,6 +10,7 @@
 		<styleTags>
 			<li>Punk</li>
 			<li>Tribal</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -21,6 +22,7 @@
 		<category>Rural</category>
 		<styleTags>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -33,6 +35,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Diane.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Diane.xml
@@ -9,6 +9,7 @@
 	<category>Urban</category>
     <styleTags>
       <li>Urban</li>
+      <li>HairShort</li>
     </styleTags>
   </HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Diane.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Diane.xml
@@ -9,7 +9,7 @@
 	<category>Urban</category>
     <styleTags>
       <li>Urban</li>
-      <li>HairShort</li>
+	  <li>HairShort</li>
     </styleTags>
   </HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Extended.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Extended.xml
@@ -10,6 +10,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -22,6 +23,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	
@@ -34,6 +36,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -46,6 +49,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -58,6 +62,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	
@@ -71,6 +76,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -83,6 +89,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -95,6 +102,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Jaffa.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Jaffa.xml
@@ -9,6 +9,7 @@
 	<category>Tribal</category>
 		<styleTags>
 			<li>Tribal</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Kantai.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Kantai.xml
@@ -10,6 +10,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -22,6 +23,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -34,6 +36,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -46,6 +49,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -58,6 +62,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -70,6 +75,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -82,6 +88,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -94,6 +101,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -106,6 +114,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -118,6 +127,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -130,6 +140,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -142,6 +153,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -154,6 +166,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -166,6 +179,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -178,6 +192,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -190,6 +205,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -202,6 +218,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -214,6 +231,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -226,6 +244,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -238,6 +257,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -250,6 +270,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -262,6 +283,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -274,6 +296,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -287,6 +310,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -299,6 +323,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -311,6 +336,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -323,6 +349,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -335,6 +362,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -347,6 +375,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -359,6 +388,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -371,6 +401,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -383,6 +414,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -395,6 +427,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -407,6 +440,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -419,6 +453,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -431,6 +466,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 	<HairDef>
@@ -443,6 +479,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Anime</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Lolidrop.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Lolidrop.xml
@@ -10,6 +10,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -22,6 +23,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 
@@ -34,6 +36,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 
@@ -46,6 +49,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -58,6 +62,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 
@@ -70,6 +75,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 
@@ -82,6 +88,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -94,6 +101,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -106,6 +114,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -118,6 +127,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -130,6 +140,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -142,6 +153,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -154,6 +166,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -166,6 +179,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -178,6 +192,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -190,6 +205,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Lovely.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Lovely.xml
@@ -9,6 +9,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -21,6 +22,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -33,6 +35,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 
@@ -46,6 +49,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Tribal</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -58,6 +62,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -70,6 +75,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 
@@ -82,6 +88,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 
@@ -94,6 +101,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -106,6 +114,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -118,6 +127,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -130,6 +140,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -142,6 +153,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -154,6 +166,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -166,6 +179,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -178,6 +192,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -190,6 +205,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 
@@ -202,6 +218,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -214,6 +231,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 
@@ -227,6 +245,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
 
@@ -240,6 +259,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_NB.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_NB.xml
@@ -10,6 +10,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Norbal</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -22,6 +23,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -34,6 +36,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -47,6 +50,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -59,6 +63,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -71,6 +76,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -84,6 +90,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Norbal.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Norbal.xml
@@ -10,6 +10,7 @@
 		<styleTags>
 			<li>Norbal</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -22,6 +23,7 @@
 		<styleTags>
 			<li>Norbal</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Piggy.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Piggy.xml
@@ -10,6 +10,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
   </HairDef>
  

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_RS.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_RS.xml
@@ -10,6 +10,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -22,6 +23,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -34,6 +36,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -47,6 +50,7 @@
 			<li>Urban</li>
 			<li>Rural</li>
 			<li>Terminator</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -59,6 +63,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Punk</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -71,6 +76,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -83,6 +89,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -95,6 +102,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_SPS.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_SPS.xml
@@ -11,6 +11,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -25,6 +26,7 @@
 			<li>Rural</li>
 			<li>Punk</li>
 			<li>Norbal</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -37,6 +39,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -49,6 +52,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -63,6 +67,7 @@
 			<li>Rural</li>
 			<li>Tribal</li>
 			<li>Norbal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -75,6 +80,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -87,6 +93,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -99,6 +106,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -111,6 +119,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -125,6 +134,7 @@
 			<li>Rural</li>
 			<li>Tribal</li>
 			<li>Norbal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -138,6 +148,7 @@
 			<li>Rural</li>
 			<li>Tribal</li>
 			<li>Norbal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -150,6 +161,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -162,6 +174,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -175,6 +188,7 @@
 			<li>Tribal</li>
 			<li>Norbal</li>
 			<li>Punk</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -187,6 +201,7 @@
 		<styleTags>
 			<li>Tribal</li>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -201,6 +216,7 @@
 			<li>Norbal</li>
 			<li>Rural</li>
 			<li>Urban</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -214,6 +230,7 @@
 			<li>Tribal</li>
 			<li>Rural</li>
 			<li>Urban</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -227,6 +244,7 @@
 			<li>Tribal</li>
 			<li>Rural</li>
 			<li>Urban</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -239,6 +257,7 @@
 		<styleTags>
 			<li>Tribal</li>
 			<li>Norbal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -253,6 +272,7 @@
 			<li>Norbal</li>
 			<li>Urban</li>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -277,6 +297,7 @@
 			<li>Norbal</li>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -289,6 +310,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Smoothawk.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Smoothawk.xml
@@ -10,6 +10,7 @@
 		<styleTags>
 			<li>Punk</li>
 			<li>Urban</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
  

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Spikes.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Spikes.xml
@@ -9,6 +9,7 @@
 	<category>Punk</category>
 		<styleTags>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
   </HairDef>
  

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Vanilla.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Vanilla.xml
@@ -19,6 +19,7 @@
 		<category>Soldier</category>
 		<styleTags>
 			<li>Soldier</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -31,6 +32,7 @@
 		<styleTags>
 			<li>Punk</li>
 			<li>Tribal</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -42,6 +44,7 @@
 		<category>Urban</category>
 		<styleTags>
 			<li>Urban</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -54,6 +57,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -65,6 +69,7 @@
 		<category>Punk</category>
 		<styleTags>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -77,6 +82,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -88,6 +94,7 @@
 		<category>Rural</category>
 		<styleTags>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -99,6 +106,7 @@
 		<category>Urban</category>
 		<styleTags>
 			<li>Urban</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -111,6 +119,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -123,6 +132,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -135,6 +145,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -147,6 +158,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -158,6 +170,7 @@
 		<category>Urban</category>
 		<styleTags>
 			<li>Urban</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -169,6 +182,7 @@
 		<category>Rural</category>
 		<styleTags>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -180,6 +194,7 @@
 		<category>Soldier</category>
 		<styleTags>
 			<li>Soldier</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -192,6 +207,7 @@
 		<styleTags>
 			<li>Punk</li>
 			<li>Tribal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -204,6 +220,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -249,6 +266,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -260,6 +278,7 @@
 		<category>Soldier</category>
 		<styleTags>
 			<li>Soldier</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -271,6 +290,7 @@
 		<category>Urban</category>
 		<styleTags>
 			<li>Urban</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -283,6 +303,7 @@
 		<styleTags>
 			<li>Punk</li>
 			<li>Tribal</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -295,6 +316,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 

--- a/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Xeva.xml
+++ b/Mods/Core_SK/Defs/Misc/HairDefs/Hairs_Xeva.xml
@@ -8,6 +8,7 @@
 		<category>Rural</category>
 		<styleTags>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -20,6 +21,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -32,6 +34,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -44,6 +47,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Tribal</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -56,6 +60,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -68,6 +73,7 @@
 		<styleTags>
 			<li>Rural</li>
 			<li>Tribal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -80,6 +86,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -91,6 +98,7 @@
 		<category>Rural</category>
 		<styleTags>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -103,6 +111,7 @@
 		<styleTags>
 			<li>Tribal</li>
 			<li>Punk</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -115,6 +124,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -127,6 +137,7 @@
 		<styleTags>
 			<li>Urban</li>
 			<li>Punk</li>
+			<li>HairShort</li>
 		</styleTags>
 	</HairDef>
 
@@ -138,6 +149,7 @@
 		<category>Tribal</category>
 		<styleTags>
 			<li>Tribal</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 
@@ -149,6 +161,7 @@
 		<category>Rural</category>
 		<styleTags>
 			<li>Rural</li>
+			<li>HairLong</li>
 		</styleTags>
 	</HairDef>
 


### PR DESCRIPTION
Added missing hair length tags for hairstyles to work correctly with xenogenes of the same name.

Добавлены пропущенные теги длины волос для причесок для корректной работы с одноименными ксеногенами.