### PR TITLE
Tweaks water tower (Корректировка водонапорной башни)

### DIFF
--- a/Mods/Dubs-Bad-Hygiene/Defs/ThingDefs_Buildings/BuildingsD_WaterManagement.xml
+++ b/Mods/Dubs-Bad-Hygiene/Defs/ThingDefs_Buildings/BuildingsD_WaterManagement.xml
@@ -200,13 +200,12 @@
 		<costList>
 		    <Mechanism>1</Mechanism>
 			<ComponentMedieval>15</ComponentMedieval>
-			<WoodLog>200</WoodLog>
 		</costList>
 		<stuffCategories>
 			<li>Metallic</li>
 			<li>Stony</li>
 		</stuffCategories>
-		<costStuffCount>100</costStuffCount>
+		<costStuffCount>300</costStuffCount>
 		<comps>
 			<li Class="DubsBadHygiene.CompProperties_WaterStorage">
 				<WaterStorageCap>8000</WaterStorageCap>


### PR DESCRIPTION
I suggest replacing 200 wood log in the water tower recipe with 200 costStuffCount, since wood logs is not found in every biome.

Предлагаю заменить 200 ед. древесины в рецепте водонапорной башни на 200 ед. costStuffCount, т.к. чистая древесина встречается не в каждом биоме.