### PR TITLE
MultiLang Colorful Traits mod update

### DIFF
--- a/Mods/MultiLang Colorful Traits/Defs/Mod_Core.xml
+++ b/Mods/MultiLang Colorful Traits/Defs/Mod_Core.xml
@@ -17,7 +17,6 @@
 		<traits>
 			<li>Kind</li> <!-- доброта / kind -->
 			<li>Ascetic</li> <!-- аскетизм / ascetic -->
-			<li>Undergrounder</li> <!-- домосед / undergrounder -->
 			<li>GreatMemory</li> <!-- хорошая память / great memory -->
 			<li>Tough</li> <!-- живучесть / tough -->
 			<li>QuickSleeper</li> <!-- эффективный сон / quick sleeper -->
@@ -29,14 +28,12 @@
 			
 			<li>SpeedOffset#1</li> <!-- скороход / fast walker -->
 			<li>SpeedOffset#2</li> <!-- бегун / jogger -->
-			<li>NaturalMood#2</li> <!-- сангвиник / sanguine -->
+			<li>NaturalMood#2</li> <!-- жизнелюбие / sanguine -->
 			<li>NaturalMood#1</li> <!-- оптимист / optimist -->
 			<li>Nerves#2</li> <!-- железные нервы / iron-willed -->
 			<li>Nerves#1</li> <!-- уравновешенность / steadfast -->
 			<li>Industriousness#2</li> <!-- усердие / industrious -->
 			<li>Industriousness#1</li> <!-- трудолюбие / hard worker -->
-			<li>PsychicSensitivity#-1</li> <!-- психическая устойчивость / psychically dull -->
-			<li>PsychicSensitivity#-2</li> <!-- психическая глухота / psychically deaf -->
 			<li>Beauty#2</li> <!-- невероятная красота / beautiful -->
 			<li>Beauty#1</li> <!-- красота / pretty -->
 			<li>Immunity#1</li> <!-- сильный иммунитет / super-immune -->
@@ -50,8 +47,10 @@
 			<li>Transhumanist</li> <!-- трансгуманист / transhumanist -->
 			<li>BodyPurist</li> <!-- биоконсерватор / body purist -->
 			<li>Gourmand</li> <!-- обжора / gourmand -->
-			<li>DrugDesire#-1</li> <!-- трезвенник / teetotaler -->
 			<li>Asexual</li> <!-- асексуал / asexual -->
+			<li>Psychopath</li> <!-- психопатия / psychopath -->
+			<li>Undergrounder</li> <!-- подземник / undergrounder -->
+			<li MayRequire="Ludeon.RimWorld.Biotech">Recluse</li> <!-- отшельничество / recluse -->
 			
 			<!-- Spectrum -->
 			
@@ -59,6 +58,11 @@
 			<li>Neurotic#2</li> <!-- тяжёлая неврастения / very neurotic -->
 			<li>ShootingAccuracy#1</li> <!-- аккуратный стрелок / careful shooter -->
 			<li>ShootingAccuracy#-1</li> <!-- беспечный стрелок / trigger-happy -->
+			<li>DrugDesire#-1</li> <!-- трезвенник / teetotaler -->
+			<li>PsychicSensitivity#-1</li> <!-- психическая устойчивость / psychically dull -->
+			<li>PsychicSensitivity#-2</li> <!-- психическая глухота / psychically deaf -->
+			<li>PsychicSensitivity#2</li> <!-- гиперчувствительность / psychically hypersensitive -->
+			<li>PsychicSensitivity#1</li> <!-- восприимчивость / psychically sensitive -->
 		</traits>
 	</Trait.ColorDef>
 	
@@ -66,11 +70,20 @@
 		<defName>clrMod_Core_Bad</defName>
 		<traits>
 			<li>Bloodlust</li> <!-- кровожадность / bloodlust -->
-			<li>Psychopath</li> <!-- психопатия / psychopath -->
 			<li>Brawler</li> <!-- драчун / brawler -->
 			<li>Gay</li> <!-- гомосексуальность / gay -->
 			<li>DislikesMen</li> <!-- мужененависть / misandrist -->
 			<li>DislikesWomen</li> <!-- женоненависть / misogynist -->
+			<li MayRequire="Ludeon.RimWorld.Biotech">Delicate</li> <!-- хрупкость / delicate -->
+			
+			<!-- Spectrum -->
+			
+			<li>SpeedOffset#-1</li> <!-- медлительность / slowpoke -->
+			<li>DrugDesire#1</li> <!-- интерес к «химии» / chemical interest -->
+			<li>NaturalMood#-1</li> <!-- пессимист / pessimist -->
+			<li>Nerves#-1</li> <!-- неуравновешенность / nervous -->
+			<li>Industriousness#-1</li> <!-- леность / lazy -->
+			<li>Beauty#-1</li> <!-- уродство / ugly -->
 		</traits>
 	</Trait.ColorDef>
 	
@@ -88,18 +101,10 @@
 			
 			<!-- Spectrum -->
 			
-			<li>SpeedOffset#-1</li> <!-- медлительность / slowpoke -->
 			<li>DrugDesire#2</li> <!-- страсть к «химии» / chemical fascination -->
-			<li>DrugDesire#1</li> <!-- интерес к «химии» / chemical interest -->
-			<li>NaturalMood#-1</li> <!-- пессимист / pessimist -->
-			<li>NaturalMood#-2</li> <!-- меланхолик / depressive -->
-			<li>Nerves#-1</li> <!-- неуравновешенность / nervous -->
+			<li>NaturalMood#-2</li> <!-- подавленность / depressive -->
 			<li>Nerves#-2</li> <!-- слабые нервы / volatile -->
