### PR TITLE
Some tweaks with loot container

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,7 +1,7 @@
-"Mods/RW_ModularizationWeapon" export-ignore
-"Mods/Realistic Trade" export-ignore
+"Mods/Prized Companions" export-ignore
+"Mods/ThingFilterResizer" export-ignore
 "Mods/MineralsFrozen" export-ignore
 "Mods/Dubs Apparel Tweaks" export-ignore
-"Mods/Prized Companions" export-ignore
+"Mods/Realistic Trade" export-ignore
+"Mods/RW_ModularizationWeapon" export-ignore
 "Mods/Weapon-Modularisation-SK-Armory" export-ignore
-"Mods/ThingFilterResizer" export-ignore

--- a/Mods/Core_SK/Ideology/Patches/ThingSetMakerDefs/ThingSetMakers_MapGen.xml
+++ b/Mods/Core_SK/Ideology/Patches/ThingSetMakerDefs/ThingSetMakers_MapGen.xml
@@ -1,0 +1,712 @@
+<?xml version="1.0" encoding="utf-8" ?>
+
+<Patch>
+	<!-- Simple loot crates -->
+	<Operation Class="PatchOperationAdd">
+	  <xpath>Defs/ThingSetMakerDef[defName="MapGen_AncientComplexRoomLoot_Default"]/root/options</xpath>
+	  <value>
+
+        <!-- Some usefull parts or components -->
+        <li>
+          <weight>0.5</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>ComponentIndustrial</li>
+				  <li>Mechanism</li>
+				  <li>ElectronicComponents</li>
+                </thingDefs>
+              </filter>
+              <countRange>4~9</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some good drugs -->
+        <li>
+          <weight>0.5</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Berserk_herb</li>
+				  <li>GoJuice</li>
+				  <li>VG_Ibuprofen</li>
+				  <li>Synchronisity</li>
+				  <li>WakeUp</li>
+				  <li>Yayo</li>
+                </thingDefs>
+              </filter>
+              <countRange>6~11</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some suitable ammo -->
+        <li>
+          <weight>0.5</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Ammo_45ACP_FMJ</li>
+				  <li>Ammo_45ACP_AP</li>
+				  <li>Ammo_45ACP_HP</li>
+				  <li>Ammo_9x19mmPara_FMJ</li>
+				  <li>Ammo_9x19mmPara_AP</li>
+				  <li>Ammo_9x19mmPara_HP</li>
+                </thingDefs>
+              </filter>
+              <countRange>500~850</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some usefull industrial-level melee weapons or tool with high quality -->
+        <li>
+          <weight>0.45</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+			  <qualityGenerator>Super</qualityGenerator>
+              <filter>
+                <thingDefs>
+                  <li>MeleeWeapon_Knife</li>
+				  <li>MeleeWeapon_Machete</li>
+				  <li>MeleeWeapon_Monkeywrench</li>
+				  <li>MeleeWeapon_Tanto</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~1</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some terraforming stuff -->
+        <li>
+          <weight>0.4</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Fertilizer</li>
+                </thingDefs>
+              </filter>
+              <countRange>25~300</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some industrial-level grenades -->
+        <li>
+          <weight>0.35</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Weapon_GrenadeHighExplosive</li>
+				  <li>Weapon_GrenadeFrag</li>
+				  <li>Weapon_GrenadeEMP</li>
+				  <li>Weapon_GrenadeFlame</li>
+                </thingDefs>
+              </filter>
+              <countRange>15~25</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+		<!-- Alloys for craft battery -->
+        <li>
+          <weight>0.25</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>LeadBar</li>
+				  <li>NickelBar</li>
+				  <li>DepletedUranium</li>
+				  <li MayRequire="arpomo6.hmc.bizmat">Edritium</li>
+                </thingDefs>
+              </filter>
+              <countRange>15~60</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Some usefull industrial alloys -->
+        <li>
+          <weight>0.25</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>CupronickelAlloy</li>
+				  <li>SteelBar</li>
+				  <li>AlnicoAlloy</li>
+				  <li>CarbonAlloy</li>
+				  <li MayRequire="arpomo6.hmc.bizmat">Sarcasmium</li>
+                </thingDefs>
+              </filter>
+              <countRange>17~78</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Some usefull industrial-level textiles -->
+        <li>
+          <weight>0.25</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Leather_Fox</li>
+				  <li>Leather_Thrumbo</li>
+				  <li>Velour</li>
+				  <li>Kevlar</li>
+				  <li MayRequire="arpomo6.hmc.bizmat">Opticweave</li>
+                </thingDefs>
+              </filter>
+              <countRange>33~99</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Some unique or non-craftable weapon (like blasters) with high quality -->
+        <li>
+          <weight>0.15</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+			  <qualityGenerator>Super</qualityGenerator>
+              <filter>
+                <thingDefs>
+                  <li>Gun_Phalanx</li>
+				  <li>Gun_BlackWidow</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~1</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Little chance for droids -->
+        <li MayRequire="ChJees.Androids">
+          <weight>0.07</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="ChJees.Androids">ChjAndroidDroidAssemblyKit</li>
+				  <li MayRequire="ChJees.Androids">ChjAndroidBattleDroidAssemblyKit</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~1</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+		<!-- My Honey... -->
+        <li>
+          <weight>0.05</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Honey</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~5</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Just for innocent jokes -->
+        <li MayRequire="Dubwise.DubsBadHygiene">
+          <weight>0.02</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="Dubwise.DubsBadHygiene">FecalSludge</li>
+                </thingDefs>
+              </filter>
+              <countRange>50~250</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+        <li MayRequire="arpomo6.hmc.bizmat">
+          <weight>0.02</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="arpomo6.hmc.bizmat">HMC_fequila</li>
+                </thingDefs>
+              </filter>
+              <countRange>5~10</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+        <li MayRequire="Dubwise.Rimatomics">
+          <weight>0.01</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="Dubwise.Rimatomics">NuclearWaste</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~10</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+	  </value>
+	</Operation>
+	
+	<!-- Better loot crates -->
+	<Operation Class="PatchOperationAdd">
+	  <xpath>Defs/ThingSetMakerDef[defName="MapGen_AncientComplexRoomLoot_Better"]/root/options</xpath>
+	  <value>
+
+        <!-- Some usefull parts or components -->
+        <li>
+          <weight>0.5</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+				  <li>ComponentAdvanced</li>
+				  <li>Electronics</li>
+				  <li>AdvMechanism</li>
+                </thingDefs>
+              </filter>
+              <countRange>4~9</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some good drugs -->
+        <li>
+          <weight>0.5</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+				  <li>GoJuice</li>
+				  <li>WakeUp</li>
+				  <li>Yayo</li>
+                </thingDefs>
+              </filter>
+              <countRange>8~14</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some suitable ammo -->
+        <li>
+          <weight>0.5</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Ammo_12Gauge_Buck</li>
+				  <li>Ammo_12Gauge_ElectroSlug</li>
+				  <li>Ammo_556x45mmNATO_FMJ</li>
+				  <li>Ammo_556x45mmNATO_AP</li>
+				  <li>Ammo_556x45mmNATO_HP</li>
+				  <li>Ammo_762x51mmNATO_FMJ</li>
+				  <li>Ammo_50BMG_FMJ</li>
+				  <li>Ammo_145x114mm_FMJ</li>
+                </thingDefs>
+              </filter>
+              <countRange>500~850</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some usefull industrial-level melee weapons or tool with high quality -->
+        <li>
+          <weight>0.45</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+			  <qualityGenerator>Super</qualityGenerator>
+              <filter>
+                <thingDefs>
+				  <li>MeleeWeapon_Machete</li>
+				  <li>MeleeWeapon_Monkeywrench</li>
+				  <li>MeleeWeapon_Tanto</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~2</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some industrial-level grenades -->
+        <li>
+          <weight>0.35</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Weapon_GrenadeHighExplosive</li>
+				  <li>Weapon_GrenadeFrag</li>
+				  <li>Weapon_GrenadeEMP</li>
+				  <li>Weapon_GrenadeFlame</li>
+                </thingDefs>
+              </filter>
+              <countRange>25~35</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+		<!-- Alloys for craft battery -->
+        <li>
+          <weight>0.25</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+				  <li>NickelBar</li>
+				  <li>DepletedUranium</li>
+				  <li MayRequire="arpomo6.hmc.bizmat">Edritium</li>
+                </thingDefs>
+              </filter>
+              <countRange>25~80</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Some usefull industrial alloys -->
+        <li>
+          <weight>0.25</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+				  <li>SteelBar</li>
+				  <li>AlnicoAlloy</li>
+				  <li>CarbonAlloy</li>
+				  <li MayRequire="arpomo6.hmc.bizmat">Sarcasmium</li>
+                </thingDefs>
+              </filter>
+              <countRange>23~89</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Some usefull industrial-level textiles -->
+        <li>
+          <weight>0.25</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+				  <li>Leather_Thrumbo</li>
+				  <li>Kevlar</li>
+				  <li MayRequire="arpomo6.hmc.bizmat">Opticweave</li>
+                </thingDefs>
+              </filter>
+              <countRange>44~111</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Some unique or non-craftable weapon (like blasters) with high quality -->
+        <li>
+          <weight>0.15</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+			  <qualityGenerator>Super</qualityGenerator>
+              <filter>
+                <thingDefs>
+                  <li>Gun_Phalanx</li>
+				  <li>Gun_Harrier</li>
+				  <li>Gun_Predator</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~1</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Little chance for droids -->
+        <li MayRequire="ChJees.Androids">
+          <weight>0.08</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="ChJees.Androids">ChjAndroidDroidAssemblyKit</li>
+				  <li MayRequire="ChJees.Androids">ChjAndroidBattleDroidAssemblyKit</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~1</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- My Honey... -->
+        <li>
+          <weight>0.05</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Honey</li>
+                </thingDefs>
+              </filter>
+              <countRange>3~10</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Just for innocent jokes -->
+        <li MayRequire="Dubwise.DubsBadHygiene">
+          <weight>0.02</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="Dubwise.DubsBadHygiene">FecalSludge</li>
+                </thingDefs>
+              </filter>
+              <countRange>50~250</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+        <li MayRequire="arpomo6.hmc.bizmat">
+          <weight>0.01</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="arpomo6.hmc.bizmat">HMC_fequila</li>
+                </thingDefs>
+              </filter>
+              <countRange>5~10</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+        <li MayRequire="Dubwise.Rimatomics">
+          <weight>0.01</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="Dubwise.Rimatomics">NuclearWaste</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~10</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+	  </value>
+	</Operation>	
+	
+	<!-- Security Crates -->
+	<Operation Class="PatchOperationAdd">
+	  <xpath>Defs/ThingSetMakerDef[defName="MapGen_AncientComplex_SecurityCrate"]/root/options</xpath>
+	  <value>
+
+        <!-- Some usefull parts or components -->
+        <li>
+          <weight>0.5</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+				  <li>Microchips</li>
+				  <li>BioMicrochips</li>
+				  <li>Hexcell</li>
+                </thingDefs>
+              </filter>
+              <countRange>4~9</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some good drugs -->
+        <li>
+          <weight>0.5</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+				  <li>GoJuice</li>
+				  <li>WakeUp</li>
+				  <li>Yayo</li>
+                </thingDefs>
+              </filter>
+              <countRange>10~15</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some suitable ammo -->
+        <li>
+          <weight>0.5</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Ammo_145x114mm_HE</li>
+				  <li>Ammo_6x24mmCharged</li>
+				  <li>Ammo_6x24mmCharged_Ion</li>
+				  <li>Ammo_BlasterBolt</li>
+				  <li>Ammo_BlasterPelletBolt</li>
+                </thingDefs>
+              </filter>
+              <countRange>500~850</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some usefull spacer-level melee weapons or tool with high quality -->
+        <li>
+          <weight>0.45</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+			  <qualityGenerator>Super</qualityGenerator>
+              <filter>
+                <thingDefs>
+				  <li>MeleeWeapon_PoweredShortsword</li>
+				  <li>TFJ_Tool_Multitool</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~1</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+        <!-- Some spacer-level grenades -->
+        <li>
+          <weight>0.35</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Weapon_GrenadeChargedFrag</li>
+				  <li>Weapon_GrenadePlasma</li>
+				  <li>Weapon_GrenadeFusion</li>
+                </thingDefs>
+              </filter>
+              <countRange>20~30</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+
+		<!-- Some usefull hightech alloys -->
+        <li>
+          <weight>0.25</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+				  <li>StelliteAlloy</li>
+				  <li>TitaniumBar</li>
+                </thingDefs>
+              </filter>
+              <countRange>33~99</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Some unique or non-craftable weapon (like blasters) with high quality -->
+        <li>
+          <weight>0.15</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+			  <qualityGenerator>Super</qualityGenerator>
+              <filter>
+                <thingDefs>
+                  <li>Gun_Predator</li>
+				  <li>Gun_Hurricane</li>
+				  <li>Gun_AvengerA</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~1</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Little chance for droids -->
+        <li MayRequire="ChJees.Androids">
+          <weight>0.07</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="ChJees.Androids">ChjAndroidDroidAssemblyKit</li>
+				  <li MayRequire="ChJees.Androids">ChjAndroidBattleDroidAssemblyKit</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~2</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- My Honey... -->
+        <li>
+          <weight>0.05</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li>Honey</li>
+                </thingDefs>
+              </filter>
+              <countRange>5~15</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+		<!-- Just for innocent jokes -->
+        <li MayRequire="Dubwise.DubsBadHygiene">
+          <weight>0.01</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="Dubwise.DubsBadHygiene">FecalSludge</li>
+                </thingDefs>
+              </filter>
+              <countRange>50~250</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+        <li MayRequire="arpomo6.hmc.bizmat">
+          <weight>0.01</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="arpomo6.hmc.bizmat">HMC_fequila</li>
+                </thingDefs>
+              </filter>
+              <countRange>5~10</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+		
+        <li MayRequire="Dubwise.Rimatomics">
+          <weight>0.01</weight>
+          <thingSetMaker Class="ThingSetMaker_StackCount">
+            <fixedParams>
+              <filter>
+                <thingDefs>
+                  <li MayRequire="Dubwise.Rimatomics">NuclearWaste</li>
+                </thingDefs>
+              </filter>
+              <countRange>1~10</countRange>
+            </fixedParams>
+          </thingSetMaker>
+        </li>
+	  </value>
+	</Operation>	
+
+</Patch>


### PR DESCRIPTION
The list of loot in various containers of abandoned settlements/complexes/stations has been expanded with items from HSK. These values ​​are preliminary and will be adjusted in the future if necessary.

Расширен перечень лута в различных контейнерах заброшенных поселений/комплексов/станций предметами из HSK. Значения предварительные, в будущем будут балансироваться при необходимости.