### PR TITLE
Updated Androids, Combat Extended and Core SK mods

### DIFF
--- a/Mods/Androids/Defs/AlienRaceSettings/AlienRaceSettings.xml
+++ b/Mods/Androids/Defs/AlienRaceSettings/AlienRaceSettings.xml
@@ -10,7 +10,7 @@
 							<kindDefs>
 								<li>AndroidColonistSK</li>
 							</kindDefs>
-							<chance>4.0</chance>
+							<chance>3.0</chance>
 						</li>
 					</pawnKindEntries>
 					<factionDefs>
@@ -31,7 +31,7 @@
 					<kindDefs>
 						<li>ChjAndroidColonist</li>
 					</kindDefs>
-					<chance>6.0</chance>
+					<chance>4.0</chance>
 				</li>
 			</alienrefugeekinds>
 			<alienwandererkinds>
@@ -41,7 +41,7 @@
 							<kindDefs>
 								<li>ChjAndroidVillager</li>
 							</kindDefs>
-							<chance>6.0</chance>
+							<chance>4.0</chance>
 						</li>
 					</pawnKindEntries>
 					<factionDefs>

--- a/Mods/CombatExtended/Languages/Russian/DefInjected/DamageDef/Damages_LocalInjury.xml
+++ b/Mods/CombatExtended/Languages/Russian/DefInjected/DamageDef/Damages_LocalInjury.xml
@@ -10,7 +10,11 @@
 	<PrometheumFlame.label>огонь</PrometheumFlame.label>
 	<PrometheumFlame.deathMessage>{0} сгорел.</PrometheumFlame.deathMessage>
 
-	<Bomb_Secondary.deathMessage>{0} был убит.</Bomb_Secondary.deathMessage>
+	<ArrowFire.label>огонь</ArrowFire.label>
+	<ArrowFire.deathMessage>{0} сгорел.</ArrowFire.deathMessage>
+
+	<Bomb_Secondary.label>повторный взрыв</Bomb_Secondary.label>
+	<Bomb_Secondary.deathMessage>{0} был повторно убит.</Bomb_Secondary.deathMessage>
 
 	<Thermobaric.label>термобарическая</Thermobaric.label>
 	<Thermobaric.deathMessage>{0} был убит.</Thermobaric.deathMessage>
@@ -21,6 +25,7 @@
 	<Electrical.label>электричество</Electrical.label>
 	<Electrical.deathMessage>{0} умер от удара электричеством.</Electrical.deathMessage>
 
+	<ArrowVenom.label>яд</ArrowVenom.label>
 	<ArrowVenom.deathMessage>{0} был отравлен.</ArrowVenom.deathMessage>
 
 	<Tranquilizer.label>транквилизатор</Tranquilizer.label>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
@@ -142,16 +142,16 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>ArrowVenom</damageDef>
-			<damageAmountBase>3</damageAmountBase>
+			<damageAmountBase>7</damageAmountBase>
 			<!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
-			<armorPenetrationBlunt>5.8</armorPenetrationBlunt>
-			<armorPenetrationSharp>3.1</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.1</armorPenetrationBlunt>
+			<armorPenetrationSharp>3.9</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_Bolt_Venom</preExplosionSpawnThingDef>			
 			<secondaryDamage>
 				<li>
 					<def>ArrowHighVelocity</def>
-					<amount>8</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_FullHead_Medieval.xml
@@ -345,6 +345,7 @@
 			<developmentalStageFilter>Child, Adult</developmentalStageFilter>
 			<bodyPartGroups>
 				<li>FullHead</li>
+				<li>Neck</li>
 			</bodyPartGroups>
 			<wornGraphicPath>Things/Apparel/NorbalHelmet/NorbalChain</wornGraphicPath>
 			<layers>
@@ -497,6 +498,8 @@
 			<developmentalStageFilter>Child, Adult</developmentalStageFilter>
 			<bodyPartGroups>
 				<li>UpperHead</li>
+				<li>Teeth</li>
+				<li>Neck</li>
 			</bodyPartGroups>
 			<wornGraphicPath>Things/Apparel/MedievalTimes/Headwear_Armor/Domed/MedievalTimes_Helmet_Domed</wornGraphicPath>
 			<layers>
@@ -569,6 +572,7 @@
 			<developmentalStageFilter>Child, Adult</developmentalStageFilter>
 			<bodyPartGroups>
 				<li>FullHead</li>
+				<li>Neck</li>
 			</bodyPartGroups>
 			<wornGraphicPath>Things/Apparel/MedievalTimes/Headwear_Armor/Sallet/MedievalTimes_Helmet_Sallet</wornGraphicPath>
 			<layers>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Medieval.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Medieval.xml
