### PR TITLE
RT_Fuse: Correct discharge values for Eng and Ger

### DIFF
--- a/Mods/RT_Fuse/Languages/English/DefInjected/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
+++ b/Mods/RT_Fuse/Languages/English/DefInjected/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
@@ -2,6 +2,6 @@
 <LanguageData>
 
 	<ResearchProject_RTBasicFuses.label>basic fuses</ResearchProject_RTBasicFuses.label>
-	<ResearchProject_RTBasicFuses.description>Allows building makeshift fuses; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 1800 Wd (three standard batteries) discharge, but will require repairs if tripped.</ResearchProject_RTBasicFuses.description>
+	<ResearchProject_RTBasicFuses.description>Allows building makeshift fuses; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 3000 Wd (three standard batteries) discharge, but will require repairs if tripped.</ResearchProject_RTBasicFuses.description>
 
 </LanguageData>

--- a/Mods/RT_Fuse/Languages/English/DefInjected/ResearchProjectDefs/ResearchProject_RTCircuitBreakers.xml
+++ b/Mods/RT_Fuse/Languages/English/DefInjected/ResearchProjectDefs/ResearchProject_RTCircuitBreakers.xml
@@ -2,6 +2,6 @@
 <LanguageData>
 
 	<ResearchProject_RTCircuitBreakers.label>circuit breakers</ResearchProject_RTCircuitBreakers.label>
-	<ResearchProject_RTCircuitBreakers.description>Allows building circuit breakers; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 1800 Wd (three standard batteries) discharge, and will need to be manually reset if tripped.</ResearchProject_RTCircuitBreakers.description>
+	<ResearchProject_RTCircuitBreakers.description>Allows building circuit breakers; can be placed anywhere on a power network with batteries. Each one is enough to safely dissipate up to 6000 Wd (six standard batteries) discharge, and will need to be manually reset if tripped.</ResearchProject_RTCircuitBreakers.description>
 
 </LanguageData>

--- a/Mods/RT_Fuse/Languages/English/DefInjected/ThingDefs/Building_RTCircuitBreaker.xml
+++ b/Mods/RT_Fuse/Languages/English/DefInjected/ThingDefs/Building_RTCircuitBreaker.xml
@@ -2,6 +2,6 @@
 <LanguageData>
 
 	<Building_RTCircuitBreaker.label>circuit breaker</Building_RTCircuitBreaker.label>
-	<Building_RTCircuitBreaker.description>A set of automatic circuit breakers. Handles up to 1800 Wd discharge, will flick off if tripped.</Building_RTCircuitBreaker.description>
+	<Building_RTCircuitBreaker.description>A set of automatic circuit breakers. Handles up to 6000 Wd discharge, will flick off if tripped.</Building_RTCircuitBreaker.description>
 
 </LanguageData>

--- a/Mods/RT_Fuse/Languages/English/DefInjected/ThingDefs/Building_RTMakeshiftFuse.xml
+++ b/Mods/RT_Fuse/Languages/English/DefInjected/ThingDefs/Building_RTMakeshiftFuse.xml
@@ -2,6 +2,6 @@
 <LanguageData>
 
 	<Building_RTMakeshiftFuse.label>makeshift fuse</Building_RTMakeshiftFuse.label>
-	<Building_RTMakeshiftFuse.description>A simple fuse. Handles up to 1800 Wd discharge, will require repairs if tripped.</Building_RTMakeshiftFuse.description>
+	<Building_RTMakeshiftFuse.description>A simple fuse. Handles up to 3000 Wd discharge, will require repairs if tripped.</Building_RTMakeshiftFuse.description>
 
 </LanguageData>

--- a/Mods/RT_Fuse/Languages/German/DefInjected/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
+++ b/Mods/RT_Fuse/Languages/German/DefInjected/ResearchProjectDefs/ResearchProject_RTBasicFuses.xml
@@ -2,6 +2,6 @@
 <LanguageData>
 
 	<ResearchProject_RTBasicFuses.label>Basis Sicherungen</ResearchProject_RTBasicFuses.label>
