### PR TITLE
Disabled combat drugs for tribals patch.

### DIFF
--- a/Mods/CombatExtended/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
+++ b/Mods/CombatExtended/Patches/Core/PawnKindDefs_Humanlike/PawnKinds.xml
@@ -861,8 +861,8 @@
 	</Operation>
 
 	<!-- Combat drugs for tribals  -->
-
-	<Operation Class="PatchOperationAdd">
+	<!-- Tribal pawns already has berserker herb. This patch is redundant.  -->
+<!-- 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/PawnKindDef[
 			defName="Tribal_Berserker" or
 			defName="Tribal_HeavyArcher" or
@@ -873,7 +873,7 @@
 			<combatEnhancingDrugsCount>1~2</combatEnhancingDrugsCount>
 		</value>
 	</Operation>
-
+ -->
 	<!-- Stranger in Black -->
 	
 	<!-- Already in HSK -->


### PR DESCRIPTION
Disabled combat drugs for tribals patch. Tribal pawns already has berserker herb. This patch is redundant.

Отключен излишний патч СЕ на добавление случайных боевых наркотиков некоторым племенным пешкам (у них уже есть берсерк трава, доп. рандомные стимуляторы излишни).