### PR TITLE
Fixed incorrect armor parameters for sentipedes and duplicated durability parameters for some mechanoids

### DIFF
--- a/Mods/Core_SK/Patches/CombatExtended/ThingDefs_Races/Races_Mechanoid.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/ThingDefs_Races/Races_Mechanoid.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <Patch>
-
+<!-- 
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[@Name="MechCentipede"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -10,9 +10,9 @@
 			</value>
 		</nomatch>
 	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[@Name="MechCentipede"]/comps</xpath>
+ -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[@Name="MechCentipede"]/comps/li[@Class="CombatExtended.CompProperties_ArmorDurability"]</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>3660</Durability>
@@ -72,7 +72,7 @@
 			</comps>
 		</value>
 	</Operation>-->
-
+<!-- 
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Mech_Scyther"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -82,9 +82,9 @@
 			</value>
 		</nomatch>
 	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Scyther"]/comps</xpath>
+ -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Scyther"]/comps/li[@Class="CombatExtended.CompProperties_ArmorDurability"]</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>1160</Durability>
@@ -108,7 +108,7 @@
 			</li>
 		</value>
 	</Operation>
-
+<!-- 
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Mech_Lancer"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -118,9 +118,9 @@
 			</value>
 		</nomatch>
 	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Lancer"]/comps</xpath>
+ -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Lancer"]/comps/li[@Class="CombatExtended.CompProperties_ArmorDurability"]</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>860</Durability>
@@ -144,7 +144,7 @@
 			</li>
 		</value>
 	</Operation>
-
+<!-- 
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Mech_Pikeman"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -154,9 +154,9 @@
 			</value>
 		</nomatch>
 	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Pikeman"]/comps</xpath>
+ -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Pikeman"]/comps/li[@Class="CombatExtended.CompProperties_ArmorDurability"]</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>1000</Durability>
@@ -256,7 +256,7 @@
 			</tools>
 		</value>
 	</Operation>
-
+<!-- 
 	<Operation Class="PatchOperationConditional">
 		<xpath>Defs/ThingDef[defName="Mech_Termite"]/comps</xpath>
 		<nomatch Class="PatchOperationAdd">
@@ -266,9 +266,9 @@
 			</value>
 		</nomatch>
 	</Operation>
-
-	<Operation Class="PatchOperationAdd">
-		<xpath>Defs/ThingDef[defName="Mech_Termite"]/comps</xpath>
+ -->
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Mech_Termite"]/comps/li[@Class="CombatExtended.CompProperties_ArmorDurability"]</xpath>
 		<value>
 			<li Class="CombatExtended.CompProperties_ArmorDurability">
 				<Durability>1880</Durability>


### PR DESCRIPTION
[ENG]
Fixed incorrect armor parameters for sentipedes (min armor was greater than base armor) and duplicated durability parameters for some mechanoids.
![1](https://github.com/user-attachments/assets/1fa853cd-3342-4f8f-b7a3-c095de36f540)
![2](https://github.com/user-attachments/assets/784cb877-a944-44b9-8302-74e2d8d341d9)


**Core_SK\Patches\CombatExtended\ThingDefs_Races** has mechanoid patches that are duplicated in **CombatExtended\Patches\Core\ThingDefs_Races**. 

I replaced "add" patches with "replace" patches and commented "Operation Class="PatchOperationConditional"" patches because it is already enabled in CE.

After making the changes it looks like this:

![3](https://github.com/user-attachments/assets/90b388d9-946a-4236-9908-6f9282448a6a)

[RUS]
Исправлены некорректные значения брони у сентипед (минимальное значение брони было больше базового) и дублирование значений строк durability у некоторых механоидов (видно на первом и втором скриншотах выше).

В Core_SK были дубликаты патчей CE, произведена замена add на replace, закомментированы PatchOperationConditional в виду их ненужности (результат на третьем скриншоте).