### PR TITLE
Some metallic floors tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Core_SK/Defs/DesignationSubCategoryDefs/SubCategories.xml
@@ -1579,11 +1579,16 @@
 		<defNames>
 			<li>CopperTile</li>
 			<li>TinTile</li>
+			<li>AluminiumTile</li>
+			<li>CupronickelTile</li>
+			<li>SteinTile</li>
 			<li>SilverTile</li>
 			<li>GoldTile</li>
 			<li>GoldSolid</li>
 <!--			<li>FloorAmber</li>
 			<li>FloorJade</li>-->
+			<li>TitaniumTile</li>
+			<li>BetaPolyTile</li>
 		</defNames>
 		<designationCategory>OutsideFloors</designationCategory>
 		<debug>false</debug>

--- a/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorMetallic.xml
+++ b/Mods/Core_SK/Defs/TerrainDefs/Terrain_FloorMetallic.xml
@@ -170,6 +170,128 @@
 		</researchPrerequisites>
 	</TerrainDef>
 
+	<!-- ============ Aluminium Tile ============ -->
+
+	<TerrainDef ParentName="MetalTileBase">
+		<defName>AluminiumTile</defName>
+		<label>simple aluminium tile</label>
+		<renderPrecedence>240</renderPrecedence>
+		<description>Simple aluminium square tiles.</description>
+		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
+		<color>(190,205,190)</color>
+		<statBases>
+			<WorkToBuild>816</WorkToBuild>
+			<Beauty>3</Beauty>
+			<Cleanliness>0.3</Cleanliness>
+			<CleaningTimeFactor>0.55</CleaningTimeFactor>
+			<FilthMultiplier>0.9</FilthMultiplier>
+		</statBases>
+		<costList>
+			<AluminiumBar>4</AluminiumBar>
+		</costList>
+		<researchPrerequisites>
+			<li>Metal_floor_C1</li>
+		</researchPrerequisites>
+		<terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+	</TerrainDef>
+
+	<!-- ============ Cupronickel (melchior) Tile ============ -->
+
+	<TerrainDef ParentName="MetalTileBase">
+		<defName>CupronickelTile</defName>
+		<label>simple melchior tile</label>
+		<renderPrecedence>240</renderPrecedence>
+		<description>Simple melchior square tiles.</description>
+		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
+		<color>(168,157,125)</color>
+		<statBases>
+			<WorkToBuild>2040</WorkToBuild>
+			<Beauty>4</Beauty>
+			<Cleanliness>0.3</Cleanliness>
+			<CleaningTimeFactor>0.55</CleaningTimeFactor>
+			<FilthMultiplier>0.9</FilthMultiplier>
+		</statBases>
+		<costList>
+			<CupronickelAlloy>4</CupronickelAlloy>
+		</costList>
+		<researchPrerequisites>
+			<li>Metal_floor_C1</li>
+		</researchPrerequisites>
+	</TerrainDef>
+
+	<!-- ============ Stein Tile ============ -->
+
+	<TerrainDef ParentName="MetalTileBase">
+		<defName>SteinTile</defName>
+		<label>simple stein tile</label>
+		<renderPrecedence>240</renderPrecedence>
+		<description>Simple stein square tiles.</description>
+		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
+		<color>(130,157,141)</color>
+		<statBases>
+			<WorkToBuild>3060</WorkToBuild>
+			<Beauty>5</Beauty>
+			<Cleanliness>0.3</Cleanliness>
+			<CleaningTimeFactor>0.55</CleaningTimeFactor>
+			<FilthMultiplier>0.9</FilthMultiplier>
+		</statBases>
+		<costList>
+			<SteelBar>4</SteelBar>
+		</costList>
+		<researchPrerequisites>
+			<li>Metal_floor_C1</li>
+		</researchPrerequisites>
+	</TerrainDef>
+
+	<!-- ============ Titanium Tile ============ -->
+
+	<TerrainDef ParentName="MetalTileBase">
+		<defName>TitaniumTile</defName>
+		<label>simple titanium tile</label>
+		<renderPrecedence>240</renderPrecedence>
+		<description>Simple titanium square tiles.</description>
+		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
+		<color>(160,178,181)</color>
+		<statBases>
+			<WorkToBuild>4080</WorkToBuild>
+			<Beauty>8</Beauty>
+			<Cleanliness>0.4</Cleanliness>
+			<CleaningTimeFactor>0.5</CleaningTimeFactor>
+			<FilthMultiplier>0.8</FilthMultiplier>
+		</statBases>
+		<costList>
+			<Titanium>4</Titanium>
+		</costList>
+		<researchPrerequisites>
+			<li>Metal_floor_D1</li>
+		</researchPrerequisites>
+	</TerrainDef>
+
+	<!-- ============ Beta Poly Tile ============ -->
+
+	<TerrainDef ParentName="MetalTileBase">
+		<defName>BetaPolyTile</defName>
+		<label>simple beta poly tile</label>
+		<renderPrecedence>240</renderPrecedence>
+		<description>Simple beta poly square tiles.</description>
+		<texturePath>Terrain/Surfaces/GenericFloorTile</texturePath>
+		<color>(100,60,60)</color>
+		<statBases>
+			<WorkToBuild>5090</WorkToBuild>
+			<Beauty>11</Beauty>
+			<Cleanliness>0.55</Cleanliness>
+			<CleaningTimeFactor>0.4</CleaningTimeFactor>
+			<FilthMultiplier>0.6</FilthMultiplier>
+		</statBases>
+		<costList>
+			<BetaPoly>4</BetaPoly>
+		</costList>
+		<researchPrerequisites>
+			<li>Metal_floor_D1</li>
+		</researchPrerequisites>
+		<terrainAffordanceNeeded>Medium</terrainAffordanceNeeded>
+	</TerrainDef>
+
 	<!-- ============ Gold Tile ============ -->
 
 	<TerrainDef  ParentName="MetalTileBase">

