### PR TITLE
Some starting research tweaks and fixes

### DIFF
--- a/Mods/AsariRace/Defs/FactionDefs/Factions_Player.xml
+++ b/Mods/AsariRace/Defs/FactionDefs/Factions_Player.xml
@@ -55,6 +55,7 @@
 		</backstoryFilters>		
 		<startingResearchTags>
 			<li>ClassicStart</li>
+			<li>AsariStart</li>
 		</startingResearchTags>
 		<apparelStuffFilter>
 			<categories>

--- a/Mods/Core_SK/Defs/FactionDefs/Factions_Player.xml
+++ b/Mods/Core_SK/Defs/FactionDefs/Factions_Player.xml
@@ -73,6 +73,7 @@
 		</backstoryFilters>
 		<startingResearchTags>
 			<li>ClassicStart</li>
+			<li>NovaStart</li>
 		</startingResearchTags>
 		<apparelStuffFilter>
 			<categories>
@@ -217,6 +218,7 @@
 		<forageabilityFactor>1.5</forageabilityFactor>
 		<startingResearchTags>
 			<li>TribalStart</li>
+			<li>NorbalStart</li>
 		</startingResearchTags>
 		<apparelStuffFilter>
 			<categories>

--- a/Mods/Core_SK/Defs/Misc/ResearchProjectTagDefs/ResearchProjectTagDefs.xml
+++ b/Mods/Core_SK/Defs/Misc/ResearchProjectTagDefs/ResearchProjectTagDefs.xml
@@ -1,0 +1,16 @@
+﻿<?xml version="1.0" encoding="utf-8" ?>
+<Defs>
+
+  <ResearchProjectTagDef>
+    <defName>NorbalStart</defName>
+  </ResearchProjectTagDef>
+
+  <ResearchProjectTagDef>
+    <defName>NovaStart</defName>
+  </ResearchProjectTagDef>
+
+  <ResearchProjectTagDef>
+    <defName>AsariStart</defName>
+  </ResearchProjectTagDef>
+
+</Defs>

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Animal.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Animal.xml
@@ -24,6 +24,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>51.00</researchViewY>
 		<tab>Animal_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -49,6 +52,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>50.00</researchViewY>
 		<tab>Animal_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechBase">

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Apparel.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Apparel.xml
@@ -10,6 +10,9 @@
 		<researchViewX>1.00</researchViewX>
 		<researchViewY>39.00</researchViewY>
 		<tab>Apparel_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -110,6 +113,9 @@
 		<researchViewX>4.00</researchViewX>
 		<researchViewY>42.00</researchViewY>
 		<tab>Apparel_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -153,6 +159,9 @@
 		<researchViewX>9.00</researchViewX>
 		<researchViewY>40.00</researchViewY>
 		<tab>Apparel_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -167,6 +176,9 @@
 		<researchViewX>9.00</researchViewX>
 		<researchViewY>42.00</researchViewY>
 		<tab>Apparel_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -268,6 +280,9 @@
 		<researchViewX>18.00</researchViewX>
 		<researchViewY>39.00</researchViewY>
 		<tab>Apparel_SK</tab>
+		<tags>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechMultiBase">

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Buildings.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Buildings.xml
@@ -10,6 +10,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>10.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -24,6 +27,9 @@
 		<researchViewX>3.00</researchViewX>
 		<researchViewY>10.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -52,6 +58,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>6.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -149,6 +158,9 @@
 		<researchViewX>3.00</researchViewX>
 		<researchViewY>7.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -203,6 +215,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>8.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -219,6 +234,7 @@
 		<tab>Buildings_SK</tab>
 		<tags>
 			<li>ClassicStart</li>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
 		</tags>
 	</ResearchProjectDef>
 
@@ -234,6 +250,9 @@
 		<researchViewX>7.00</researchViewX>
 		<researchViewY>8.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -324,6 +343,7 @@
 		<tab>Buildings_SK</tab>
 		<tags>
 			<li>ClassicStart</li>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
 		</tags>
 	</ResearchProjectDef>
 
@@ -354,6 +374,10 @@
 		<researchViewX>9.00</researchViewX>
 		<researchViewY>9.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -426,6 +450,7 @@
 		<tab>Buildings_SK</tab>
 		<tags>
 			<li>ClassicStart</li>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
 		</tags>
 	</ResearchProjectDef>
 
