### PR TITLE
Fixes duplicated resource readout when selecting ores

### DIFF
--- a/Mods/Minerals/Defs/ThingDefs_Rocks/OresBase.xml
+++ b/Mods/Minerals/Defs/ThingDefs_Rocks/OresBase.xml
@@ -23,7 +23,7 @@
     <randomlyDropResources>
       <li>
         <ResourceDefName>RoughGem</ResourceDefName>
-        <DropProbability>0</DropProbability>
+        <DropProbability>0.01</DropProbability>
       </li>
     </randomlyDropResources>
     <!-- The probability that this mineral type will be spawned at all on a given map -->

--- a/Mods/Minerals/Defs/ThingDefs_Rocks/OresBase.xml
+++ b/Mods/Minerals/Defs/ThingDefs_Rocks/OresBase.xml
@@ -8,7 +8,7 @@
     <building>
       <isResourceRock>true</isResourceRock>
       <mineableThing>RoughGem</mineableThing>
-      <mineableDropChance>0.01</mineableDropChance>
+      <mineableDropChance>0</mineableDropChance>
       <mineableYield>1</mineableYield>
       <isInert>true</isInert>
       <canBuildNonEdificesUnder>false</canBuildNonEdificesUnder>
@@ -23,7 +23,7 @@
     <randomlyDropResources>
       <li>
         <ResourceDefName>RoughGem</ResourceDefName>
-        <DropProbability>0.01</DropProbability>
+        <DropProbability>0</DropProbability>
       </li>
     </randomlyDropResources>
     <!-- The probability that this mineral type will be spawned at all on a given map -->
@@ -51,7 +51,7 @@
     <building>
       <isResourceRock>true</isResourceRock>
       <mineableThing>RoughGem</mineableThing>
-      <mineableDropChance>0.01</mineableDropChance>
+      <mineableDropChance>0</mineableDropChance>
       <mineableYield>1</mineableYield>
       <isInert>true</isInert>
       <canBuildNonEdificesUnder>false</canBuildNonEdificesUnder>
@@ -94,7 +94,7 @@
     <building>
       <isResourceRock>true</isResourceRock>
       <mineableThing>RoughGem</mineableThing>
-      <mineableDropChance>0.01</mineableDropChance>
+      <mineableDropChance>0</mineableDropChance>
       <mineableYield>1</mineableYield>
       <isInert>true</isInert>
       <canBuildNonEdificesUnder>false</canBuildNonEdificesUnder>


### PR DESCRIPTION
The base definition for the Minerals Weathered/Solid/Hewn ores includes a RoughGem drop with a chance of 0.01.
All custom minerals override this drop with the type of the ore (i.e WeatheredOreCopper has a mineableThing of Copper), but do not change the drop chance or the yield (Yield being 1, i.e it would drop 1 copper 1% of the time when destroyed), which leads to the UI displaying the main resource a second time, but with a low number. Such as WeatheredOreCopper showing "60 Copper, 0.01 Rough Gems, 0.01 Copper".

Changing the drop chance to 0 removes this extra readout, while having absolutely zero impact on gameplay as it was a drop of 1, 1% of the time. 