### PR TITLE
Fixed an incorrect maxPawnCostPerTotalPointsCurve value. Skynet has no pawns costing 650 points; the cheapest one costs 700.

### DIFF
--- a/Mods/Faster raids progression/Patches/Skynet_SK_Faction_Patch.xml
+++ b/Mods/Faster raids progression/Patches/Skynet_SK_Faction_Patch.xml
@@ -33,7 +33,7 @@
 						<maxPawnCostPerTotalPointsCurve>
 							<points>
 								<li>(0,600)</li>
-								<li>(13500,650)</li>
+								<li>(13500,700)</li>
 								<li>(16000,1000)</li>
 								<li>(18500,1750)</li>
 								<li>(100000,10000)</li>

--- a/Mods/Skynet_SK/Defs/FactionDefs/Skynet.xml
+++ b/Mods/Skynet_SK/Defs/FactionDefs/Skynet.xml
@@ -51,7 +51,7 @@
 		<maxPawnCostPerTotalPointsCurve>
 			<points>
 				<li>(0,600)</li>
-				<li>(14500,650)</li>
+				<li>(14500,700)</li>
 				<li>(17000,1000)</li>
 				<li>(20000,1750)</li>
 				<li>(100000,10000)</li>


### PR DESCRIPTION
Исправлено некорректное значение maxPawnCostPerTotalPointsCurve. У Скайнета нет пешек за 650 поинтов, самый дешевый стоит 700.