### PR TITLE
Some suppression tweaks & fixes

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrow_Explosive.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrow_Explosive.xml
@@ -33,17 +33,17 @@
             <graphicClass>Graphic_Single</graphicClass>
         </graphicData>
         <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>12</damageAmountBase>
+            <damageAmountBase>11</damageAmountBase>
             <!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
-            <armorPenetrationSharp>2</armorPenetrationSharp>
-            <armorPenetrationBlunt>4.2</armorPenetrationBlunt>
-            <suppressionFactor>2</suppressionFactor>
+            <armorPenetrationSharp>2.1</armorPenetrationSharp>
+            <armorPenetrationBlunt>4.3</armorPenetrationBlunt>
+            <suppressionFactor>1.2</suppressionFactor>
             <dangerFactor>1.4</dangerFactor>
-            <airborneSuppressionFactor>3.5</airborneSuppressionFactor>
+            <airborneSuppressionFactor>1.3</airborneSuppressionFactor>
             <secondaryDamage>
                 <li>
                     <def>Bomb_Secondary</def>
-                    <amount>14</amount>
+                    <amount>13</amount>
                 </li>
             </secondaryDamage>
         </projectile>
@@ -56,13 +56,16 @@
             <graphicClass>Graphic_Single</graphicClass>
         </graphicData>
         <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>13</damageAmountBase>
-            <armorPenetrationSharp>2.2</armorPenetrationSharp>
-            <armorPenetrationBlunt>4.5</armorPenetrationBlunt>
+            <damageAmountBase>12</damageAmountBase>
+            <armorPenetrationSharp>2.3</armorPenetrationSharp>
+            <armorPenetrationBlunt>4.6</armorPenetrationBlunt>
+            <suppressionFactor>1.2</suppressionFactor>
+            <dangerFactor>1.4</dangerFactor>
+            <airborneSuppressionFactor>1.3</airborneSuppressionFactor>
             <secondaryDamage>
                 <li>
                     <def>Bomb_Secondary</def>
-                    <amount>14</amount>
+                    <amount>13</amount>
                 </li>
             </secondaryDamage>
         </projectile>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrow_Explosive.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Arrow_Explosive.xml
@@ -33,17 +33,17 @@
             <graphicClass>Graphic_Single</graphicClass>
         </graphicData>
         <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>11</damageAmountBase>
+            <damageAmountBase>12</damageAmountBase>
             <!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
-            <armorPenetrationSharp>2.1</armorPenetrationSharp>
-            <armorPenetrationBlunt>4.3</armorPenetrationBlunt>
+            <armorPenetrationSharp>2</armorPenetrationSharp>
+            <armorPenetrationBlunt>4.2</armorPenetrationBlunt>
             <suppressionFactor>1.2</suppressionFactor>
             <dangerFactor>1.4</dangerFactor>
             <airborneSuppressionFactor>1.3</airborneSuppressionFactor>
             <secondaryDamage>
                 <li>
                     <def>Bomb_Secondary</def>
-                    <amount>13</amount>
+                    <amount>14</amount>
                 </li>
             </secondaryDamage>
         </projectile>
@@ -56,16 +56,16 @@
             <graphicClass>Graphic_Single</graphicClass>
         </graphicData>
         <projectile Class="CombatExtended.ProjectilePropertiesCE">
-            <damageAmountBase>12</damageAmountBase>
-            <armorPenetrationSharp>2.3</armorPenetrationSharp>
-            <armorPenetrationBlunt>4.6</armorPenetrationBlunt>
+            <damageAmountBase>13</damageAmountBase>
+            <armorPenetrationSharp>2.2</armorPenetrationSharp>
+            <armorPenetrationBlunt>4.5</armorPenetrationBlunt>
             <suppressionFactor>1.2</suppressionFactor>
             <dangerFactor>1.4</dangerFactor>
             <airborneSuppressionFactor>1.3</airborneSuppressionFactor>
             <secondaryDamage>
                 <li>
                     <def>Bomb_Secondary</def>
