### PR TITLE
Changed altitude layer of trees to avoid clipping behind walls

### DIFF
--- a/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Base.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Plants/Plants_Base.xml
@@ -226,7 +226,7 @@
 			<Mass>150</Mass>
 		</statBases>
 		<description>A tree.</description>
-		<altitudeLayer>Building</altitudeLayer>
+		<altitudeLayer>BuildingOnTop</altitudeLayer>
 		<selectable>true</selectable>
 		<fillPercent>0.26</fillPercent>
 		<minifiedDef>MinifiedTree</minifiedDef>


### PR DESCRIPTION
Often top of the trees clip behind walls, especially if using Vile's textures, I've changed it to render in front of the walls for better look