### PR TITLE
The spawn chance of items and buildings made from clay blocks has been reduced to 0.

### DIFF
--- a/Mods/Minerals/Defs/ThingsDefs_Resources/Item_Resource_Blocks.xml
+++ b/Mods/Minerals/Defs/ThingsDefs_Resources/Item_Resource_Blocks.xml
@@ -62,6 +62,7 @@
       <soundMeleeHitSharp>MeleeHit_Stone</soundMeleeHitSharp>
       <soundMeleeHitBlunt>MeleeHit_Stone</soundMeleeHitBlunt>
       <stuffAdjective>clay</stuffAdjective>
+	  <commonality>0</commonality>
       <statFactors>
         <Beauty>1.3</Beauty>  
         <MarketValue>0.8</MarketValue>


### PR DESCRIPTION
Since clay blocks do not have a category (thingCategories IsNull="true"), they cannot be stored in a warehouse.