-                    <amount>13</amount>
+                    <amount>14</amount>
                 </li>
             </secondaryDamage>
         </projectile>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Ballista.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Ballista.xml
@@ -77,9 +77,9 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Stab</damageDef>
 			<speed>45</speed>
-            <suppressionFactor>5</suppressionFactor>
+            <suppressionFactor>1.7</suppressionFactor>
             <dangerFactor>4</dangerFactor>
-            <airborneSuppressionFactor>7</airborneSuppressionFactor>
+            <airborneSuppressionFactor>1.8</airborneSuppressionFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
@@ -108,9 +108,9 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Arrow</damageDef>
 			<speed>72</speed>
-            <suppressionFactor>4</suppressionFactor>
-            <dangerFactor>3</dangerFactor>
-            <airborneSuppressionFactor>4</airborneSuppressionFactor>
+            <suppressionFactor>1.4</suppressionFactor>
+            <dangerFactor>1.3</dangerFactor>
+            <airborneSuppressionFactor>1.5</airborneSuppressionFactor>
 		</projectile>
 	</ThingDef>
 
@@ -123,10 +123,10 @@
 			<drawSize>0.67</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>18</damageAmountBase>
+			<damageAmountBase>17</damageAmountBase>
 			<!-- <armorPenetrationBase>0.37</armorPenetrationBase> -->			
-			<armorPenetrationBlunt>5.8</armorPenetrationBlunt>
-			<armorPenetrationSharp>3.7</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.9</armorPenetrationBlunt>
+			<armorPenetrationSharp>3.8</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_Bolt_Metallic</preExplosionSpawnThingDef>
 		</projectile>
@@ -144,14 +144,14 @@
 			<damageDef>ArrowVenom</damageDef>
 			<damageAmountBase>7</damageAmountBase>
 			<!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
-			<armorPenetrationBlunt>5.1</armorPenetrationBlunt>
-			<armorPenetrationSharp>3.9</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.2</armorPenetrationBlunt>
+			<armorPenetrationSharp>4.0</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_Bolt_Venom</preExplosionSpawnThingDef>			
 			<secondaryDamage>
 				<li>
 					<def>ArrowHighVelocity</def>
-					<amount>5</amount>
+					<amount>4</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -166,14 +166,14 @@
 			<drawSize>0.67</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 			<!-- <armorPenetrationBase>0.35</armorPenetrationBase> -->
-			<armorPenetrationBlunt>6.2</armorPenetrationBlunt>
-			<armorPenetrationSharp>2.72</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.3</armorPenetrationBlunt>
+			<armorPenetrationSharp>2.8</armorPenetrationSharp>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>14</amount>
+					<amount>13</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Bolts.xml
@@ -123,10 +123,10 @@
 			<drawSize>0.67</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>17</damageAmountBase>
+			<damageAmountBase>18</damageAmountBase>
 			<!-- <armorPenetrationBase>0.37</armorPenetrationBase> -->			
-			<armorPenetrationBlunt>5.9</armorPenetrationBlunt>
-			<armorPenetrationSharp>3.8</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.8</armorPenetrationBlunt>
+			<armorPenetrationSharp>3.7</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_Bolt_Metallic</preExplosionSpawnThingDef>
 		</projectile>
@@ -144,14 +144,14 @@
 			<damageDef>ArrowVenom</damageDef>
 			<damageAmountBase>7</damageAmountBase>
 			<!-- <armorPenetrationBase>0.28</armorPenetrationBase> -->
-			<armorPenetrationBlunt>5.2</armorPenetrationBlunt>
-			<armorPenetrationSharp>4.0</armorPenetrationSharp>
+			<armorPenetrationBlunt>5.1</armorPenetrationBlunt>
+			<armorPenetrationSharp>3.9</armorPenetrationSharp>
 			<preExplosionSpawnChance>0.6</preExplosionSpawnChance>	<!-- 25 arrows per resource -->
 			<preExplosionSpawnThingDef>Ammo_Bolt_Venom</preExplosionSpawnThingDef>			
 			<secondaryDamage>
 				<li>
 					<def>ArrowHighVelocity</def>
