### PR TITLE
Antidotes are untied from the pawn royal title

### DIFF
--- a/Mods/Core_SK/Royalty/Patches/VariousPatches.xml
+++ b/Mods/Core_SK/Royalty/Patches/VariousPatches.xml
@@ -14,4 +14,12 @@
 		</value>
 	</Operation>
 	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/RoyalTitleDef[@Name="BaseEmpireTitleNPC" or defName="Count" or defName="Baron" or defName="Praetor" or defName="Knight" or defName="Acolyte"]/foodRequirement/allowedDefs</xpath>
+		<value>
+			<li>AntidoteSimple</li>
+			<li>AntidoteSafe</li>
+		</value>
+	</Operation>
+
 </Patch>


### PR DESCRIPTION
Added antidotes to the list of exceptions to the restrictions of the dishes of titled pawns upon request at the link below.

Добавил антидоты в список исключений ограничений блюд титулованных пешек по запросу по ссылке ниже.

https://discord.com/channels/272340793174392832/1224011503435386963