### PR TITLE
Removed CombatExtended.ToolCE and tools patch from all planks

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Wood.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Resources/Items_Resource_Wood.xml
@@ -250,7 +250,7 @@
 	</ThingDef>
 
 
-	<ThingDef ParentName="SK_ResourceBase">
+	<ThingDef ParentName="SK_ResourceVerbBase">
 		<defName>Bamboo</defName>
 		<label>bamboo log</label>
 		<description>Bamboo Logs are a type of wood-like grass. It is a fast growing wood alternative that is useful for construction.</description>
@@ -391,23 +391,6 @@
 			</statFactors>
 		</stuffProps>
 		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
-		<weaponClasses>
-			<li>Melee</li>
-			<li>MeleeBlunt</li>
-			<li>Neolithic</li>
-		</weaponClasses>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>6</power>
-				<cooldownTime>1.7</cooldownTime>
-				<chanceFactor>1.33</chanceFactor>
-				<armorPenetrationBlunt>0.738</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
-			</li>
-		</tools>
 	</ThingDef>
 
 	<ThingDef ParentName="SK_ResourceBase">
@@ -473,23 +456,6 @@
 			</statFactors>
 		</stuffProps>
 		<terrainAffordanceNeeded>Light</terrainAffordanceNeeded>
-		<weaponClasses>
-			<li>Melee</li>
-			<li>MeleeBlunt</li>
-			<li>Neolithic</li>
-		</weaponClasses>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>9</power>
-				<cooldownTime>2.1</cooldownTime>
-				<chanceFactor>1.33</chanceFactor>
-				<armorPenetrationBlunt>0.738</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
-			</li>
-		</tools>
 	</ThingDef>
 
 	<ThingDef ParentName="SK_ResourceBase">
@@ -522,23 +488,6 @@
 				<li>Kindlingstuff</li>
 			</categories>
 		</stuffProps>
-		<weaponClasses>
-			<li>Melee</li>
-			<li>MeleeBlunt</li>
-			<li>Neolithic</li>
-		</weaponClasses>
-		<tools>
-			<li Class="CombatExtended.ToolCE">
-				<capacities>
-					<li>Blunt</li>
-				</capacities>
-				<power>7</power>
-				<cooldownTime>1.7</cooldownTime>
-				<chanceFactor>1.33</chanceFactor>
-				<armorPenetrationBlunt>0.738</armorPenetrationBlunt>
-				<linkedBodyPartsGroup>Base</linkedBodyPartsGroup>
-			</li>
-		</tools>
 	</ThingDef>
 
 </Defs>

--- a/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Wood.xml
+++ b/Mods/SurvivalToolsLite/Patches/Core_SK/ThingDefs_Resources/Items_Resource_Wood.xml
@@ -35,40 +35,6 @@
 	</Operation>
 
 	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="WoodPlank"]</xpath>
-		<value>
-			<li Class="SurvivalToolsLite.StuffPropsTool">
-				<toolStatFactors>
-					<TreeFellingSpeed>0.6</TreeFellingSpeed>
-					<PlantHarvestingSpeed>0.6</PlantHarvestingSpeed>
-					<PlantWorkSpeed>0.6</PlantWorkSpeed>
-					<MiningSpeed>0.6</MiningSpeed>
-					<MiningYieldDigging>0.8</MiningYieldDigging>
-					<ConstructionSpeed>0.6</ConstructionSpeed>
-					<SmithingSpeed>0.7</SmithingSpeed>
-				</toolStatFactors>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="RedWoodPlank"]</xpath>
-		<value>
-			<li Class="SurvivalToolsLite.StuffPropsTool">
-				<toolStatFactors>
-					<TreeFellingSpeed>0.45</TreeFellingSpeed>
-					<PlantHarvestingSpeed>0.45</PlantHarvestingSpeed>
-					<PlantWorkSpeed>0.45</PlantWorkSpeed>
-					<MiningSpeed>0.5</MiningSpeed>
-					<MiningYieldDigging>0.7</MiningYieldDigging>
-					<ConstructionSpeed>0.5</ConstructionSpeed>
-					<SmithingSpeed>0.65</SmithingSpeed>
-				</toolStatFactors>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
 		<xpath>Defs/ThingDef[defName="Bamboo"]</xpath>
 		<value>
 			<li Class="SurvivalToolsLite.StuffPropsTool">
@@ -80,39 +46,6 @@
 					<MiningYieldDigging>0.7</MiningYieldDigging>
 					<ConstructionSpeed>0.5</ConstructionSpeed>
 					<SmithingSpeed>0.65</SmithingSpeed>
-				</toolStatFactors>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="BambooPlank"]</xpath>
-		<value>
-			<li Class="SurvivalToolsLite.StuffPropsTool">
-				<toolStatFactors>
-					<TreeFellingSpeed>0.5</TreeFellingSpeed>
-					<PlantHarvestingSpeed>0.5</PlantHarvestingSpeed>
-					<PlantWorkSpeed>0.5</PlantWorkSpeed>
-					<MiningSpeed>0.5</MiningSpeed>
-					<MiningYieldDigging>0.7</MiningYieldDigging>
-					<ConstructionSpeed>0.5</ConstructionSpeed>
-					<SmithingSpeed>0.65</SmithingSpeed>
-				</toolStatFactors>
-			</li>
-		</value>
-	</Operation>
-
-	<Operation Class="PatchOperationAddModExtension">
-		<xpath>Defs/ThingDef[defName="Kindling"]</xpath>
-		<value>
-			<li Class="SurvivalToolsLite.StuffPropsTool">
-				<toolStatFactors>
-					<TreeFellingSpeed>0.6</TreeFellingSpeed>
-					<PlantHarvestingSpeed>0.6</PlantHarvestingSpeed>
-					<PlantWorkSpeed>0.6</PlantWorkSpeed>
-					<MiningSpeed>0.6</MiningSpeed>
-					<MiningYieldDigging>0.8</MiningYieldDigging>
-					<ConstructionSpeed>0.6</ConstructionSpeed>
 				</toolStatFactors>
 			</li>
 		</value>


### PR DESCRIPTION
Removed CombatExtended.ToolCE and tools patch from all planks. Its have not equippable compClass and can break slave and prisoner AI and a significant drop in TPS (see discord link).
Also added missed verb to bamboo (bamboo could not be equipped as a weapon).
https://discord.com/channels/272340793174392832/272924909649395712/1225454217175629905

Удален CombatExtended.ToolCE и патч инструментов для всех видов досок. У них нет подходящего для этого compClass, что может привести к поломке ИИ рабов и заключенных и значительной просадке тпса (см. по ссылке дискорда).
Добавлен пропущенный verb обычному бамбуку (без него бамбук нельзя было использовать в качестве оружия).