-					<amount>4</amount>
+					<amount>5</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>
@@ -166,14 +166,14 @@
 			<drawSize>0.67</drawSize>
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
-			<damageAmountBase>14</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 			<!-- <armorPenetrationBase>0.35</armorPenetrationBase> -->
-			<armorPenetrationBlunt>6.3</armorPenetrationBlunt>
-			<armorPenetrationSharp>2.8</armorPenetrationSharp>
+			<armorPenetrationBlunt>6.2</armorPenetrationBlunt>
+			<armorPenetrationSharp>2.7</armorPenetrationSharp>
 			<secondaryDamage>
 				<li>
 					<def>Bomb_Secondary</def>
-					<amount>13</amount>
+					<amount>14</amount>
 				</li>
 			</secondaryDamage>
 		</projectile>

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/CatapultaBalls.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/CatapultaBalls.xml
@@ -91,9 +91,9 @@
 			<flyOverhead>true</flyOverhead>
 			<dropsCasings>false</dropsCasings>
 			<gravityFactor>10</gravityFactor>
-            <suppressionFactor>5</suppressionFactor>
+            <suppressionFactor>1.7</suppressionFactor>
             <dangerFactor>4</dangerFactor>
-            <airborneSuppressionFactor>7</airborneSuppressionFactor>
+            <airborneSuppressionFactor>1.8</airborneSuppressionFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Darts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Darts.xml
@@ -70,8 +70,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>3</damageAmountBase>
 			<!-- <armorPenetrationBase>0.15</armorPenetrationBase> -->
-			<armorPenetrationBlunt>1.1</armorPenetrationBlunt>
-			<armorPenetrationSharp>2</armorPenetrationSharp>
+			<armorPenetrationBlunt>1</armorPenetrationBlunt>
+			<armorPenetrationSharp>1.9</armorPenetrationSharp>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Darts.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Darts.xml
@@ -58,9 +58,9 @@
 			<damageDef>ArrowVenom</damageDef>
 			<speed>28</speed>
 			<dropsCasings>false</dropsCasings>
-            <suppressionFactor>2</suppressionFactor>
+            <suppressionFactor>1.2</suppressionFactor>
             <dangerFactor>1</dangerFactor>
-            <airborneSuppressionFactor>2.5</airborneSuppressionFactor>
+            <airborneSuppressionFactor>1.3</airborneSuppressionFactor>
 		</projectile>
 	</ThingDef>
 
@@ -70,8 +70,8 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageAmountBase>3</damageAmountBase>
 			<!-- <armorPenetrationBase>0.15</armorPenetrationBase> -->
-			<armorPenetrationBlunt>1</armorPenetrationBlunt>
-			<armorPenetrationSharp>1.9</armorPenetrationSharp>
+			<armorPenetrationBlunt>1.1</armorPenetrationBlunt>
+			<armorPenetrationSharp>2</armorPenetrationSharp>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Pillum.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Neolithic/Pillum.xml
@@ -38,9 +38,9 @@
 		</graphicData>
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<damageDef>Stab</damageDef>
-            <suppressionFactor>5</suppressionFactor>
+            <suppressionFactor>1.7</suppressionFactor>
             <dangerFactor>4</dangerFactor>
-            <airborneSuppressionFactor>7</airborneSuppressionFactor>
+            <airborneSuppressionFactor>1.8</airborneSuppressionFactor>
 		</projectile>
 	</ThingDef>
 

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
@@ -78,7 +78,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<speed>9</speed>
 			<flyOverhead>false</flyOverhead>
-			<suppressionFactor>3.0</suppressionFactor>
+			<suppressionFactor>1.3</suppressionFactor>
 			<dangerFactor>2.0</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</projectile>
