### PR TITLE
1.5 fixes for Darkest Night mod.

### DIFF
--- a/Mods/DarkestNight_SK/Defs/GameConditionDefs/MapConditions_Darkest.xml
+++ b/Mods/DarkestNight_SK/Defs/GameConditionDefs/MapConditions_Darkest.xml
@@ -8,6 +8,8 @@
     <endMessage>The darkness is gone</endMessage>
     <exclusiveConditions>
         <li>UnnaturalDarkness</li>
+        <li>BloodRain</li>
+        <li>DeathPall</li>
     </exclusiveConditions>
   </GameConditionDef>
 

--- a/Mods/DarkestNight_SK/Defs/GameConditionDefs/MapConditions_Darkest.xml
+++ b/Mods/DarkestNight_SK/Defs/GameConditionDefs/MapConditions_Darkest.xml
@@ -6,6 +6,9 @@
     <label>Darkness</label>
     <description>An unusual dark and cold... night.</description>
     <endMessage>The darkness is gone</endMessage>
+    <exclusiveConditions>
+        <li>UnnaturalDarkness</li>
+    </exclusiveConditions>
   </GameConditionDef>
 
 </Defs>

--- a/Mods/DarkestNight_SK/Defs/ThingDefs/Races_Darkest.xml
+++ b/Mods/DarkestNight_SK/Defs/ThingDefs/Races_Darkest.xml
@@ -57,6 +57,7 @@
 			<intelligence>Animal</intelligence>
 			<thinkTreeMain>Void</thinkTreeMain>
 			<body>QuadrupedAnimalWithHooves</body>
+			<renderTree>Animal</renderTree>
 			<needsRest>false</needsRest>
 			<makesFootprints>false</makesFootprints>
 			<hasGenders>false</hasGenders>

--- a/Mods/DarkestNight_SK/Patches/UpdateAnomalyEvents.xml
+++ b/Mods/DarkestNight_SK/Patches/UpdateAnomalyEvents.xml
@@ -1,9 +1,10 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
+
     <Operation Class="PatchOperationConditional">
-        <xpath>/Defs/GameConditionDef[defName = "UnnaturalDarkness"]/exclusiveConditions</xpath>
+        <xpath>/Defs/GameConditionDef[defName = "UnnaturalDarkness" or defName = "BloodRain" or defName = "DeathPall"]/exclusiveConditions</xpath>
         <nomatch Class="PatchOperationAdd">
-            <xpath>/Defs/GameConditionDef[defName = "UnnaturalDarkness"]</xpath>
+            <xpath>/Defs/GameConditionDef[defName = "UnnaturalDarkness" or defName = "BloodRain" or defName = "DeathPall"]</xpath>
             <value>
                 <exclusiveConditions>
                     <li>Darkness</li>
@@ -11,7 +12,7 @@
             </value>
         </nomatch>
         <match Class="PatchOperationAdd">
-            <xpath>/Defs/GameConditionDef[defName = "UnnaturalDarkness"]/exclusiveConditions</xpath>
+            <xpath>/Defs/GameConditionDef[defName = "UnnaturalDarkness" or defName = "BloodRain" or defName = "DeathPall"]/exclusiveConditions</xpath>
             <value>
                 <li>Darkness</li>
             </value>

--- a/Mods/DarkestNight_SK/Patches/UpdateUnnaturalDarknessAnomalyEvent.xml
+++ b/Mods/DarkestNight_SK/Patches/UpdateUnnaturalDarknessAnomalyEvent.xml
@@ -1,0 +1,21 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Patch>
+    <Operation Class="PatchOperationConditional">
+        <xpath>/Defs/GameConditionDef[defName = "UnnaturalDarkness"]/exclusiveConditions</xpath>
+        <nomatch Class="PatchOperationAdd">
+            <xpath>/Defs/GameConditionDef[defName = "UnnaturalDarkness"]</xpath>
+            <value>
+                <exclusiveConditions>
+                    <li>Darkness</li>
+                </exclusiveConditions>
+            </value>
+        </nomatch>
+        <match Class="PatchOperationAdd">
+            <xpath>/Defs/GameConditionDef[defName = "UnnaturalDarkness"]/exclusiveConditions</xpath>
+            <value>
+                <li>Darkness</li>
+            </value>
+        </match>
+    </Operation>
+
+</Patch>


### PR DESCRIPTION
Small configuration changes to support new 1.5 pawn render system. Also forbid `Darkness` game condition if `UnnaturalDarkness` or `BloodRain` or `DeathPall` from Anomaly DLC is active (and vice versa).
**Main Darkest Night assembly is updated and available in hsk-source repo as PR.**