### PR TITLE
Some Tribal Faction tweaks and fixes

### DIFF
--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Tribe.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Tribe.xml
@@ -63,6 +63,7 @@
 			<points>
 				<li>(0, 4)</li>
 				<li>(1000, 3)</li>
+				<li>(1400, 2.5)</li>
 				<li>(2500, 1)</li>
 				<li>(5000, 0.6)</li>
 				<li>(7000, 0.35)</li>
@@ -73,8 +74,10 @@
 		<maxPawnCostPerTotalPointsCurve>
 			<points>
 				<li>(0,90)</li>
-				<li>(300, 130)</li>
-				<li>(600, 190)</li>
+				<li>(400, 110)</li> <!-- The player starts with an average of 350 points, ​​lower values are meaningless -->
+				<li>(600, 120)</li>
+				<li>(1000, 130)</li>
+				<li>(1400, 190)</li>
 				<li>(100000, 10000)</li>
 			</points>
 		</maxPawnCostPerTotalPointsCurve>
@@ -106,7 +109,7 @@
 					<Tribal_Hunter>10</Tribal_Hunter>
 					<Tribal_HeavyArcher>10</Tribal_HeavyArcher>
 					<Tribal_Berserker>5</Tribal_Berserker>
-					<Tribal_Demoman>4</Tribal_Demoman>
+					<Tribal_Demoman>2</Tribal_Demoman>
 					<Tribal_ChiefRanged>3</Tribal_ChiefRanged>
 					<Tribal_ChiefMelee>1.5</Tribal_ChiefMelee>
 				</options>
@@ -120,7 +123,7 @@
 					<Tribal_Hunter>10</Tribal_Hunter>
 					<Tribal_HeavyArcher>10</Tribal_HeavyArcher>
 					<Tribal_ChiefRanged>5</Tribal_ChiefRanged>
-					<Tribal_Demoman>3</Tribal_Demoman>
+					<Tribal_Demoman>1.5</Tribal_Demoman>
 				</options>
 			</li>
 			<li>
@@ -132,7 +135,7 @@
 					<Tribal_Warrior>10</Tribal_Warrior>
 					<Tribal_Berserker>10</Tribal_Berserker>
 					<Tribal_ChiefMelee>5</Tribal_ChiefMelee>
-					<Tribal_Demoman>2</Tribal_Demoman>
+					<Tribal_Demoman>1</Tribal_Demoman>
 				</options>
 			</li>
 			<li>

--- a/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Tribal.xml
+++ b/Mods/Core_SK/Defs/PawnKindDefs_Humanlikes/PawnKinds_Tribal.xml
@@ -359,7 +359,7 @@
 		<defName>Tribal_Demoman</defName>
 		<label>Demoman</label>
 		<race>Human</race>
-		<combatPower>150</combatPower>
+		<combatPower>130</combatPower>
 		<maxGenerationAge>45</maxGenerationAge>
 		<canBeSapper>true</canBeSapper>
 		<isGoodBreacher>true</isGoodBreacher>
@@ -383,7 +383,7 @@
 			<max>600</max>
 		</weaponMoney>
 		<weaponTags>
-			<li>CE_GrenadeNeolithic</li>
+			<li>GrenadeFlameNeolithic</li>
 		</weaponTags>
 		<disallowedTraits>
 			<li>Brawler</li>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/PawnKindDef/PawnKinds_Tribal.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/PawnKindDef/PawnKinds_Tribal.xml
@@ -2,9 +2,21 @@
 <LanguageData>
   
   <!-- EN: demoman -->
-  <Tribal_Demoman.label>подрывник</Tribal_Demoman.label>
-  <Tribal_Demoman.labelFemale>подрывница</Tribal_Demoman.labelFemale>
-  <Tribal_Demoman.labelMale>подрывник</Tribal_Demoman.labelMale>
-  <Tribal_Demoman.labelPlural>подрывники</Tribal_Demoman.labelPlural>
+  <Tribal_Demoman.label>поджигатель</Tribal_Demoman.label>
+  <Tribal_Demoman.labelFemale>поджигательница</Tribal_Demoman.labelFemale>
+  <Tribal_Demoman.labelMale>поджигатель</Tribal_Demoman.labelMale>
+  <Tribal_Demoman.labelPlural>поджигатели</Tribal_Demoman.labelPlural>
+  
+  <!-- EN: boomer -->
+  <CE_Tribal_Grenadier.label>подрывник</CE_Tribal_Grenadier.label>
+  <CE_Tribal_Grenadier.labelFemale>подрывница</CE_Tribal_Grenadier.labelFemale>
+  <CE_Tribal_Grenadier.labelMale>подрывник</CE_Tribal_Grenadier.labelMale>
+  <CE_Tribal_Grenadier.labelPlural>подрывники</CE_Tribal_Grenadier.labelPlural>
+  
+  <!-- EN: thunderer -->
+  <CE_Tribal_Gunner.label>громовержец</CE_Tribal_Gunner.label>
+  <CE_Tribal_Gunner.labelFemale>громовержица</CE_Tribal_Gunner.labelFemale>
+  <CE_Tribal_Gunner.labelMale>громовержец</CE_Tribal_Gunner.labelMale>
+  <CE_Tribal_Gunner.labelPlural>громовержцы</CE_Tribal_Gunner.labelPlural>
   
 </LanguageData>

--- a/Mods/Core_SK/Patches/CombatExtended/PawnKindDefs/PawnKinds_CE.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/PawnKindDefs/PawnKinds_CE.xml
@@ -50,7 +50,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/PawnKindDef[defName="CE_Tribal_Gunner"]/combatPower</xpath>
 		<value>
-			<combatPower>120</combatPower>
+			<combatPower>140</combatPower>
 		</value>
 	</Operation>
 


### PR DESCRIPTION
ENG:
1 Fixed a bug where the number of grenadiers in tribal faction raids was doubled.
2 Tribal factions have been given a small number of pawns with primitive incendiary grenades (the total number of grenadiers will still be less).
3 The cost of tribal pawns and the curves of dependence of tribal raids on the cost of the colony has been adjusted. Now they will correctly take into account the starting cost of the colony and the danger of tribal raids will gradually increase as the game progresses (now the game almost immediately dumps the entire available arsenal of tribal raids on the player).
4 Added missed tribal's pawns russian translations.

RUS
1 Исправлена ошибка, из-за которой количество гренадеров у рейдов племенных фракции удваивалось.
2 Племенным фракциям добавлено небольшое количество пешек с примитивными зажигательными гранатами (общее число гренадеров все равно будет меньше при этом, чем до изменений).
3 Скорректированы стоимости племенных пешек и кривые зависимости племенных набегов от стоимости колонии. Теперь они будут корректно учитывать стартовую стоимость колонии и опасность племенных набегов будет постепенно увеличиваться по ходу игры (Сейчас игра практически сразу вываливает на игрока весь доступный арсенал племенных набегов).
4 Добавлены пропущенные переводы некоторых племенных пешек.