### PR TITLE
Apparel correction: Ratkin research glasses

### DIFF
--- a/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
+++ b/Mods/RatkinRaceHSK/Defs/ThingsDefs/RK_Apparel.xml
@@ -846,7 +846,6 @@
 		<apparel>
 			<countsAsClothingForNudity>false</countsAsClothingForNudity>
 			<bodyPartGroups>
-				<li>UpperHead</li>
 				<li>Eyes</li>
 			</bodyPartGroups>
 			<defaultOutfitTags>
@@ -854,7 +853,7 @@
 			</defaultOutfitTags>
 			<wornGraphicPath>Apparel/RK_ResearchGlasses</wornGraphicPath>
 			<layers>
-				<li>Overhead</li>
+				<li>StrappedHead</li>
 			</layers>
 			<tags>
 				<li>RK_Doctor</li>


### PR DESCRIPTION
Moved Ratkin research glasses to "StrappedHead" Layer and removed UpperHead coverage.