@@ -97,18 +97,18 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>2</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>45</damageAmountBase>
+			<damageAmountBase>42</damageAmountBase>
 			<explosionDelay>150</explosionDelay>
 			<soundExplode>Explosion_Bomb</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<suppressionFactor>2.5</suppressionFactor>
+			<suppressionFactor>1.2</suppressionFactor>
 			<dangerFactor>2.0</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>45</Fragment_Small>
+					<Fragment_Small>42</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -197,7 +197,7 @@
 			<ai_IsIncendiary>true</ai_IsIncendiary>
 			<explosionDelay>30</explosionDelay>
 			<dropsCasings>false</dropsCasings>
-			<suppressionFactor>2.0</suppressionFactor>
+			<suppressionFactor>1.1</suppressionFactor>
 			<dangerFactor>1.5</dangerFactor>
 			<airborneSuppressionFactor>0.2</airborneSuppressionFactor>
 		</projectile>
@@ -278,21 +278,21 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.5</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>90</damageAmountBase>
+			<damageAmountBase>85</damageAmountBase>
 			<explosionDelay>180</explosionDelay>
 			<soundExplode>Explosion_Bomb</soundExplode>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<suppressionFactor>3.5</suppressionFactor>
+			<suppressionFactor>1.4</suppressionFactor>
 			<dangerFactor>2.5</dangerFactor>
 			<airborneSuppressionFactor>0.35</airborneSuppressionFactor>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>50</Fragment_Small>
+					<Fragment_Small>48</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -369,21 +369,21 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.5</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>70</damageAmountBase>
+			<damageAmountBase>67</damageAmountBase>
 			<explosionDelay>180</explosionDelay>
 			<soundExplode>Explosion_Bomb</soundExplode>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<suppressionFactor>3.0</suppressionFactor>
+			<suppressionFactor>1.3</suppressionFactor>
 			<dangerFactor>2.0</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_GrenadeFrag>90</Fragment_GrenadeFrag>
+					<Fragment_GrenadeFrag>85</Fragment_GrenadeFrag>
 				</fragments>
 			</li>
 		</comps>
@@ -458,12 +458,12 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>3</explosionRadius>
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>110</damageAmountBase>
+			<damageAmountBase>105</damageAmountBase>
 			<explosionDelay>180</explosionDelay>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
-			<suppressionFactor>1.5</suppressionFactor>
+			<suppressionFactor>1</suppressionFactor>
 			<dangerFactor>1.2</dangerFactor>
 			<airborneSuppressionFactor>0.15</airborneSuppressionFactor>
 		</projectile>
@@ -546,7 +546,7 @@
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
-			<suppressionFactor>2.5</suppressionFactor>
+			<suppressionFactor>1.2</suppressionFactor>
 			<dangerFactor>1.7</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</projectile>
@@ -625,21 +625,21 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>2.5</explosionRadius>
 			<damageDef>BombCharged</damageDef>
-			<damageAmountBase>105</damageAmountBase>
+			<damageAmountBase>100</damageAmountBase>
 			<explosionDelay>215</explosionDelay>
 			<!-- <soundExplode>Explosion_Bomb</soundExplode> -->
 			<dropsCasings>false</dropsCasings>
 			<!-- <casingMoteDefname>Fleck_GrenadePin</casingMoteDefname> -->
 			<!-- <casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname> -->
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<suppressionFactor>4.5</suppressionFactor>
+			<suppressionFactor>1.6</suppressionFactor>
 			<dangerFactor>3.5</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</projectile>
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_GrenadeFragCharged>120</Fragment_GrenadeFragCharged>
+					<Fragment_GrenadeFragCharged>115</Fragment_GrenadeFragCharged>
 				</fragments>
 			</li>
 		</comps>
@@ -723,7 +723,7 @@
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<suppressionFactor>3.5</suppressionFactor>
+			<suppressionFactor>1.4</suppressionFactor>
 			<dangerFactor>2.5</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</projectile>
@@ -809,7 +809,7 @@
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-			<suppressionFactor>4.0</suppressionFactor>
+			<suppressionFactor>1.5</suppressionFactor>
 			<dangerFactor>3.0</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</projectile>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_Grenades.xml
