### PR TITLE
Add HSK diseases to Perfect Immunity gene

### DIFF
--- a/Mods/Core_SK/Patches/GeneDefs.xml
+++ b/Mods/Core_SK/Patches/GeneDefs.xml
@@ -1,0 +1,19 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+
+	<Operation Class="PatchOperationAdd">
+	  <xpath>Defs/GeneDef[defName = "PerfectImmunity"]/makeImmuneTo</xpath>
+	  <value>
+		  <li>CommonCold</li>
+		  <li>StrepThroat</li>
+		  <li>Earache</li>
+		  <li>Fever</li>
+		  <li>Ebola</li>
+		  <li>Measles</li>
+		  <li>Pneumonia</li>
+		  <li>Coronavirus</li>
+	  </value>
+	</Operation>	
+	
+</Patch>


### PR DESCRIPTION
1. Gene description: "...They are totally immune to most normal illnesses."
2. HSK diseases are pretty normal illnesses.
Therefore, we add them to the gene's immunity list.