### PR TITLE
Fixed doubling of thermobaric damage for the 80x256mm fuel shell (Thermobaric)

### DIFF
--- a/Mods/Core_SK/Defs/CombatExtended/Ammo/Ammo_80x256mmFuel_Thermobaric.xml
+++ b/Mods/Core_SK/Defs/CombatExtended/Ammo/Ammo_80x256mmFuel_Thermobaric.xml
@@ -51,13 +51,13 @@
             <alwaysFreeIntercept>false</alwaysFreeIntercept>
             <bulletChanceToStartFire>0.4</bulletChanceToStartFire>
         </projectile>
-        <comps>
-            <li Class="CombatExtended.CompProperties_ExplosiveCE">
-                <damageAmountBase>150</damageAmountBase>
-                <explosiveDamageType>Thermobaric</explosiveDamageType>
-                <explosiveRadius>1.9</explosiveRadius>
-                <applyDamageToExplosionCellsNeighbors>true</applyDamageToExplosionCellsNeighbors>
-            </li>
-        </comps>
+		<comps>
+			<li Class="CombatExtended.CompProperties_Fragments">
+				<fragments>
+					<Fragment_Large>30</Fragment_Large>
+					<Fragment_Small>60</Fragment_Small>
+				</fragments>
+			</li>
+		</comps>
     </ThingDef>
 </Defs>


### PR DESCRIPTION
Fixed doubling of thermobaric damage for the 80x256mm fuel shell (Thermobaric) (currently this is the only thermobaric shell that explodes twice, the others either produce fragments or do nothing) (compared with larger and smaller shells, such as the RPG7, 130mm Rocket missile, 30x64 mm Fuel shell (Thermobaric), and others).

Исправлено задвоение термобарического урона у 80x256mm fuel shell (Thermobaric) (сейчас это единственный термобарический снаряд, что взрывается дважды, у остальных либо осколки, либо ничего не делают) (сравнивал с более и менее крупными снарядами, например, RPG7, 130mm Rocket missile, 30x64 mm Fuel shell (Thermobaric) и прочие).