@@ -97,7 +97,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>2</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>42</damageAmountBase>
+			<damageAmountBase>45</damageAmountBase>
 			<explosionDelay>150</explosionDelay>
 			<soundExplode>Explosion_Bomb</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
@@ -108,7 +108,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>42</Fragment_Small>
+					<Fragment_Small>45</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -278,7 +278,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.5</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>85</damageAmountBase>
+			<damageAmountBase>90</damageAmountBase>
 			<explosionDelay>180</explosionDelay>
 			<soundExplode>Explosion_Bomb</soundExplode>
 			<dropsCasings>true</dropsCasings>
@@ -292,7 +292,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_Small>48</Fragment_Small>
+					<Fragment_Small>50</Fragment_Small>
 				</fragments>
 			</li>
 		</comps>
@@ -369,7 +369,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>1.5</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>67</damageAmountBase>
+			<damageAmountBase>70</damageAmountBase>
 			<explosionDelay>180</explosionDelay>
 			<soundExplode>Explosion_Bomb</soundExplode>
 			<dropsCasings>true</dropsCasings>
@@ -383,7 +383,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_GrenadeFrag>85</Fragment_GrenadeFrag>
+					<Fragment_GrenadeFrag>90</Fragment_GrenadeFrag>
 				</fragments>
 			</li>
 		</comps>
@@ -458,7 +458,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>3</explosionRadius>
 			<damageDef>EMP</damageDef>
-			<damageAmountBase>105</damageAmountBase>
+			<damageAmountBase>110</damageAmountBase>
 			<explosionDelay>180</explosionDelay>
 			<dropsCasings>true</dropsCasings>
 			<casingMoteDefname>Fleck_GrenadePin</casingMoteDefname>
@@ -625,7 +625,7 @@
 		<projectile Class="CombatExtended.ProjectilePropertiesCE">
 			<explosionRadius>2.5</explosionRadius>
 			<damageDef>BombCharged</damageDef>
-			<damageAmountBase>100</damageAmountBase>
+			<damageAmountBase>105</damageAmountBase>
 			<explosionDelay>215</explosionDelay>
 			<!-- <soundExplode>Explosion_Bomb</soundExplode> -->
 			<dropsCasings>false</dropsCasings>
@@ -639,7 +639,7 @@
 		<comps>
 			<li Class="CombatExtended.CompProperties_Fragments">
 				<fragments>
-					<Fragment_GrenadeFragCharged>115</Fragment_GrenadeFragCharged>
+					<Fragment_GrenadeFragCharged>120</Fragment_GrenadeFragCharged>
 				</fragments>
 			</li>
 		</comps>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
@@ -21,7 +21,7 @@
 		<possessionCount>1</possessionCount>
 		<generateCommonality>0.02</generateCommonality>
 		<equippedStatOffsets>
-			<Suppressability>-0.15</Suppressability>
+			<Suppressability>-0.05</Suppressability>
 		</equippedStatOffsets>
 		<altitudeLayer>Item</altitudeLayer>
 		<alwaysHaulable>True</alwaysHaulable>

--- a/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
+++ b/Mods/Core_SK/Defs/ThingDefs_Weapons/Weapons_RangedNeolithic.xml
@@ -21,7 +21,7 @@
 		<possessionCount>1</possessionCount>
 		<generateCommonality>0.02</generateCommonality>
 		<equippedStatOffsets>
-			<Suppressability>-0.05</Suppressability>
+			<Suppressability>-0.15</Suppressability>
 		</equippedStatOffsets>
 		<altitudeLayer>Item</altitudeLayer>
 		<alwaysHaulable>True</alwaysHaulable>

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/AmmoBases.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/AmmoBases.xml
@@ -48,7 +48,7 @@
 		<value>
 			<suppressionFactor>1.1</suppressionFactor>
 			<dangerFactor>0.4</dangerFactor>
