### PR TITLE
Fix ru translation for diseases.

### DIFF
--- a/Mods/Core_SK/Languages/Russian/DefInjected/IncidentDef/Incidents_Map_Disease_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/IncidentDef/Incidents_Map_Disease_SK.xml
@@ -1,44 +1,36 @@
-﻿<?xml version="1.0" encoding="utf-8"?>
+<?xml version="1.0" encoding="utf-8"?>
 <LanguageData>
 
   <Disease_CommonCold.label>простуда</Disease_CommonCold.label>
-  <Disease_CommonCold.letterText>У {0} из ваших поселенцев {2}.\n\nУбедитесь, что у вас есть медицинская кровать и врач. Удостоверьтесь, что они получат надлежащее лечение и проводят как можно больше времени в постели
-\nНа симптомы жалуются следующие {1}:\n\n{3}</Disease_CommonCold.letterText>
-  <Disease_CommonCold.letterLabel>простуда</Disease_CommonCold.letterLabel>
+  <Disease_CommonCold.letterText>У {0} из ваших поселенцев обнаружена {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_CommonCold.letterText>
+  <Disease_CommonCold.letterLabel>Болезнь: простуда</Disease_CommonCold.letterLabel>
 
   <Disease_strepthroat.label>ангина</Disease_strepthroat.label>
-  <Disease_strepthroat.letterText>У {0} из ваших поселенцев {2}.\n\nУбедитесь, что у вас есть медицинская кровать и врач. Удостоверьтесь, что они получат надлежащее лечение и проводят как можно больше времени в постели
-\nНа симптомы жалуются следующие {1}:\n\n{3}</Disease_strepthroat.letterText>
-  <Disease_strepthroat.letterLabel>ангина</Disease_strepthroat.letterLabel>
+  <Disease_strepthroat.letterText>У {0} из ваших поселенцев обнаружена {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_strepthroat.letterText>
+  <Disease_strepthroat.letterLabel>Болезнь: ангина</Disease_strepthroat.letterLabel>
 
   <Disease_earache.label>ушная боль</Disease_earache.label>
-  <Disease_earache.letterText>У {0} из ваших поселенцев {2}.\n\nУбедитесь, что у вас есть медицинская кровать и врач. Удостоверьтесь, что они получат надлежащее лечение и проводят как можно больше времени в постели
-\nНа симптомы жалуются следующие {1}:\n\n{3}</Disease_earache.letterText>
-  <Disease_earache.letterLabel>ушная боль</Disease_earache.letterLabel>
+  <Disease_earache.letterText>У {0} из ваших поселенцев обнаружена {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_earache.letterText>
+  <Disease_earache.letterLabel>Болезнь: ушная боль</Disease_earache.letterLabel>
 
   <Disease_Fever.label>лихорадка</Disease_Fever.label>
-  <Disease_Fever.letterText>У {0} из ваших поселенцев {2}.\n\nУбедитесь, что у вас есть медицинская кровать и врач. Удостоверьтесь, что они получат надлежащее лечение и проводят как можно больше времени в постели
-\nНа симптомы жалуются следующие {1}:\n\n{3}</Disease_Fever.letterText>
-  <Disease_Fever.letterLabel>лихорадка</Disease_Fever.letterLabel>
+  <Disease_Fever.letterText>У {0} из ваших поселенцев обнаружена {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_Fever.letterText>
+  <Disease_Fever.letterLabel>Болезнь: лихорадка</Disease_Fever.letterLabel>
 
   <Disease_Ebola.label>эбола</Disease_Ebola.label>
-  <Disease_Ebola.letterText>У {0} из ваших поселенцев {2}.\n\nУбедитесь, что у вас есть медицинская кровать и врач. Удостоверьтесь, что они получат надлежащее лечение и проводят как можно больше времени в постели
-\nНа симптомы жалуются следующие {1}:\n\n{3}</Disease_Ebola.letterText>
-  <Disease_Ebola.letterLabel>эбола</Disease_Ebola.letterLabel>
+  <Disease_Ebola.letterText>У {0} из ваших поселенцев обнаружена {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_Ebola.letterText>
+  <Disease_Ebola.letterLabel>Болезнь: эбола</Disease_Ebola.letterLabel>
 
   <Disease_Measles.label>корь</Disease_Measles.label>
-  <Disease_Measles.letterText>У {0} из ваших поселенцев {2}.\n\nУбедитесь, что у вас есть медицинская кровать и врач. Удостоверьтесь, что они получат надлежащее лечение и проводят как можно больше времени в постели.
-\nНа симптомы жалуются следующие {1}:\n\n{3}</Disease_Measles.letterText>
-  <Disease_Measles.letterLabel>корь</Disease_Measles.letterLabel>
+  <Disease_Measles.letterText>У {0} из ваших поселенцев обнаружена {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_Measles.letterText>
+  <Disease_Measles.letterLabel>Болезнь: корь</Disease_Measles.letterLabel>
 
   <Disease_Pneumonia.label>пневмония</Disease_Pneumonia.label>
-  <Disease_Pneumonia.letterText>У {0} из ваших поселенцев {2}.\n\nУбедитесь, что у вас есть медицинская кровать и врач. Удостоверьтесь, что они получат надлежащее лечение и проводят как можно больше времени в постели.
-\nНа симптомы жалуются следующие {1}:\n\n{3}</Disease_Pneumonia.letterText>
-  <Disease_Pneumonia.letterLabel>пневмония</Disease_Pneumonia.letterLabel>
+  <Disease_Pneumonia.letterText>У {0} из ваших поселенцев обнаружена {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_Pneumonia.letterText>
+  <Disease_Pneumonia.letterLabel>Болезнь: пневмония</Disease_Pneumonia.letterLabel>
   
   <Disease_Coronavirus.label>коронавирус</Disease_Coronavirus.label>
-  <Disease_Coronavirus.letterText>У {0} из ваших поселенцев {2}.\n\nУбедитесь, что у вас есть медицинская кровать и врач. Удостоверьтесь, что они получат надлежащее лечение и проводят как можно больше времени в постели.
-\nНа симптомы жалуются следующие {1}:\n\n{3}</Disease_Coronavirus.letterText>
-  <Disease_Coronavirus.letterLabel>коронавирус</Disease_Coronavirus.letterLabel>
+  <Disease_Coronavirus.letterText>У {0} из ваших поселенцев обнаружена {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_Coronavirus.letterText>
+  <Disease_Coronavirus.letterLabel>Болезнь: коронавирус</Disease_Coronavirus.letterLabel>
 
 </LanguageData>

--- a/Mods/Core_SK/Languages/Russian/DefInjected/IncidentDef/Incidents_Map_Disease_SK.xml
+++ b/Mods/Core_SK/Languages/Russian/DefInjected/IncidentDef/Incidents_Map_Disease_SK.xml
@@ -30,7 +30,7 @@
   <Disease_Pneumonia.letterLabel>Болезнь: пневмония</Disease_Pneumonia.letterLabel>
   
   <Disease_Coronavirus.label>коронавирус</Disease_Coronavirus.label>
-  <Disease_Coronavirus.letterText>У {0} из ваших поселенцев обнаружена {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_Coronavirus.letterText>
+  <Disease_Coronavirus.letterText>У {0} из ваших поселенцев обнаружен {2}.\n\nУбедитесь, что у вас есть медицинская кровать и доктор. Заболевшие нуждаются в надлежащем лечении и постельном режиме.\n\nНа симптомы жалуются следующие {1}</Disease_Coronavirus.letterText>
   <Disease_Coronavirus.letterLabel>Болезнь: коронавирус</Disease_Coronavirus.letterLabel>
 
 </LanguageData>


### PR DESCRIPTION
`letterText` and `letterLabel` values are changed to match a vanilla description of diseases.
Also it will fix "cannot resolve {3} argument" error if ru translation is selected in game.