### PR TITLE
Update DamageDef_Patch.xml

### DIFF
--- a/Mods/Core_SK/Patches/DamageDef_Patch.xml
+++ b/Mods/Core_SK/Patches/DamageDef_Patch.xml
@@ -20,11 +20,8 @@
 			<buildingDamageFactorPassable>2.15</buildingDamageFactorPassable>
 		</value>
 	</Operation>
-	<Operation Class="SK.PatchOperationReplaceExtended">
-		<xpath>Defs/DamageDef[defName="Thermobaric"]</xpath>
-		<value>
-			<buildingDamageFactor>2.15</buildingDamageFactor>
-		</value>
+	<Operation Class="PatchOperationRemove">
+		<xpath>Defs/DamageDef[defName="Thermobaric"]/buildingDamageFactor</xpath>
 	</Operation>
 	<!-- I am not sure why we added this, but the details seem better, and passable is already 2
     <Operation Class="SK.PatchOperationReplaceExtended">


### PR DESCRIPTION
[EN]
Fixed doubling of thermobaric damage multipliers for buildings.

DamageDef should use only:
- buildingDamageFactor.

OR

- buildingDamageFactorPassable + buildingDamageFactorImpassable.

They can't be combined. Removed the deprecated buildingDamageFactor, which isn't used in vanilla explosives.

[RU]
Исправлено задвоение у термобарического урона по постройкам.

В DamageDef должно использоваться:
- либо только buildingDamageFactor
- либо buildingDamageFactorPassable + buildingDamageFactorImpassable

Вместе нельзя. Убрал устаревший buildingDamageFactor, который не используется в ваниле у взрывчатки.