@@ -442,6 +467,9 @@
 		<researchViewX>8.00</researchViewX>
 		<researchViewY>11.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -456,6 +484,9 @@
 		<researchViewX>9.00</researchViewX>
 		<researchViewY>11.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -484,6 +515,7 @@
 		<tab>Buildings_SK</tab>
 		<tags>
 			<li>ClassicStart</li>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
 		</tags>
 	</ResearchProjectDef>
 
@@ -559,6 +591,10 @@
 		<researchViewX>7.00</researchViewX>
 		<researchViewY>12.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -655,6 +691,9 @@
 		<researchViewX>4.00</researchViewX>
 		<researchViewY>14.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -957,6 +996,10 @@
 		<researchViewX>10.00</researchViewX>
 		<researchViewY>16.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -1114,6 +1157,9 @@
 		<researchViewX>17.00</researchViewX>
 		<researchViewY>13.00</researchViewY>
 		<tab>Buildings_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechMultiBase">

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Craft.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Craft.xml
@@ -15,6 +15,7 @@
 		<tab>Craft_SK</tab>
 		<tags>
 			<li>ClassicStart</li>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
 		</tags>
 	</ResearchProjectDef>
 
@@ -61,6 +62,9 @@
 		<researchViewX>12.00</researchViewX>
 		<researchViewY>19.00</researchViewY>
 		<tab>Craft_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechBase">
@@ -100,6 +104,9 @@
 		<researchViewX>3.00</researchViewX>
 		<researchViewY>24.00</researchViewY>
 		<tab>Craft_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -316,6 +323,9 @@
 		<researchViewX>11.00</researchViewX>
 		<researchViewY>27.00</researchViewY>
 		<tab>Craft_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -402,6 +412,9 @@
 		<researchViewX>17.00</researchViewX>
 		<researchViewY>21.00</researchViewY>
 		<tab>Craft_SK</tab>
+		<tags>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechMultiBase">
@@ -652,6 +665,9 @@
 		<researchViewX>8.00</researchViewX>
 		<researchViewY>23.00</researchViewY>
 		<tab>Craft_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Floors.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Floors.xml
@@ -24,6 +24,9 @@
 		<researchViewX>1.00</researchViewX>
 		<researchViewY>4.00</researchViewY>
 		<tab>Floors_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -199,6 +202,9 @@
 		<researchViewX>7.00</researchViewX>
 		<researchViewY>4.00</researchViewY>
 		<tab>Floors_SK</tab>
+		<tags>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -299,6 +305,9 @@
 		<researchViewX>17.00</researchViewX>
 		<researchViewY>4.00</researchViewY>
 		<tab>Floors_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -310,6 +319,9 @@
 		<researchViewX>1.00</researchViewX>
 		<researchViewY>1.00</researchViewY>
 		<tab>Floors_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -340,6 +352,9 @@
 		<researchViewX>5.00</researchViewX>
 		<researchViewY>1.00</researchViewY>
 		<tab>Floors_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Food.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Food.xml
@@ -44,6 +44,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>46.00</researchViewY>
 		<tab>Food_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 
@@ -60,6 +63,11 @@
 		<researchViewX>3.00</researchViewX>
 		<researchViewY>46.00</researchViewY>
 		<tab>Food_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+			<li>AsariStart</li>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -135,6 +143,9 @@
 		<researchViewX>5.00</researchViewX>
 		<researchViewY>47.00</researchViewY>
 		<tab>Food_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 
@@ -268,6 +279,10 @@
 		<researchViewX>17.00</researchViewX>
 		<researchViewY>45.00</researchViewY>
 		<tab>Food_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 
@@ -285,6 +300,9 @@
 		<researchViewX>3.00</researchViewX>
 		<researchViewY>48.00</researchViewY>
 		<tab>Food_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Medicine.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Medicine.xml
@@ -10,6 +10,9 @@
 		<researchViewX>1.00</researchViewX>
 		<researchViewY>62.00</researchViewY>
 		<tab>Medicine_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -40,6 +43,7 @@
 		<tab>Medicine_SK</tab>
 		<tags>
 			<li>ClassicStart</li>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
 		</tags>
 	</ResearchProjectDef>
 
@@ -179,6 +183,9 @@
 		<researchViewX>9.00</researchViewX>
 		<researchViewY>63.00</researchViewY>
 		<tab>Medicine_SK</tab>