@@ -133,6 +133,7 @@
 			<developmentalStageFilter>Child, Adult</developmentalStageFilter>
 			<bodyPartGroups>
 				<li>UpperHead</li>
+				<li>Nose</li>
 				<li>Teeth</li>
 				<li>Neck</li>
 			</bodyPartGroups>

--- a/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Neolitic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Apparel/Apparel_Helmets_UpperHead_Neolitic.xml
@@ -330,7 +330,11 @@
 		<graphicData>
 			<texPath>Things/Apparel/Apparello/Hats/Animalhats/Scarhat</texPath>
 			<graphicClass>Graphic_Single</graphicClass>
-		</graphicData>			
+		</graphicData>	
+		<stuffCategories>
+			<li>Leathery</li>
+		</stuffCategories>
+		<costStuffCount>14</costStuffCount>
 		<costList>
 			<Chitin>10</Chitin>
 		</costList>
@@ -373,6 +377,7 @@
 			<bodyPartGroups>
 				<li>UpperHead</li>
 				<li>Mouth</li>
+				<li>Neck</li>
 			</bodyPartGroups>
 			<wornGraphicPath>Things/Apparel/Apparello/Hats/Animalhats/Scarhat</wornGraphicPath>
 			<layers>

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Neolithic/Arrows.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Neolithic/Arrows.xml
@@ -154,6 +154,18 @@
 			<airborneSuppressionFactor>4.5</airborneSuppressionFactor>
 		</value>
 	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Venom"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>3.7</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Venom"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>3.3</armorPenetrationSharp>
+		</value>
+	</Operation>
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Venom"]/projectile</xpath>
 		<value>
@@ -185,9 +197,63 @@
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Stone"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>11</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Stone"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>4.1</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Stone"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>2.6</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/label</xpath>
 		<value>
 			<label>streamlined arrow (metallic)</label>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>15</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>4.6</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>3.3</armorPenetrationSharp>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Venom"]/projectile/armorPenetrationBlunt</xpath>
+		<value>
+			<armorPenetrationBlunt>4</armorPenetrationBlunt>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Venom"]/projectile/damageAmountBase</xpath>
+		<value>
+			<damageAmountBase>7</damageAmountBase>
+		</value>
+	</Operation>
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Venom"]/projectile/armorPenetrationSharp</xpath>
+		<value>
+			<armorPenetrationSharp>3.6</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAdd">


### PR DESCRIPTION
Eng:
- Added missed CE arrows patches (some arrows had greatly reduced damage and armor penetration. For example recurve bow had significant less damage and penetration than short bow).
- Rebalanced venom bolts to better match other venom projectiles (like venom arrows) (increased venom damage and sharp penetration, decreased non-venom damage and blunt penetration).
- Fixed some medieval and neolitic helmet body part groups and layers covering (for example Nasal Helmet now cover Nose, all helmets with chainmail aventail now also covers a neck and so on) (https://discord.com/channels/272340793174392832/1213150642634489937).
- Fixed Chitin Head Garment crafting recipe and null armor param (added 14 leathery stuff categories to recipe (without a type of material, a helmet cannot have armor)).
- Slightly reduced android pawn chance spawn in classic scenario.
- Added missed ArrowVenom, ArrowFire and Bomb_Secondary russian translation.

Rus:
- добавлены пропущенные патчи СЕ для стрел (некоторые стрелы имели значительно сниженные урон и бронепробитие. Например, рекурсивный лук был значительно слабее короткого лука);
- перебалансированы ядовитые болты для лучшего соответствия прочим ядовитым снарядам (например, ядовитые стрелы) (был увеличен ядовитый урон и пронепробитие в БКГ, но уменьшен неядовитый урон и бронепробитие в МПа);
- исправлено укрывание частей головы для некоторых средневековых и неолитовых шлемов в соответствии с их внешним видом (например, Норманнский шлем теперь корректно закрывает нос, т.к. имеет наносник на своей текстуре, все шлемы с кольчужной бармицей также укрывают шею и т.д.) (сделано по запросу в дискорде https://discord.com/channels/272340793174392832/1213150642634489937);
- исправлен рецепт шапки из хитина и полное отсутствие брони у неё (т.к. в рецепте не выбирается материал изготовления, она всегда имела нулевую броню. Добавлено 14 ед. любой кожи в крафт для решения этой проблемы);
- немного уменьшен шанс спавна андроидов в классическом сценарии;
- добавлен пропущенный перевод для типов урона ArrowVenom, ArrowFire и Bomb_Secondary.