-			<airborneSuppressionFactor>3.2</airborneSuppressionFactor>
+			<airborneSuppressionFactor>1.2</airborneSuppressionFactor>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAttributeSet">

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Neolithic/Arrows.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Neolithic/Arrows.xml
@@ -104,19 +104,19 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Stone"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>3.9</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.8</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Stone"]/projectile/damageAmountBase</xpath>
 		<value>
-			<damageAmountBase>9</damageAmountBase>
+			<damageAmountBase>10</damageAmountBase>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Stone"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>2.5</armorPenetrationSharp>
+			<armorPenetrationSharp>2.4</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationRemove">
@@ -131,19 +131,19 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Steel"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>4.3</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.2</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Steel"]/projectile/damageAmountBase</xpath>
 		<value>
-			<damageAmountBase>13</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Steel"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>3.1</armorPenetrationSharp>
+			<armorPenetrationSharp>3</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAdd">
@@ -157,13 +157,13 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Venom"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>3.8</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.7</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Venom"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>3.4</armorPenetrationSharp>
+			<armorPenetrationSharp>3.3</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAdd">
@@ -199,19 +199,19 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Stone"]/projectile/damageAmountBase</xpath>
 		<value>
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>11</damageAmountBase>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Stone"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>4.2</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.1</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Stone"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>2.7</armorPenetrationSharp>
+			<armorPenetrationSharp>2.6</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
@@ -223,25 +223,25 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/projectile/damageAmountBase</xpath>
 		<value>
-			<damageAmountBase>14</damageAmountBase>
+			<damageAmountBase>15</damageAmountBase>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>4.7</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.6</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>3.4</armorPenetrationSharp>
+			<armorPenetrationSharp>3.3</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Venom"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>4.1</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
@@ -253,7 +253,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Venom"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>3.7</armorPenetrationSharp>
+			<armorPenetrationSharp>3.6</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAdd">

--- a/Mods/Core_SK/Patches/CombatExtended/Ammo/Neolithic/Arrows.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/Ammo/Neolithic/Arrows.xml
@@ -96,27 +96,27 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[@Name="BaseArrowProjectile"]/projectile</xpath>
 		<value>
-			<suppressionFactor>2</suppressionFactor>
+			<suppressionFactor>1.2</suppressionFactor>
 			<dangerFactor>0.2</dangerFactor>
-			<airborneSuppressionFactor>3.5</airborneSuppressionFactor>
+			<airborneSuppressionFactor>2.1</airborneSuppressionFactor>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Stone"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>3.84</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.9</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Stone"]/projectile/damageAmountBase</xpath>
 		<value>
-			<damageAmountBase>10</damageAmountBase>
+			<damageAmountBase>9</damageAmountBase>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Stone"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>2.4</armorPenetrationSharp>
+			<armorPenetrationSharp>2.5</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationRemove">
@@ -131,39 +131,39 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Steel"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>4.2</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.3</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Steel"]/projectile/damageAmountBase</xpath>
 		<value>
-			<damageAmountBase>14</damageAmountBase>
+			<damageAmountBase>13</damageAmountBase>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Steel"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.1</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Steel"]/projectile</xpath>
 		<value>
-			<suppressionFactor>3</suppressionFactor>
+			<suppressionFactor>1.3</suppressionFactor>
 			<dangerFactor>0.3</dangerFactor>
-			<airborneSuppressionFactor>4.5</airborneSuppressionFactor>
+			<airborneSuppressionFactor>2.2</airborneSuppressionFactor>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Venom"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>3.7</armorPenetrationBlunt>
+			<armorPenetrationBlunt>3.8</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Venom"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>3.3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.4</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAdd">
@@ -180,9 +180,9 @@
 	<Operation Class="PatchOperationAdd">
 		<xpath>Defs/ThingDef[defName="Projectile_Arrow_Flame"]/projectile</xpath>
 		<value>
-			<suppressionFactor>3</suppressionFactor>
+			<suppressionFactor>1.4</suppressionFactor>
 			<dangerFactor>0.4</dangerFactor>