+		<tags>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -223,6 +230,9 @@
 		<researchViewX>10.00</researchViewX>
 		<researchViewY>64.00</researchViewY>
 		<tab>Medicine_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -251,6 +261,9 @@
 		<researchViewX>8.00</researchViewX>
 		<researchViewY>65.00</researchViewY>
 		<tab>Medicine_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -293,6 +306,9 @@
 		<researchViewX>8.00</researchViewX>
 		<researchViewY>67.00</researchViewY>
 		<tab>Medicine_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechBase">
@@ -713,6 +729,9 @@
 		<researchViewX>17.00</researchViewX>
 		<researchViewY>66.00</researchViewY>
 		<tab>Medicine_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechMultiBase">
@@ -911,6 +930,9 @@
 		<researchViewX>11.00</researchViewX>
 		<researchViewY>60.00</researchViewY>
 		<tab>Medicine_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Plants.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Plants.xml
@@ -10,6 +10,9 @@
 		<researchViewX>1.00</researchViewX>
 		<researchViewY>55.00</researchViewY>
 		<tab>Plants_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -24,6 +27,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>55.00</researchViewY>
 		<tab>Plants_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -103,6 +109,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>57.00</researchViewY>
 		<tab>Plants_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -183,6 +192,9 @@
 		<researchViewX>0.00</researchViewX>
 		<researchViewY>59.00</researchViewY>
 		<tab>Plants_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -224,6 +236,9 @@
 		<researchViewX>1.00</researchViewX>
 		<researchViewY>56.00</researchViewY>
 		<tab>Plants_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -252,6 +267,9 @@
 		<researchViewX>3.00</researchViewX>
 		<researchViewY>56.00</researchViewY>
 		<tab>Plants_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">
@@ -266,6 +284,9 @@
 		<researchViewX>7.00</researchViewX>
 		<researchViewY>56.00</researchViewY>
 		<tab>Plants_SK</tab>
+		<tags>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -277,6 +298,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>52.00</researchViewY>
 		<tab>Plants_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="IndustrialBase">

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Terraforming.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Terraforming.xml
@@ -10,6 +10,9 @@
 		<researchViewX>2.00</researchViewX>
 		<researchViewY>53.00</researchViewY>
 		<tab>Terraforming_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -39,6 +42,9 @@
 		<researchViewX>11.00</researchViewX>
 		<researchViewY>53.00</researchViewY>
 		<tab>Terraforming_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 </Defs>

--- a/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Weapon.xml
+++ b/Mods/Core_SK/Defs/ResearchProjectDefs/Research_Weapon.xml
@@ -14,6 +14,10 @@
 		<researchViewX>4.00</researchViewX>
 		<researchViewY>29.00</researchViewY>
 		<tab>Weapon_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -101,6 +105,9 @@
 		<researchViewX>1.00</researchViewX>
 		<researchViewY>30.00</researchViewY>
 		<tab>Weapon_SK</tab>
+		<tags>
+			<li>NorbalStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="PrimitiveBase">
@@ -130,6 +137,9 @@
 		<researchViewX>4.00</researchViewX>
 		<researchViewY>30.00</researchViewY>
 		<tab>Weapon_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="MedievalBase">
@@ -317,6 +327,9 @@
 		<researchViewX>12.00</researchViewX>
 		<researchViewY>30.00</researchViewY>
 		<tab>Weapon_SK</tab>
+		<tags>
+			<li>NovaStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechBase">
@@ -489,6 +502,9 @@
 		<researchViewX>18.00</researchViewX>
 		<researchViewY>30.00</researchViewY>
 		<tab>Weapon_SK</tab>
+		<tags>
+			<li>AsariStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechMultiBase">
@@ -593,6 +609,9 @@
 		<researchViewX>4.00</researchViewX>
 		<researchViewY>36.00</researchViewY>
 		<tab>Weapon_SK</tab>
+		<tags>
+			<li MayRequire="Solaris.RatkinRaceMod">RatkinStart</li>
+		</tags>
 	</ResearchProjectDef>
 
 	<ResearchProjectDef ParentName="HitechBase">

--- a/Mods/Core_SK/Patches/ResearchTree/DubsBadHygiene.xml
+++ b/Mods/Core_SK/Patches/ResearchTree/DubsBadHygiene.xml
@@ -75,6 +75,10 @@
                         <researchViewX>9.00</researchViewX>
                         <researchViewY>10.00</researchViewY>
                         <tab>Buildings_SK</tab>
