### PR TITLE
Updated intermediate, rifle, large-caliber and shotgun ammunition

### DIFF
--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Grenade/30x29mmGrenade.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Grenade/30x29mmGrenade.xml
@@ -41,15 +41,45 @@
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_30x29mmGrenade_HE"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>55</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_30x29mmGrenade_HE"]/projectile/explosionRadius</xpath>
+		<value>
+			<explosionRadius>1.3</explosionRadius>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bullet_30x29mmGrenade_HE"]/comps</xpath>
 		<value>
 			<comps>
 				<li Class="CombatExtended.CompProperties_Fragments">
 					<fragments>
-						<Fragment_Small>28</Fragment_Small>
+						<Fragment_GrenadeFrag>15</Fragment_GrenadeFrag>
 					</fragments>
 				</li>
 			</comps>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_30x29mmGrenade_EMP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>35</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_30x29mmGrenade_HE_TFuzed"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>55</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_30x29mmGrenade_HE_TFuzed"]/projectile/explosionRadius</xpath>
+		<value>
+			<explosionRadius>1.3</explosionRadius>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
@@ -58,7 +88,7 @@
 			<comps>
 				<li Class="CombatExtended.CompProperties_Fragments">
 					<fragments>
-						<Fragment_Small>28</Fragment_Small>
+						<Fragment_GrenadeFrag>15</Fragment_GrenadeFrag>
 					</fragments>
 					<fragAngleRange>-89~-5</fragAngleRange>
 				</li>

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Grenade/40x46mmGrenade.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Grenade/40x46mmGrenade.xml
@@ -61,15 +61,39 @@
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_40x46mmGrenade_HE"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>75</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_40x46mmGrenade_HE"]/projectile/explosionRadius</xpath>
+		<value>
+			<explosionRadius>1.6</explosionRadius>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bullet_40x46mmGrenade_HE"]/comps</xpath>
 		<value>
 			<comps>
 				<li Class="CombatExtended.CompProperties_Fragments">
 					<fragments>
-						<Fragment_Small>20</Fragment_Small>
+						<Fragment_GrenadeFrag>25</Fragment_GrenadeFrag>
 					</fragments>
 				</li>
 			</comps>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_40x46mmGrenade_HE_TFuzed"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>75</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_40x46mmGrenade_HE_TFuzed"]/projectile/explosionRadius</xpath>
+		<value>
+			<explosionRadius>1.6</explosionRadius>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
@@ -78,7 +102,7 @@
 			<comps>
 				<li Class="CombatExtended.CompProperties_Fragments">
 					<fragments>
-						<Fragment_Small>20</Fragment_Small>
+						<Fragment_GrenadeFrag>25</Fragment_GrenadeFrag>
 					</fragments>
 					<fragAngleRange>-89~-5</fragAngleRange>
 				</li>
@@ -101,6 +125,18 @@
 					</fragments>
 				</li>
 			</comps>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_40x46mmGrenade_EMP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>48</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_40x46mmGrenade_EMP"]/projectile/explosionRadius</xpath>
+		<value>
+			<explosionRadius>2</explosionRadius>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAttributeSet">

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/HighCaliber/14.5x114mmSoviet.xml
@@ -83,7 +83,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Flame_Secondary</def>
-					<amount>21</amount>
+					<amount>19</amount>
 				</li>
 			</secondaryDamage>
 		</value>
@@ -100,9 +100,63 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>32</amount>
+					<amount>27</amount>
 				</li>
 			</secondaryDamage>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_145x114mm_FMJ"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>46</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_145x114mm_FMJ"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>22</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_145x114mm_FMJ"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>570</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_145x114mm_HE"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>35</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_145x114mm_HE"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>22</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_145x114mm_HE"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>570</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_145x114mm_Incendiary"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>36</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_145x114mm_Incendiary"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>33</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_145x114mm_Incendiary"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>570</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAttributeSet">

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/HighCaliber/50BMG.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/HighCaliber/50BMG.xml
@@ -93,6 +93,78 @@
 		<value>BaseBulletCE</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_FMJ"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>34</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_FMJ"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_FMJ"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>334</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_Sabot"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>30</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_Sabot"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>32</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_Sabot"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>377</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_HE"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>28</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_HE"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>18</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_HE"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>334</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_Incendiary"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>28</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_Incendiary"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>28</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_50BMG_Incendiary"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>334</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Bullet_50BMG_Incendiary"]/projectile/secondaryDamage</xpath>
 		<value>
 			<secondaryDamage>