-			<li>Industriousness#-1</li> <!-- леность / lazy -->
 			<li>Industriousness#-2</li> <!-- праздность / slothful -->
-			<li>PsychicSensitivity#2</li> <!-- гиперчувствительность / psychically hypersensitive -->
-			<li>PsychicSensitivity#1</li> <!-- восприимчивость / psychically sensitive -->
-			<li>Beauty#-1</li> <!-- уродство / ugly -->
 			<li>Beauty#-2</li> <!-- невероятное уродство / staggeringly ugly -->
 			<li>Immunity#-1</li> <!-- слабый иммунитет / sickly -->
 		</traits>

--- a/Mods/MultiLang Colorful Traits/Defs/Mod_SK.xml
+++ b/Mods/MultiLang Colorful Traits/Defs/Mod_SK.xml
@@ -4,10 +4,6 @@
 	<Trait.ColorDef ParentName="ColorUnique">
 		<defName>clrMod_SK_Unique</defName>
 		<traits>
-			<li>Nudist</li> <!-- нудист / nudist -->
-			<li>Cannibal</li> <!-- каннибализм / cannibal -->
-			<li>Masochist</li> <!-- мазохизм / masochist -->
-			<li>NightOwl</li> <!-- сова / night owl -->
 			<li>Photophobia</li> <!-- фотофобия / photophobic -->
 			<li>ColdLover</li> <!-- психрофил / cold lover -->
 			<li>HeatLover</li> <!-- теплолюбивый / heat lover -->
@@ -44,7 +40,7 @@
 			<li>Diplomat#1</li> <!-- дипломат / diplomat -->
 			<li>Diplomat#2</li> <!-- мастер дипломатии / master diplomat -->
 			<li>Constitution#1</li> <!-- сильный иммунитет / strong constitution -->
-			<li>EatingSpeed#1</li> <!-- обжора / glutton -->
+			<li>EatingSpeed#1</li> <!-- едок / glutton -->
 			<li>BrownThumb#1</li> <!-- хороший садовод / green thumb -->
 			<li>ShootingAccuracy#2</li> <!-- меткий выстрел / deadshot -->
 		</traits>
@@ -57,6 +53,7 @@
 			<li>Dumb</li> <!-- тупость / dumb -->
 			<li>ChaoticGenius</li> <!-- гениальность / volatile genius -->
 			<li>DIY</li> <!-- строитель / builder -->
+			<li>Religious</li> <!-- религиозность / religious -->
 			<li>Fanatic</li> <!-- фанатизм / fanatic -->
 			<li>Numb</li> <!-- хладнокровность / numb -->
 			<li>AnimalLover</li> <!-- любитель животных / animal lover -->
@@ -67,6 +64,7 @@
 			<li>Inventor</li> <!-- изобретатель / inventor -->
 			<li>NeatFreak</li> <!-- чистоплотность / neat freak -->
 			<li>Rockhound</li> <!-- горняк / rockhound -->
+			<li>Pragmatist</li> <!-- прагматичность / pragmatic -->
 			
 			<!-- Spectrum -->
 			
@@ -80,9 +78,6 @@
 		<traits>
 			<li>Ignorant</li> <!-- безграмотный / dunce -->
 			<li>Weak</li> <!-- слабость / weak -->
-			<li>Religious</li> <!-- религиозность / religious -->
-			<li>Paranoid</li> <!-- параноик / paranoid -->
-			<li>Pragmatist</li> <!-- прагматичность / pragmatic -->
 			<li>Introvert</li> <!-- интроверт / shy -->
 			<li>Villian</li> <!-- злодей / villian -->
 			<li>Allergic</li> <!-- аллергик / animal hater -->
@@ -93,7 +88,7 @@
 			
 			<li>EatingSpeed#-1</li> <!-- гурман / nibbler -->
             <li>PainThreshold#-1</li> <!-- непереносимость боли / low pain tolerance -->
-			<li>Medic#-1</li> <!-- плохой медик / poor medic -->
+			<li>Medic#-1</li> <!-- плохой врач / poor medic -->
 			<li>Dodging#-1</li> <!-- вялость / sluggish -->
 			<li>Trader#-1</li> <!-- простофиля / sucker -->
 			<li>Diplomat#-1</li> <!-- неуклюжесть / uncouth -->
@@ -107,6 +102,7 @@
 			<li>Bipolar</li> <!-- биполярный / bipolar -->
 			<li>Claustrophobic</li> <!-- клаустрофобия / claustrophobic -->
 			<li>Slow</li> <!-- неторопливость / slow -->
+			<li>Paranoid</li> <!-- параноик / paranoid -->
 			<li>Fragile</li> <!-- хрупкость / fragile -->
 			
 			<!-- Spectrum -->


### PR DESCRIPTION
1 added missed color to biotech traits;
2 some tweaks with color of some traits (some colors are no longer relevant, for example, traits for psychosensitivity);
3 deleted duplucate traits;
4 fixed wrong translations.

1 добавлены пропущенные цвета чертам характера из Biotech;
2 некоторые перестановки цвета у некоторых черт характера (части из них цвет был выставлен до появления DLC и на текущий момент неактуален, например, черты на психочувствительность).
3 удалены дублирующиеся черты;
4 исправлена локализация в комментах.