### PR TITLE
another CE patches tweaks & fixes

### DIFF
--- a/Mods/Androids/Defs/AlienRaceSettings/AlienRaceSettings.xml
+++ b/Mods/Androids/Defs/AlienRaceSettings/AlienRaceSettings.xml
@@ -10,7 +10,7 @@
 							<kindDefs>
 								<li>AndroidColonistSK</li>
 							</kindDefs>
-							<chance>3.0</chance>
+							<chance>0</chance>
 						</li>
 					</pawnKindEntries>
 					<factionDefs>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Heavy.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Turrets_Heavy.xml
@@ -26,7 +26,6 @@
 				<hasStandardCommand>true</hasStandardCommand>
 				<defaultProjectile>Projectile_BalistaBolt</defaultProjectile>
 				<warmupTime>1.60</warmupTime>
-				<minRange>10</minRange>
 				<range>60</range>
 				<burstShotCount>1</burstShotCount>
 				<soundCast>Bow_Large</soundCast>

--- a/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
+++ b/Mods/Core_SK/Defs/TraitDefs/RCT_Traits.xml
@@ -462,31 +462,17 @@
 				<label>perfectionist</label>
 				<description>{PAWN_nameDef} refuses to accept less than {PAWN_possessive} best in any endeavor, no matter how long it takes. {PAWN_pronoun}'s less likely to fail when doing something, but {PAWN_pronoun} works slowly.</description>
 				<statOffsets>
-					<WorkSpeedGlobal>-0.2</WorkSpeedGlobal>
-					<AnimalGatherSpeed>-0.1</AnimalGatherSpeed>
+					<WorkSpeedGlobal>-0.3</WorkSpeedGlobal>
 					<AnimalGatherYield>0.2</AnimalGatherYield>
-					<DrugCookingSpeed>-0.1</DrugCookingSpeed>
 					<ButcheryFleshEfficiency>0.2</ButcheryFleshEfficiency>
-					<ButcheryFleshSpeed>-0.1</ButcheryFleshSpeed>
 					<ButcheryMechanoidEfficiency>0.2</ButcheryMechanoidEfficiency>
-					<ButcheryMechanoidSpeed>-0.1</ButcheryMechanoidSpeed>
-					<ConstructionSpeed>-0.1</ConstructionSpeed>
 					<ConstructSuccessChance>0.2</ConstructSuccessChance>
-					<CookSpeed>-0.1</CookSpeed>
-					<DrugSynthesisSpeed>-0.1</DrugSynthesisSpeed>
 					<FixBrokenDownBuildingSuccessChance>0.2</FixBrokenDownBuildingSuccessChance>
 					<FoodPoisonChance>-0.2</FoodPoisonChance>
-					<MedicalOperationSpeed>-0.1</MedicalOperationSpeed>
 					<MedicalSurgerySuccessChance>0.2</MedicalSurgerySuccessChance>
 					<MedicalTendQuality>0.2</MedicalTendQuality>
-					<MedicalTendSpeed>-0.1</MedicalTendSpeed>
-					<MiningSpeed>-0.1</MiningSpeed>
 					<MiningYield>0.2</MiningYield>
 					<PlantHarvestYield>0.2</PlantHarvestYield>
-					<PlantWorkSpeed>-0.1</PlantWorkSpeed>
-					<ResearchSpeed>-0.1</ResearchSpeed>
-					<SmithingSpeed>-0.1</SmithingSpeed>
-					<TailoringSpeed>-0.1</TailoringSpeed>
 				</statOffsets>
 			</li>
 		</degreeDatas>

--- a/Mods/Core_SK/Patches/CombatExtended/ThingDefs_Buildings/Buildings_Security.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/ThingDefs_Buildings/Buildings_Security.xml
@@ -42,6 +42,31 @@
 		</value>
 	</Operation>
 
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/ThingDef[defName="Artillery_Mortar"]/verbs</xpath>
+		<value>
+			<verbs>
+				<li Class="CombatExtended.VerbPropertiesCE">
+					<verbClass>CombatExtended.Verb_ShootMortarCE</verbClass>
+					<forceNormalTimeSpeed>false</forceNormalTimeSpeed>
+					<hasStandardCommand>true</hasStandardCommand>
+					<defaultProjectile>Bullet_81mmMortarShell_HE</defaultProjectile>
+					<warmupTime>3.0</warmupTime>
+					<minRange>32</minRange>
+					<range>280</range>
+					<burstShotCount>1</burstShotCount>
+					<soundCast>Mortar_LaunchA</soundCast>
+					<muzzleFlashScale>16</muzzleFlashScale>
+					<circularError>1</circularError>
+					<indirectFirePenalty>1.0</indirectFirePenalty>
+					<targetParams>
+						<canTargetLocations>true</canTargetLocations>
+					</targetParams>
+				</li>
+			</verbs>
+		</value>
+	</Operation>
+
 	<Operation Class="SK.PatchOperationReplaceExtended">
 		<xpath>Defs/ThingDef[defName="Turret_MiniTurret"]/statBases</xpath>
 		<value>

--- a/Mods/Core_SK/Patches/Core/FactionDefs/Factions_Misc.xml
+++ b/Mods/Core_SK/Patches/Core/FactionDefs/Factions_Misc.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<Patch>
+
+	<!-- ========== Patch mech raid delay and Centipede spawn weight ========== -->
+
+	<Operation Class="PatchOperationReplace">
+		<xpath>Defs/FactionDef[defName="Mechanoid"]/earliestRaidDays</xpath>
+		<value>
+			<earliestRaidDays>160</earliestRaidDays>
+		</value>
+	</Operation>
+
+</Patch>


### PR DESCRIPTION
- 1) fixed phenomenally high accuracy of 81mm mortar;
- 2) fixed spawn of mechanoid faction (could attack in first year of colony);
- 3) removed the minimum attack radius of the ballista (I still haven't found the reason why it was added at all, and why it was so huge);
- 4) for better readability, replaced multiple 10% penalties to different work speeds with a 10% penalty to global work speed for the perfectionist trait.

- 1) исправлена феноменально высокая точность 81 мм миномета;
- 2) исправлен спавн фракции механоидов (могли напасть в первый год колонии);
- 3) удален минимальный радиус атаки у баллисты (так и не нашел причину, зачем он вообще был добавлен, да и ещё и такой огромный);
- 4) для лучшей читабельности, заменил множественные штрафы в 10% к разным скоростям работы на 10% штраф к общей скорости работы для черты перфекционист.