### PR TITLE
lowered needed level to advance tech level

### DIFF
--- a/Config/Mod_TechAdvancing_SettingController.xml
+++ b/Config/Mod_TechAdvancing_SettingController.xml
@@ -19,7 +19,7 @@
 			<values>
 				<li>0</li>
 				<li>1</li>
-				<li>85</li>
+				<li>75</li>
 				<li>0</li>
 				<li>0</li>
 				<li>0</li>


### PR DESCRIPTION
85% to advance a level is just too much.
- Right now Classic start has neolithic level which brings a variety of problems and I think it already has too many researches
- Having a bit lower requirement means players can skip most useless techs and not clog his building/recipe menues (for example snow techs are useless 90% of the time) and also help people with addons since they also add their own techs

Classic start has 79% of techs now which means they get nature shrines, but no landing markers for shuttles 
![image](https://github.com/user-attachments/assets/d436f1c0-a405-46d1-a2cd-a76e28490a7c)