--- a/Mods/Core_SK/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/ArchitectSense.DesignationSubCategoryDefs/SubCategories.xml
@@ -334,8 +334,8 @@
 	<SubCategory_MetalTiles.label>металл</SubCategory_MetalTiles.label> 
 	<SubCategory_MetalTiles.description>Металлические поверхности.\n\nПривлекательность: 3</SubCategory_MetalTiles.description>
 	
-	<SubCategory_PlateMetalTiles.label>металлическая плитка</SubCategory_PlateMetalTiles.label> 
-	<SubCategory_PlateMetalTiles.description>Металлическая плитка.\n\nПривлекательность: 2</SubCategory_PlateMetalTiles.description> 
+	<SubCategory_PlateMetalTiles.label>металлические пластины</SubCategory_PlateMetalTiles.label> 
+	<SubCategory_PlateMetalTiles.description>Металлические пластины.\n\nПривлекательность: 2</SubCategory_PlateMetalTiles.description> 
 	
 	<SubCategory_PreciousMetalTiles.label>металлические плиты</SubCategory_PreciousMetalTiles.label> 
 	<SubCategory_PreciousMetalTiles.description>Металлические плиты.\n\nПривлекательность: 3-10</SubCategory_PreciousMetalTiles.description> 

--- a/Mods/Core_SK/Languages/Russian/DefInjected/TerrainDef/Terrain_Floors_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/TerrainDef/Terrain_Floors_SK.xml
@@ -77,6 +77,15 @@
 	<TinTile.label>Оловянная плитка</TinTile.label>
 	<TinTile.description>Белое оловянное металлическое покрытие.</TinTile.description>
 
+	<AluminiumTile.label>Алюминиевая плитка</AluminiumTile.label>
+	<AluminiumTile.description>Алюминиевое металлическое покрытие.</AluminiumTile.description>
+
+	<CupronickelTile.label>Мельхиоровая плитка</CupronickelTile.label>
+	<CupronickelTile.description>Мельхиоровое металлическое покрытие.</CupronickelTile.description>
+
+	<SteinTile.label>Штейновая плитка</SteinTile.label>
+	<SteinTile.description>Штейновое металлическое покрытие.</SteinTile.description>
+
 	<MetalTileTwo.label>Чёрное металл. покрытие</MetalTileTwo.label>
 	<MetalTileTwo.description>Металлическое покрытие для истинных злодеев. Мухахаха.</MetalTileTwo.description>
 
@@ -85,6 +94,12 @@
 
 	<MetalTileFour.label>Белое металл. покрытие</MetalTileFour.label>
 	<MetalTileFour.description>Почувствуй себя в звездолете!</MetalTileFour.description>
+
+	<TitaniumTile.label>Титановая плитка</TitaniumTile.label>
+	<TitaniumTile.description>Титановое металлическое покрытие.</TitaniumTile.description>
+
+	<BetaPolyTile.label>Бета-полимерная плитка</BetaPolyTile.label>
+	<BetaPolyTile.description>Бета-полимерное покрытие.</BetaPolyTile.description>
 
 	
 	


### PR DESCRIPTION
1 added some new metallic floors to fill gaps in "Metal floor III" and "Metal floor V" researches, its empty now (added: aluminium tile, melchior tile, stein tile for "Metal floor III" and titanium tile, beta poly tile for "Metal floor V");
2 fixed "Plate metal tile" sub category in russian translation.

1 добавлено несколько новых металлических полов, чтобы заполнить пробелы в исследованиях "Металлические покрытия III" и "Металлические покрытия V", сейчас они пусты (добавлены: алюминиевая плитка, мельхиоровая плитка, штейновая плитка для "Металлические покрытия III" и титановая плитка, бета-полимерная плитка для "Металлические покрытия V");
2 исправлено наименование категории с металлическими пластинами (сейчас она называется "Металлическая плитка", будет называться "Металлические пластины").
