### PR TITLE
Fix CoreTranslation mod load order

### DIFF
--- a/Mods/CoreTranslation/About/About.xml
+++ b/Mods/CoreTranslation/About/About.xml
@@ -17,6 +17,9 @@
 	</modDependencies>
 	<loadBefore>
 		<li>skyarkhangel.HSK</li>
+		<li>skyarkhangel.royaltytranslation</li>
+		<li>skyarkhangel.ideologytranslation</li>
+		<li>skyarkhangel.biotechtranslation</li>
 	</loadBefore>
 	<loadAfter>
 		<li>brrainz.harmony</li>	


### PR DESCRIPTION
Incorrect CoreTranslation load order breaks russian-sk language to properly load injected translations and apply necessary patches.

This mod should be loaded before any CoreTranslation.* mods.