### PR TITLE
Fix CONN items erroring after use

### DIFF
--- a/Mods/CyberneticOrganism_SK/Defs/ThingDefs_Items/Items_Exotic.xml
+++ b/Mods/CyberneticOrganism_SK/Defs/ThingDefs_Items/Items_Exotic.xml
@@ -20,7 +20,7 @@
 			<li>RewardStandardHighFreq</li>
 		</thingSetMakerTags>
 		<comps>
-			<li Class="CompProperties_UseEffectDestroySelf" />
+			<!-- <li Class="CompProperties_UseEffectDestroySelf" />  All CONN Comps already destroy itself after doing effect -->	
 		</comps>
 	</ThingDef>
 


### PR DESCRIPTION
All CONN Comps already destroy itself after doing effect, the `CompProperties_UseEffectDestroySelf` in base def is redundant