### PR TITLE
Update Raw buckwheat stack limit (HMC Biomes)

### DIFF
--- a/Mods/HMC Biomes/Defs/ThingDefs_Resources/Items_Resource_Crops_CookingSupplies.xml
+++ b/Mods/HMC Biomes/Defs/ThingDefs_Resources/Items_Resource_Crops_CookingSupplies.xml
@@ -26,6 +26,7 @@
 				<daysToRotStart>60</daysToRotStart>
 			</li>
 		</comps>
+		<stackLimit>300</stackLimit>
 	</ThingDef>
 
 </Defs>


### PR DESCRIPTION
Increased stack limit from 75 to 300 (like corn and rice).

Увеличен размер стака с 75 до 300 (как у кукурузы и риса).