-	<ResearchProject_RTBasicFuses.description>Erlaubt es provisorische Sicherungen zu bauen; kann überall am Stromnetz mit Batterien angeschlossen werden. Jedes kann bis zu 1800 W (drei standard Batterien) absichern. Benötigt Reparatur, wenn ausgelöst.</ResearchProject_RTBasicFuses.description>
+	<ResearchProject_RTBasicFuses.description>Erlaubt es provisorische Sicherungen zu bauen; kann überall am Stromnetz mit Batterien angeschlossen werden. Jedes kann bis zu 3000 W (drei standard Batterien) absichern. Benötigt Reparatur, wenn ausgelöst.</ResearchProject_RTBasicFuses.description>
 
 </LanguageData>

--- a/Mods/RT_Fuse/Languages/German/DefInjected/ResearchProjectDefs/ResearchProject_RTCircuitBreakers.xml
+++ b/Mods/RT_Fuse/Languages/German/DefInjected/ResearchProjectDefs/ResearchProject_RTCircuitBreakers.xml
@@ -2,6 +2,6 @@
 <LanguageData>
 
 	<ResearchProject_RTCircuitBreakers.label>Leistungsschalter</ResearchProject_RTCircuitBreakers.label>
-	<ResearchProject_RTCircuitBreakers.description>Erlaubt es Leistungsschalter zu bauen; kann überall am Stromnetz mit Batterien angeschlossen werden. Jedes kann bis zu 1800 W (drei standard Batterien) absichern. Benötigt manuelles umschalten, wenn ausgelöst.</ResearchProject_RTCircuitBreakers.description>
+	<ResearchProject_RTCircuitBreakers.description>Erlaubt es Leistungsschalter zu bauen; kann überall am Stromnetz mit Batterien angeschlossen werden. Jedes kann bis zu 6000 W (sechs standard Batterien) absichern. Benötigt manuelles umschalten, wenn ausgelöst.</ResearchProject_RTCircuitBreakers.description>
 
 </LanguageData>

--- a/Mods/RT_Fuse/Languages/German/DefInjected/ThingDefs/Building_RTCircuitBreaker.xml
+++ b/Mods/RT_Fuse/Languages/German/DefInjected/ThingDefs/Building_RTCircuitBreaker.xml
@@ -2,6 +2,6 @@
 <LanguageData>
 
 	<Building_RTCircuitBreaker.label>Leistungsschalter</Building_RTCircuitBreaker.label>
-	<Building_RTCircuitBreaker.description>Ein Satz von automatischen Leistungsschaltern. Absicherung bis 1800 W und wiederverwendbar nach Auslösung mittels Schalter.</Building_RTCircuitBreaker.description>
+	<Building_RTCircuitBreaker.description>Ein Satz von automatischen Leistungsschaltern. Absicherung bis 6000 W und wiederverwendbar nach Auslösung mittels Schalter.</Building_RTCircuitBreaker.description>
 
 </LanguageData>

--- a/Mods/RT_Fuse/Languages/German/DefInjected/ThingDefs/Building_RTMakeshiftFuse.xml
+++ b/Mods/RT_Fuse/Languages/German/DefInjected/ThingDefs/Building_RTMakeshiftFuse.xml
@@ -2,6 +2,6 @@
 <LanguageData>
 
 	<Building_RTMakeshiftFuse.label>Provisorische Sicherung</Building_RTMakeshiftFuse.label>
-	<Building_RTMakeshiftFuse.description>Eine einfache Sicherung. Absicherung bis 1800 W. Benötigt nach Auslösung eine Reparatur.</Building_RTMakeshiftFuse.description>
+	<Building_RTMakeshiftFuse.description>Eine einfache Sicherung. Absicherung bis 3000 W. Benötigt nach Auslösung eine Reparatur.</Building_RTMakeshiftFuse.description>
 
 </LanguageData>


### PR DESCRIPTION
Fix discharge values for English and German locale.
Affected items: [Makeshift fuse, Circuit Breaker]

Issue description: 
[Issue-3925](https://github.com/skyarkhangel/Hardcore-SK/issues/3925)