### PR TITLE
An attempt to fix incorrect pawn spawning in the classic scenario

### DIFF
--- a/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_Asari.xml
+++ b/Mods/AsariRace/Defs/PawnKindDefs_Humanlikes/PawnKinds_Asari.xml
@@ -12,11 +12,6 @@
 		</backstoryFilters>	
 		<defaultFactionType>AsariHunters</defaultFactionType>	
 		<isFighter>true</isFighter>
-		<xenotypeSet>
-		  <xenotypeChances>
-			<Baseline_Asari MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Asari>
-		  </xenotypeChances>
-		</xenotypeSet>
 		<forcedHair>Asari</forcedHair>
 		<techHediffsChance>0</techHediffsChance>
 		<chemicalAddictionChance>0.03</chemicalAddictionChance>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Feral.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Feral.xml
@@ -68,6 +68,7 @@
 		</colorSpectrum>
 		<xenotypeSet>
 			<xenotypeChances>
+				<Baseline_Dova MayRequire="Ludeon.RimWorld.Biotech">0.775</Baseline_Dova>
 				<Dirtmole MayRequire="Ludeon.RimWorld.Biotech">0.1</Dirtmole>
 				<Hussar MayRequire="Ludeon.RimWorld.Biotech">0.05</Hussar>
 				<Waster MayRequire="Ludeon.RimWorld.Biotech">0.025</Waster>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Syndicate.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Syndicate.xml
@@ -24,6 +24,7 @@
 		</colorSpectrum>
 		<xenotypeSet>
 			<xenotypeChances>
+				<Baseline_Dova MayRequire="Ludeon.RimWorld.Biotech">0.75</Baseline_Dova>
 				<Dirtmole MayRequire="Ludeon.RimWorld.Biotech">0.1</Dirtmole>
 				<Hussar MayRequire="Ludeon.RimWorld.Biotech">0.05</Hussar>
 				<Waster MayRequire="Ludeon.RimWorld.Biotech">0.025</Waster>

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Feral.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Feral.xml
@@ -36,17 +36,6 @@
 		<requiredWorkTags>
 			<li>Violent</li>
 		</requiredWorkTags>
-		<xenotypeSet Inherit="False">
-		  <xenotypeChances>
-			<Baseline_Dova MayRequire="Ludeon.RimWorld.Biotech">0.675</Baseline_Dova>
-			<Dirtmole MayRequire="Ludeon.RimWorld.Biotech">0.1</Dirtmole>
-			<Hussar MayRequire="Ludeon.RimWorld.Biotech">0.05</Hussar>
-			<Waster MayRequire="Ludeon.RimWorld.Biotech">0.025</Waster>
-			<Pigskin MayRequire="Ludeon.RimWorld.Biotech">0.025</Pigskin>
-			<Neanderthal MayRequire="Ludeon.RimWorld.Biotech">0.025</Neanderthal>
-		  </xenotypeChances>
-		  <warnIfTotalAbove1>false</warnIfTotalAbove1>
-		</xenotypeSet>
 	</PawnKindDef>
 	<!-- Refugee -->
 	<PawnKindDef ParentName="FeralBase">

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Norbals.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Norbals.xml
@@ -33,11 +33,6 @@
 		</techHediffsTags>
 		<techHediffsMaxAmount>3</techHediffsMaxAmount>
 		<techHediffsChance>0.6</techHediffsChance>
-		<xenotypeSet Inherit="False">
-		  <xenotypeChances>
-			<Baseline_Norbal MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Norbal>
-		  </xenotypeChances>
-		</xenotypeSet>
 	</PawnKindDef>
 	<!-- Warrior -->
 	<PawnKindDef Name="NorbalWarrior" ParentName="NorbalBase">

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_NovaAlliance.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_NovaAlliance.xml
@@ -35,12 +35,6 @@
 		</techHediffsTags>
 		<techHediffsChance>0.45</techHediffsChance>
 		<techHediffsMaxAmount>4</techHediffsMaxAmount>
-		<xenotypeSet Inherit="False">
-		  <xenotypeChances>
-			<Baseline_Nova MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Nova>
-		  </xenotypeChances>
-		  <warnIfTotalAbove1>false</warnIfTotalAbove1>
-		</xenotypeSet>
 	</PawnKindDef>
 	<!-- Refugee -->
 	<PawnKindDef ParentName="NovaAllianceBase">

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Orassan.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Orassan.xml
@@ -33,11 +33,6 @@
 		</techHediffsTags>
 		<techHediffsMaxAmount>3</techHediffsMaxAmount>
 		<techHediffsChance>0.25</techHediffsChance>
-		<xenotypeSet Inherit="False">
-		  <xenotypeChances>
-			<Baseline_Orassan MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Orassan>
-		  </xenotypeChances>
-		</xenotypeSet>	
 	</PawnKindDef>
 
 	<!-- Refugee -->

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Syndicate.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Syndicate.xml
@@ -54,12 +54,6 @@
 			<li>ExoskeletonSuit</li>
 			<li>BrainStimulator</li>
 		</techHediffsRequired>
-		<xenotypeSet Inherit="False">
-		  <xenotypeChances>
-			<Baseline_Dova MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Dova>
-		  </xenotypeChances>
-		  <warnIfTotalAbove1>false</warnIfTotalAbove1>
-		</xenotypeSet>
 	</PawnKindDef>
 
 	<!-- Prospector -->

--- a/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
+++ b/Mods/RatkinRaceHSK/Defs/PawnKindDef_Ratkin/PawnKinds_Player.xml
@@ -13,12 +13,6 @@
 		<backstoryCryptosleepCommonality>0</backstoryCryptosleepCommonality>
 		<initialResistanceRange>0~10</initialResistanceRange>
 		<initialWillRange>5~10</initialWillRange>
-		<xenotypeSet>
-		  <xenotypeChances>
-			<Baseline_Ratkin MayRequire="Ludeon.RimWorld.Biotech">999</Baseline_Ratkin>
-		  </xenotypeChances>
-		  <warnIfTotalAbove1>false</warnIfTotalAbove1>
-		</xenotypeSet>
 	</PawnKindDef>	
 	<!-- 평화 -->
 	<!-- 시민 -->


### PR DESCRIPTION
An attempt to fix incorrect pawn spawning in the classic scenario by removing redundant xenotypes of raid faction pawns part 1 (and I hope last). These changes do not affect raiders generation.

Попытка исправить некорректное появление пешек в классическом сценарии путем удаления лишних ксенотипов пешек рейдовых фракций, часть 1 (и надеюсь, последняя). Эти изменения не затрагивают генерацию рейдеров