-			<airborneSuppressionFactor>4.5</airborneSuppressionFactor>
+			<airborneSuppressionFactor>2.3</airborneSuppressionFactor>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAttributeSet">
@@ -199,19 +199,19 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Stone"]/projectile/damageAmountBase</xpath>
 		<value>
-			<damageAmountBase>11</damageAmountBase>
+			<damageAmountBase>10</damageAmountBase>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Stone"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>4.1</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.2</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Stone"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>2.6</armorPenetrationSharp>
+			<armorPenetrationSharp>2.7</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
@@ -223,25 +223,25 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/projectile/damageAmountBase</xpath>
 		<value>
-			<damageAmountBase>15</damageAmountBase>
+			<damageAmountBase>14</damageAmountBase>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>4.6</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.7</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Steel"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>3.3</armorPenetrationSharp>
+			<armorPenetrationSharp>3.4</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Venom"]/projectile/armorPenetrationBlunt</xpath>
 		<value>
-			<armorPenetrationBlunt>4</armorPenetrationBlunt>
+			<armorPenetrationBlunt>4.1</armorPenetrationBlunt>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationReplace">
@@ -253,7 +253,7 @@
 	<Operation Class="PatchOperationReplace">
 		<xpath>Defs/ThingDef[defName="Projectile_StreamlinedArrow_Venom"]/projectile/armorPenetrationSharp</xpath>
 		<value>
-			<armorPenetrationSharp>3.6</armorPenetrationSharp>
+			<armorPenetrationSharp>3.7</armorPenetrationSharp>
 		</value>
 	</Operation>
 	<Operation Class="PatchOperationAdd">

--- a/Mods/Core_SK/Patches/CombatExtended/ThingDefs_Weapons/Weapons_Grenades.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/ThingDefs_Weapons/Weapons_Grenades.xml
@@ -61,7 +61,7 @@
 		<value>
 			<explosionRadius>2</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>65</damageAmountBase>
+			<damageAmountBase>70</damageAmountBase>
 			<explosionDelay>175</explosionDelay>
 			<soundExplode>Explosion_Bomb</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>

--- a/Mods/Core_SK/Patches/CombatExtended/ThingDefs_Weapons/Weapons_Grenades.xml
+++ b/Mods/Core_SK/Patches/CombatExtended/ThingDefs_Weapons/Weapons_Grenades.xml
@@ -30,7 +30,7 @@
 			<casingFilthDefname>Filth_GrenadeAmmoCasings</casingFilthDefname>
 			<speed>10</speed>
 			<screenShakeFactor>0</screenShakeFactor>
-			<suppressionFactor>2.0</suppressionFactor>
+			<suppressionFactor>1.1</suppressionFactor>
 			<dangerFactor>1.5</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</value>
@@ -61,12 +61,12 @@
 		<value>
 			<explosionRadius>2</explosionRadius>
 			<damageDef>Bomb</damageDef>
-			<damageAmountBase>70</damageAmountBase>
+			<damageAmountBase>65</damageAmountBase>
 			<explosionDelay>175</explosionDelay>
 			<soundExplode>Explosion_Bomb</soundExplode>
 			<applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
 			<speed>8</speed>
-			<suppressionFactor>3.0</suppressionFactor>
+			<suppressionFactor>1.3</suppressionFactor>
 			<dangerFactor>2.0</dangerFactor>
 			<airborneSuppressionFactor>0.25</airborneSuppressionFactor>
 		</value>


### PR DESCRIPTION
Some suppression tweaks & fixes:
- reduced significantly inflated suppression multipliers for primitive projectiles and grenades;
- the armor penetration value for some arrows has been rounded to tenths (it was rounded to hundredths).

Некоторые исправления и изменения параметров подавления:
- уменьшены значительно завышенные множители подавления для примитивных снарядов и гранат;
- округлено значение бронепробитие у некоторых стрел до десятых (было округление до сотых).