### PR TITLE
Some UI and localization fixes №2

### DIFF
--- a/Mods/Core_SK/Biotech/Defs/Factions/Factions_Misc.xml
+++ b/Mods/Core_SK/Biotech/Defs/Factions/Factions_Misc.xml
@@ -200,6 +200,7 @@
           <Mercenary_Sniper_Yttakin>7</Mercenary_Sniper_Yttakin>
           <Mercenary_Elite_Yttakin>10</Mercenary_Elite_Yttakin>
           <PirateBoss>5</PirateBoss>
+		  <PirateBomb>2</PirateBomb>
           <Warg>15</Warg>
           <WildBoar>15</WildBoar>
         </options>
@@ -232,6 +233,7 @@
           <Mercenary_Gunner_Yttakin>1</Mercenary_Gunner_Yttakin>
           <Mercenary_Heavy_Yttakin>10</Mercenary_Heavy_Yttakin>
           <Mercenary_Elite_Yttakin>1</Mercenary_Elite_Yttakin>
+		  <PirateBomb>1</PirateBomb>
           <PirateBoss>1</PirateBoss>
           <WildBoar>5</WildBoar>
         </options>
@@ -257,6 +259,7 @@
           <Mercenary_Sniper_Yttakin>10</Mercenary_Sniper_Yttakin>
           <Mercenary_Gunner_Yttakin>10</Mercenary_Gunner_Yttakin>
           <Mercenary_Elite_Yttakin>10</Mercenary_Elite_Yttakin>
+		  <PirateBomb>2</PirateBomb>
           <PirateBoss>10</PirateBoss>
           <Warg>12</Warg>
           <WildBoar>8</WildBoar>
@@ -490,6 +493,7 @@
           <Mercenary_Gunner_Pig>7</Mercenary_Gunner_Pig>
           <Mercenary_Elite_Pig>10</Mercenary_Elite_Pig>
           <Town_Councilman_Pig>10</Town_Councilman_Pig>
+		  <PirateBomb>2</PirateBomb>
         </options>
       </li>
       <li>
@@ -611,6 +615,7 @@
           <Mercenary_EliteTox>5</Mercenary_EliteTox>
           <Mercenary_Elite>1</Mercenary_Elite>
           <PirateBossTox>5</PirateBossTox>
+		  <PirateBomb>2</PirateBomb>
         </options>
       </li>
       <li>
@@ -644,6 +649,7 @@
           <Mercenary_EliteTox>5</Mercenary_EliteTox>
           <Mercenary_Elite>1</Mercenary_Elite>
           <PirateBossTox>5</PirateBossTox>
+		  <PirateBomb>1</PirateBomb>
         </options>
       </li>
       <li>
@@ -663,6 +669,7 @@
           <Mercenary_EliteTox>1</Mercenary_EliteTox>
           <Mercenary_Elite>0.25</Mercenary_Elite>
           <PirateBossTox>1</PirateBossTox>
+		  <PirateBomb>1</PirateBomb>
         </options>
       </li>
       <li>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ExpansionDef/ExpansionDefs.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ExpansionDef/ExpansionDefs.xml
@@ -1,9 +1,0 @@
-﻿<?xml version="1.0" encoding="UTF-8"?>
-<LanguageData>
-
-  <!-- EN: Hardcore SK -->
-  <Core.label>Hardcore SK</Core.label>
-  <!-- EN: Hardcore SK RimWorld content. -->
-  <Core.description>Основной контент Hardcore SK.</Core.description>
-
-</LanguageData>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/RiverDef/RiverDefs.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/RiverDef/RiverDefs.xml
@@ -1,0 +1,7 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<LanguageData>
+
+  <!-- EN: almost a lake -->
+  <HyperRiver.label>почти озеро</HyperRiver.label>
+
+</LanguageData>

--- a/Mods/Core_SK/Patches/ExpansionDef.xml
+++ b/Mods/Core_SK/Patches/ExpansionDef.xml
@@ -8,25 +8,4 @@
         </value>
     </Operation>
 
-    <Operation Class="PatchOperationReplace">
-        <xpath>Defs/ExpansionDef[defName="Core"]/iconPath</xpath>
-        <value>
-            <iconPath>UI/HeroArt/HSKLogo</iconPath>
-        </value>
-    </Operation>
-
-    <Operation Class="PatchOperationReplace">
-        <xpath>Defs/ExpansionDef[defName="Core"]/label</xpath>
-        <value>
-            <label>Hardcore SK</label>
-        </value>
-    </Operation>
-
-    <Operation Class="PatchOperationReplace">
-        <xpath>Defs/ExpansionDef[defName="Core"]/description</xpath>
-        <value>
-            <description>Hardcore SK RimWorld content.</description>
-        </value>
-    </Operation>
-
 </Patch>


### PR DESCRIPTION
ENG:
- Fixed UI bug due to which the HSK was considered official Rimworld content during the loading screen.
- Added missed pawns with M79 GL to pirate/outlander Biotech factions.
- Added missed almost a lake river type russian translation.

RUS:
- Исправлена ошибка UI, из-за которой HSK считался официальным контентом Rimworld во время экрана загрузки.
- Добавлены пропущенные пешки с РГ M79 в пиратские/аутлендеровские фракции Biotech.
- Добавлен пропущенный перевод типу реки "Almost a lake".