### PR TITLE
Renamed Fragile trait in the russian localization

### DIFF
--- a/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/Expanded Traits.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/TraitDef/Expanded Traits.xml
@@ -108,7 +108,7 @@
   <Pyrophobia.degreeDatas.0.label>пирофобия</Pyrophobia.degreeDatas.0.label>
   <Pyrophobia.degreeDatas.0.description>{PAWN_nameDef} крайне боится огоня. {PAWN_pronoun} не сможет совладать с собой, чтобы тушить пожар.</Pyrophobia.degreeDatas.0.description>
 
-  <Fragile.degreeDatas.0.label>хрупкость</Fragile.degreeDatas.0.label>
-  <Fragile.degreeDatas.0.description>{PAWN_nameDef} обладает тонкой кожей, слабыми мышцами и хрупкими костями. По сравнению с обычным человеком {PAWN_pronoun} получает больше урона от тех же атак. {PAWN_possessive} проще убить.</Fragile.degreeDatas.0.description>
+  <Fragile.degreeDatas.0.label>ломкость</Fragile.degreeDatas.0.label>
+  <Fragile.degreeDatas.0.description>{PAWN_nameDef} обладает тонкой кожей, слабыми мышцами и ломкими костями. По сравнению с обычным человеком {PAWN_pronoun} получает больше урона от тех же атак. {PAWN_possessive} проще убить.</Fragile.degreeDatas.0.description>
 
 </LanguageData>


### PR DESCRIPTION
Renamed Fragile trait in the russian localization, because it duplicated the vanilla Delicate trait.

Переименовал черту "Хрупкость" на "Ломкость" в русской локализации, т.к. в ваниле появилась одноименная черта.