### PR TITLE
Added back quality to Gun Links

### DIFF
--- a/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/Apparel_Various.xml
+++ b/Mods/Core_SK/Royalty/Patches/ThingDefs_Misc/Apparel_Various.xml
@@ -394,5 +394,14 @@
 			<li>AdvToolBench</li>
 		</value>
 	</Operation>
+	
+	<Operation Class="PatchOperationAdd">
+		<xpath>Defs/ThingDef[defName="Apparel_Gunlink"]/comps</xpath>
+		<value>
+			<li>
+			<compClass>CompQuality</compClass>
+			</li>
+		</value>
+  </Operation>
 
 </Patch>


### PR DESCRIPTION
Added back quality comp to Gun Links that got removed in 1.5.4241 which causes pawns unable to equip them if You restrict their outifts quality