### PR TITLE
Remove negative multiplier from Comfy/Luxurious Infusion

### DIFF
--- a/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
+++ b/Mods/Infused_SK/Defs/InfusionDefs/IndustrialBoosted.xml
@@ -385,18 +385,6 @@
     </filter>
     <stats>
       <li>
-        <key>ArmorRating_Blunt</key>
-        <value>
-          <offset>-0.3</offset>
-        </value>
-      </li>
-      <li>
-        <key>ArmorRating_Sharp</key>
-        <value>
-          <offset>-0.3</offset>
-        </value>
-      </li>
-      <li>
         <key>ComfyTemperatureMin</key>
         <value>
           <offset>-1.25</offset>
@@ -412,12 +400,6 @@
         <key>ResearchSpeed</key>
         <value>
           <multiplier>1.01</multiplier>
-        </value>
-      </li>
-      <li>
-        <key>WorkSpeedGlobal</key>
-        <value>
-          <multiplier>.98</multiplier>
         </value>
       </li>
       <li>
@@ -1306,18 +1288,6 @@
     </filter>
     <stats>
       <li>
-        <key>ArmorRating_Blunt</key>
-        <value>
-          <offset>-0.6</offset>
-        </value>
-      </li>
-      <li>
-        <key>ArmorRating_Sharp</key>
-        <value>
-          <offset>-0.6</offset>
-        </value>
-      </li>
-      <li>
         <key>ComfyTemperatureMin</key>
         <value>
           <offset>-2.25</offset>
@@ -1333,12 +1303,6 @@
         <key>ResearchSpeed</key>
         <value>
           <multiplier>1.02</multiplier>
-        </value>
-      </li>
-      <li>
-        <key>WorkSpeedGlobal</key>
-        <value>
-          <multiplier>.96</multiplier>
         </value>
       </li>
       <li>
@@ -2222,18 +2186,6 @@
     </filter>
     <stats>
       <li>
-        <key>ArmorRating_Blunt</key>
-        <value>
-          <offset>-0.9</offset>
-        </value>
-      </li>
-      <li>
-        <key>ArmorRating_Sharp</key>
-        <value>
-          <offset>-0.9</offset>
-        </value>
-      </li>
-      <li>
         <key>ComfyTemperatureMin</key>
         <value>
           <offset>-3</offset>
@@ -2252,12 +2204,6 @@
         </value>
       </li>
       <li>
-        <key>WorkSpeedGlobal</key>
-        <value>
-          <multiplier>.94</multiplier>
-        </value>
-      </li>
-      <li>
         <key>GlobalLearningFactor</key>
         <value>
           <multiplier>1.03</multiplier>
@@ -2272,7 +2218,7 @@
       <li>
         <key>SocialImpact</key>
         <value>
-          <multiplier>1.06</multiplier>
+          <multiplier>1.04</multiplier>
         </value>
       </li>
     </stats>
@@ -3118,7 +3064,7 @@
   </Infused.Def>
   <Infused.Def ParentName="BoostedEpic">
     <defName>cmf3</defName>
-    <label>Luxiurious UrbTech</label>
+    <label>Luxurious UrbTech</label>
     <labelShort>cmf3</labelShort>
     <filter>
       <allowance>
@@ -3126,18 +3072,6 @@
       </allowance>
     </filter>
     <stats>
-      <li>
-        <key>ArmorRating_Blunt</key>
-        <value>
-          <offset>-1.5</offset>
-        </value>
-      </li>
-      <li>
-        <key>ArmorRating_Sharp</key>
-        <value>
-          <offset>-1.5</offset>
-        </value>
-      </li>
       <li>
         <key>ComfyTemperatureMin</key>
         <value>
@@ -3153,19 +3087,13 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <multiplier>1.05</multiplier>
-        </value>
-      </li>
-      <li>
-        <key>WorkSpeedGlobal</key>
-        <value>
-          <multiplier>.90</multiplier>
+          <multiplier>1.04</multiplier>
         </value>
       </li>
       <li>
         <key>GlobalLearningFactor</key>
         <value>
-          <multiplier>1.05</multiplier>
+          <multiplier>1.04</multiplier>
         </value>
       </li>
       <li>
@@ -3177,7 +3105,7 @@
       <li>
         <key>SocialImpact</key>
         <value>
-          <multiplier>1.10</multiplier>
+          <multiplier>1.1</multiplier>
         </value>
       </li>
     </stats>
@@ -4032,18 +3960,6 @@
     </filter>
     <stats>
       <li>
-        <key>ArmorRating_Blunt</key>
-        <value>
-          <offset>-2.3</offset>
-        </value>
-      </li>
-      <li>
-        <key>ArmorRating_Sharp</key>
-        <value>
-          <offset>-2.3</offset>
-        </value>
-      </li>
-      <li>
         <key>ComfyTemperatureMin</key>
         <value>
           <offset>-5.25</offset>
@@ -4058,19 +3974,13 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <multiplier>1.07</multiplier>
-        </value>
-      </li>
-      <li>
-        <key>WorkSpeedGlobal</key>
-        <value>
-          <multiplier>.86</multiplier>
+          <multiplier>1.06</multiplier>
         </value>
       </li>
       <li>
         <key>GlobalLearningFactor</key>
         <value>
-          <multiplier>1.07</multiplier>
+          <multiplier>1.06</multiplier>
         </value>
       </li>
       <li>
@@ -4082,7 +3992,7 @@
       <li>
         <key>SocialImpact</key>
         <value>
-          <multiplier>1.14</multiplier>
+          <multiplier>1.12</multiplier>
         </value>
       </li>
     </stats>
@@ -4991,18 +4901,6 @@
     </filter>
     <stats>
       <li>
-        <key>ArmorRating_Blunt</key>
-        <value>
-          <offset>-3</offset>
-        </value>
-      </li>
-      <li>
-        <key>ArmorRating_Sharp</key>
-        <value>
-          <offset>-3</offset>
-        </value>
-      </li>
-      <li>
         <key>ComfyTemperatureMin</key>
         <value>
           <offset>-7.5</offset>
@@ -5017,19 +4915,13 @@
       <li>
         <key>ResearchSpeed</key>
         <value>
-          <multiplier>1.12</multiplier>
-        </value>
-      </li>
-      <li>
-        <key>WorkSpeedGlobal</key>
-        <value>
-          <multiplier>.80</multiplier>
+          <multiplier>1.08</multiplier>
         </value>
       </li>
       <li>
         <key>GlobalLearningFactor</key>
         <value>
-          <multiplier>1.12</multiplier>
+          <multiplier>1.08</multiplier>
         </value>
       </li>
       <li>
@@ -5041,7 +4933,7 @@
       <li>
         <key>SocialImpact</key>
         <value>
-          <multiplier>1.20</multiplier>
+          <multiplier>1.14</multiplier>
         </value>
       </li>
     </stats>


### PR DESCRIPTION
- Removed negative armor and work speed from Comfy and Luxurious infusions
- Nerfed positive bonuses to compensate
- Fixed typo in the display name