@@ -109,7 +181,7 @@
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>24</amount>
+					<amount>22</amount>
 				</li>
 			</secondaryDamage>
 		</value>

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Rifle/303British.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Rifle/303British.xml
@@ -86,6 +86,42 @@
 			<casingMoteDefname>Fleck_RifleAmmoCasings_HighCal</casingMoteDefname>
 		</value>
 	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_303British_FMJ"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>20</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_303British_FMJ"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>10</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_303British_AP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>15</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_303British_AP"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>15</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_303British_HP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>27</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_303British_HP"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>7.5</armorPenetrationSharp>
+		</value>
+	</Operation>
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_303British_FMJ"]</xpath>
 		<attribute>ParentName</attribute>

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Rifle/556x45mmNATO.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Rifle/556x45mmNATO.xml
@@ -97,6 +97,42 @@
 			</secondaryDamage>
 		</value>
 	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_556x45mmNATO_FMJ"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>16</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_556x45mmNATO_FMJ"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>9</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_556x45mmNATO_AP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>13</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_556x45mmNATO_AP"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>13</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_556x45mmNATO_HP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>24</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_556x45mmNATO_HP"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>6.5</armorPenetrationSharp>
+		</value>
+	</Operation>
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_556x45mmNATO_FMJ"]</xpath>
 		<attribute>ParentName</attribute>

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Rifle/762x39mmSoviet.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Rifle/762x39mmSoviet.xml
@@ -74,6 +74,42 @@
 		<attribute>ParentName</attribute>
 		<value>BaseBulletCE</value>
 	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x39mmSoviet_FMJ"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>18</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x39mmSoviet_FMJ"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>8.8</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x39mmSoviet_AP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>14</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x39mmSoviet_AP"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>12</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x39mmSoviet_HP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>26</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x39mmSoviet_HP"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>6.25</armorPenetrationSharp>
+		</value>
+	</Operation>
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x39mmSoviet_FMJ"]</xpath>
 		<attribute>ParentName</attribute>

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Rifle/762x51mmNATO.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Rifle/762x51mmNATO.xml
@@ -74,6 +74,42 @@
 		<attribute>ParentName</attribute>
 		<value>BaseBulletCE</value>
 	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x51mmNATO_FMJ"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>21</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x51mmNATO_FMJ"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>11.5</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x51mmNATO_AP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>17</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x51mmNATO_AP"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>16</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x51mmNATO_HP"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>28</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_762x51mmNATO_HP"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>8.5</armorPenetrationSharp>
+		</value>
+	</Operation>
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_762x51mmNATO_FMJ"]</xpath>
 		<attribute>ParentName</attribute>

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Shotgun/12Gauge.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Shotgun/12Gauge.xml
@@ -63,6 +63,36 @@
 	<Operation Class="PatchOperationRemove">
 		<xpath>Defs/ThingDef[defName="Bullet_12Gauge_ElectroSlug"]/graphicData/color</xpath>
 	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_12Gauge_Buck"]/projectile/spreadMult</xpath>
+		<value>
+			<spreadMult>17.8</spreadMult>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_12Gauge_Buck"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>5.7</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_12Gauge_Buck"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>6.44</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_12Gauge_Slug"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>8</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Bullet_12Gauge_Beanbag"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>5</armorPenetrationBlunt>
+		</value>
+	</Operation>
 	<Operation Class="PatchOperationAttributeSet">
 		<xpath>Defs/RecipeDef[defName="MakeAmmo_12Gauge_Buck"]</xpath>
 		<attribute>ParentName</attribute>


### PR DESCRIPTION
Updated intermediate, rifle, large-caliber, grenade and shotgun ammunition (some values were not transferred during the CE update and are now greatly reduced, I corrected this).

Дообновлены промежуточные, винтовочные, крупнокалиберные боеприпасы, гранаты и боеприпасы для дробовика (часть значений не были перенесены при обновлении СЕ и сейчас сильно снижены, поправил это).