+						<tags>
+							<li>NovaStart</li>
+							<li>AsariStart</li>
+						</tags>
                     </ResearchProjectDef>
                 </value>
             </li>

--- a/Mods/Core_SK/Patches/ResearchTree/NewRatkinPlus.xml
+++ b/Mods/Core_SK/Patches/ResearchTree/NewRatkinPlus.xml
@@ -22,6 +22,9 @@
                         <researchViewX>5.00</researchViewX>
                         <researchViewY>43.00</researchViewY>
                         <tab>Apparel_SK</tab>
+						<tags>
+							<li>RatkinStart</li>
+						</tags>
                     </ResearchProjectDef>
                 </value>
             </li>
@@ -58,6 +61,9 @@
                         <researchViewX>4.00</researchViewX>
                         <researchViewY>43.00</researchViewY>
                         <tab>Apparel_SK</tab>
+						<tags>
+							<li>RatkinStart</li>
+						</tags>
                     </ResearchProjectDef>
                 </value>
             </li>

--- a/Mods/RatkinRaceHSK/Defs/Scenario/RK_Scenarios.xml
+++ b/Mods/RatkinRaceHSK/Defs/Scenario/RK_Scenarios.xml
@@ -20,36 +20,6 @@
 					<method>Standing</method>
 				</li>
 
-				<!-- Starting research -->
-				<li Class="ScenPart_StartingResearch">
-					<def>StartingResearch</def>
-					<project>Ratkin_Apparel_B1</project>
-				</li>
-				<li Class="ScenPart_StartingResearch">
-					<def>StartingResearch</def>
-					<project>Craft_B1</project>
-				</li>
-				<li Class="ScenPart_StartingResearch">
-					<def>StartingResearch</def>
-					<project>Bow_B2</project>
-				</li>
-				<li Class="ScenPart_StartingResearch">
-					<def>StartingResearch</def>
-					<project>Smithing</project>
-				</li>
-				<li Class="ScenPart_StartingResearch">
-					<def>StartingResearch</def>
-					<project>Food_B1</project>
-				</li>
-				<li Class="ScenPart_StartingResearch">
-					<def>StartingResearch</def>
-					<project>Food_B3</project>
-				</li>
-				<li Class="ScenPart_StartingResearch">
-					<def>StartingResearch</def>
-					<project>Food_Plants_A2</project>
-				</li>
-
 				<!-- Other -->
 				<li Class="ScenPart_StartingThing_Defined">
 					<def>StartingThing_Defined</def>

--- a/Mods/RatkinRaceHSK/Patches/ResearchPatch.xml
+++ b/Mods/RatkinRaceHSK/Patches/ResearchPatch.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="utf-8" ?>
 <Patch>
 
-	<Operation Class="PatchOperationSequence"> 
+<!-- 	<Operation Class="PatchOperationSequence"> 
 		<success>Normal</success>
 		<operations>
 			<li Class="PatchOperationTest">
@@ -16,7 +16,7 @@
 				</value>
 			</li>		
 		</operations>
-	</Operation>
+	</Operation> -->
 	<Operation Class="PatchOperationSequence">
 		<success>Normal</success>
 		<operations>


### PR DESCRIPTION
[ENG]
1 Adjusted starting research set for the Ratkin scenario. It has not changed since they were added (including when the ResearchTree_SK research tree was added).
2 Norbal, Nova and Azari starting scenarios have been given their own starting research set (based on their scenario description, starting items, starting animals and technology level). 

Currently almost all starting scenarios have the same starting research set based on the classic scenario (except for the Norbals - it uses the tribal research set). I propose making these changes to add a little variety between the starting scenarios.


[RUS]
1 Скорректирован стартовый набор исследований для сценария Раткинов. Он не менялся с момента их добавления (включая добавление дерева исследований ResearchTree_SK).
2 Стартовым сценариям Норбалов, Новы и Азари был предоставлен собственный стартовый набор исследований (на основе описания сценария, стартовых предметов, стартовых животных и уровня технологий).

В настоящее время почти все стартовые сценарии имеют одинаковый стартовый набор исследований, основанный на классическом сценарии (за исключением сценария Норбалов - он использует племенной набор исследований). Я предлагаю внести эти изменения, чтобы добавить немного разнообразия между стартовыми сценариями.