### PR TITLE
Fix PawnGenerator exception for Tribal PawnKindDef

### DIFF
--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Tribal.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Tribal.xml
@@ -408,6 +408,17 @@
 		<combatPower>170</combatPower>
 		<itemQuality>Good</itemQuality>
 		<backstoryCryptosleepCommonality>0.01</backstoryCryptosleepCommonality>
+		<backstoryFiltersOverride>
+			<li>
+				<categoriesChildhood>
+					<li>Tribal</li>
+				</categoriesChildhood>
+				<categoriesAdulthood>
+					<li>Tribal</li>
+					<li>TribalHunter</li>
+				</categoriesAdulthood>
+			</li>
+		</backstoryFiltersOverride>
 		<minGenerationAge>35</minGenerationAge>
 		<factionLeader>true</factionLeader>
 		<gearHealthRange>


### PR DESCRIPTION
There is a small chance that PawnGenerator will fail to generate a Pawn with Tribal_ChiefMelee or Tribal_ChiefRanged PawnKindDef requested configuration.

It happens when game tries to generate Factions on a map so user might see empty map without any settlements (it depends how much user choose Factions on Create World screen).

Seems like Generator cannot find a correct Tribal backstory with Violent work tag after 120 retries so we must explicitly set Backstories (Adulthood category) filter to include a correct Spawn Category (that includes backstories with Violent requiredWorkTag).

Other PawnKindDef's might have the same issue and should be checked as well.